### PR TITLE
Consolidating test directories with package contexts

### DIFF
--- a/packages/cli/lib/init.js
+++ b/packages/cli/lib/init.js
@@ -1,23 +1,27 @@
 const fs = require('fs');
 const path = require('path');
 const greenwoodWorkspace = path.join(__dirname, '..');
+const defaultTemplateDir = path.join(greenwoodWorkspace, 'templates/');
+const defaultSrc = path.join(process.cwd(), 'src');
 
-const userWorkspace = fs.existsSync(path.join(process.cwd(), 'src'))
-  ? path.join(process.cwd(), 'src')
-  : path.join(greenwoodWorkspace, 'templates/');
+const userWorkspace = fs.existsSync(defaultSrc)
+  ? defaultSrc
+  : defaultTemplateDir;
 
 const pagesDir = fs.existsSync(path.join(userWorkspace, 'pages'))
   ? path.join(userWorkspace, 'pages/')
-  : path.join(greenwoodWorkspace, 'templates/');
+  : defaultTemplateDir;
 
 const templatesDir = fs.existsSync(path.join(userWorkspace, 'templates'))
   ? path.join(userWorkspace, 'templates/')
-  : path.join(greenwoodWorkspace, 'templates/');
+  : defaultTemplateDir;
 
 module.exports = initContexts = async() => {
-
+  
   return new Promise((resolve, reject) => {
+    
     try {
+      
       const context = {
         userWorkspace,
         pagesDir,

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,9 +1,29 @@
 const os = require('os');
 const { spawn } = require('child_process');
+const path = require('path');
+const initContext = require('../packages/cli/lib/init');
 
 module.exports = class Setup {
   constructor(enableStdOut) {
     this.enableStdOut = enableStdOut; // debugging tests
+  }
+
+  init() {
+    return new Promise(async(resolve, reject) => {
+      try {
+        const ctx = await initContext();
+        const context = { 
+          ...ctx,
+          userSrc: path.join(__dirname, '..', 'src'), // static src
+          userTemplates: path.join(__dirname, '..', 'src', 'templates'), // static src/templates for testing empty templates dir, redundant in #38
+          testApp: path.join(__dirname, 'fixtures', 'mock-app', 'src')
+        };
+  
+        resolve(context);
+      } catch (err) {
+        reject(err);
+      }
+    });
   }
 
   run(args) {


### PR DESCRIPTION
## Summary of Changes
 * consolidating paths from cli package `init.js` with test
* removed the beforeEach/afterEach for each build and replaced it with before/after, sped up test massively.
* replaced duplicate path.joins() in `init.js`