### PR TITLE
disable host check for devServer and fix host parsing

### DIFF
--- a/packages/cli/config/webpack.config.develop.js
+++ b/packages/cli/config/webpack.config.develop.js
@@ -41,6 +41,7 @@ module.exports = ({ config, context, graph }) => {
     devServer: {
       port,
       host,
+      disableHostCheck: true,
       historyApiFallback: true,
       hot: false,
       inline: true

--- a/packages/cli/lifecycles/config.js
+++ b/packages/cli/lifecycles/config.js
@@ -82,7 +82,7 @@ module.exports = readAndMergeConfig = async() => {
           if (devServer.host) {
             // eslint-disable-next-line max-depth
             if (url.parse(devServer.host).pathname === null) {
-              reject(`Error: greenwood.config.js devServer host type must be a valid url, including http://.  Passed value was: ${devServer.host}`);
+              reject(`Error: greenwood.config.js devServer host type must be a valid pathname.  Passed value was: ${devServer.host}`);
             } else {
               customConfig.devServer.host = devServer.host;
               // console.log(`custom host provided => ${customConfig.devServer.host}`);

--- a/packages/cli/lifecycles/config.js
+++ b/packages/cli/lifecycles/config.js
@@ -81,7 +81,7 @@ module.exports = readAndMergeConfig = async() => {
           
           if (devServer.host) {
             // eslint-disable-next-line max-depth
-            if (url.parse(devServer.host).hostname === null) {
+            if (url.parse(devServer.host).pathname === null) {
               reject(`Error: greenwood.config.js devServer host type must be a valid url, including http://.  Passed value was: ${devServer.host}`);
             } else {
               customConfig.devServer.host = devServer.host;

--- a/test/cli/test-bed.js
+++ b/test/cli/test-bed.js
@@ -4,7 +4,7 @@
  *   workspace: path.join(process.cwd(), 'src'),
  *   devServer: {
        port: 1984,
-       host: 'http://localhost'
+       host: 'localhost'
      },
      publicPath: '/'
  * } 

--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -18,7 +18,7 @@ module.exports = {
 ### Dev Server
 Configuration for Greenwood's development server are available using the `devServer` option.  Two options are available:
 - `port`: Pick a different port when starting the dev server
-- `host`: If you need to use a custom domain when developing locally (generally used along with editing an `/etc/hosts` file)
+- `host`: If you need to use a custom domain (using [pathname](https://nodejs.org/api/url.html#url_url_pathname)) when developing locally and generally used along with editing an `/etc/hosts` file.
 
 #### Example
 ```render js


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #167 

## Summary of Changes
1. Check for `pathname` instead
1. Add `disableHostCheck: true` to `devServer` config