### PR TITLE
Fix CSS syntax error

### DIFF
--- a/www/components/shelf/shelf.css
+++ b/www/components/shelf/shelf.css
@@ -1,8 +1,8 @@
 @import url('https://fonts.googleapis.com/css?family=Nunito+Sans:400,600|Poppins:300,400,600&display=swap');
 :host {
 
-  & h1, h2, h3, h4, h5, h6 {
-    font-family: Nunito Sans,sans-serif;
+  & h1, & h2, & h3, & h4, & h5, & h6 {
+    font-family: 'Nunito Sans', sans-serif;
   }
 
   & a {


### PR DESCRIPTION
## Related Issue
Closes #104 

## Summary of Changes
Fix h1, h2, h3, h4, h5 font-family

edit: 

* added exception catch for css parse errors