### PR TITLE
minor refactor to seperate directories from files

### DIFF
--- a/packages/cli/config/webpack.config.common.js
+++ b/packages/cli/config/webpack.config.common.js
@@ -100,7 +100,7 @@ module.exports = (context) => {
       ),
       
       new HtmlWebpackPlugin({
-        template: path.join(context.scratchDir, 'index.html'),
+        template: path.join(context.scratchDir, context.indexPageTemplate),
         chunksSortMode: 'dependency'
       })
     ]

--- a/packages/cli/config/webpack.config.develop.js
+++ b/packages/cli/config/webpack.config.develop.js
@@ -65,29 +65,28 @@ module.exports = (context) => {
         publicPath
       }),
       new HtmlWebpackPlugin({
-        filename: 'index.html',
-        template: context.indexPageScratch,
+        template: path.join(context.scratchDir, context.indexPageTemplate),
         spaIndexFallbackScript: `
-        <script>
-        (function(){
-            var redirect = sessionStorage.redirect;
-            delete sessionStorage.redirect;
-            if (redirect && redirect != location.href) {
-            history.replaceState(null, null, redirect);
-            }
-        })();
-        </script>
+          <script>
+          (function(){
+              var redirect = sessionStorage.redirect;
+              delete sessionStorage.redirect;
+              if (redirect && redirect != location.href) {
+              history.replaceState(null, null, redirect);
+              }
+          })();
+          </script>
         `
       }),
       new HtmlWebpackPlugin({
-        filename: '404.html',
-        template: context.notFoundPageScratch,
+        filename: context.notFoundPageTemplate,
+        template: path.join(context.scratchDir, context.notFoundPageTemplate),
         spaIndexFallbackScript: `
-        <script>
-          sessionStorage.redirect = location.href;
-        </script>
-    
-        <meta http-equiv="refresh" content="0;URL='${publicPath}'"></meta>
+          <script>
+            sessionStorage.redirect = location.href;
+          </script>
+      
+          <meta http-equiv="refresh" content="0;URL='${publicPath}'"></meta>
         `
       })
     ]

--- a/packages/cli/config/webpack.config.prod.js
+++ b/packages/cli/config/webpack.config.prod.js
@@ -16,9 +16,9 @@ module.exports = (context) => {
 
     plugins: [  
       new HtmlWebpackPlugin({
-        filename: '404.html',
-        template: context.notFoundPageScratch,
-        publicPath: configWithContext.output.publicPath
+        filename: context.notFoundPageTemplate,
+        template: path.join(context.scratchDir, context.notFoundPageTemplate),
+        publicPath: configWithContext.publicPath
       })
     ]
 

--- a/packages/cli/lib/init.js
+++ b/packages/cli/lib/init.js
@@ -31,10 +31,8 @@ module.exports = initContexts = async() => {
         publicDir: path.join(process.cwd(), './public'),
         pageTemplate: 'page-template.js',
         appTemplate: 'app-template.js',
-        indexPageTemplate: path.join(defaultTemplateDir, 'index.html'),
-        notFoundPageTemplate: path.join(defaultTemplateDir, '404.html'),
-        indexPageScratch: path.join(scratchDir, 'index.html'),
-        notFoundPageScratch: path.join(scratchDir, '404.html')
+        indexPageTemplate: 'index.html',
+        notFoundPageTemplate: '404.html'
       };
     
       // TODO allow per template overrides

--- a/packages/cli/lib/scaffold.js
+++ b/packages/cli/lib/scaffold.js
@@ -89,8 +89,14 @@ const writeRoutes = async(compilation) => {
 const setupIndex = async({ context }) => {
   return new Promise(async (resolve, reject) => {
     try {
-      fs.copyFileSync(context.notFoundPageTemplate, context.notFoundPageScratch);
-      fs.copyFileSync(context.indexPageTemplate, context.indexPageScratch);
+      fs.copyFileSync(
+        path.join(context.templatesDir, context.indexPageTemplate), 
+        path.join(context.scratchDir, context.indexPageTemplate)
+      );
+      fs.copyFileSync(
+        path.join(context.templatesDir, context.notFoundPageTemplate), 
+        path.join(context.scratchDir, context.notFoundPageTemplate)
+      );
       resolve();
     } catch (err) {
       reject(err);

--- a/packages/cli/lib/serialize.js
+++ b/packages/cli/lib/serialize.js
@@ -26,7 +26,7 @@ module.exports = serializeBuild = async (compilation) => {
         port: PORT,
         https: false,
         directory: compilation.context.publicDir,
-        spa: 'index.html'
+        spa: compilation.context.indexPageTemplate
       });
 
       await runBrowser(compilation);


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
minor refactor in support of #45  

## Summary of Changes
Took #45  and made some small tweaks, although the change to _scaffold.js_ may look a little clunky, don't think it suffers too much in terms of readability, and is still pretty straightforward in terms of logic as it was before.  

Also allows to resolve more "free" usages of _index.html_ and _404.html_.  

So instead of `context` potentially becoming this melting point of state, limiting it to just the core directories and key template files can help:
- Establish a bit of consistency in this particular API that we can document later
- Helps provide good distinction between global and local state
- Same information, just narrowed.  Still the same business logic at the end of the day