### PR TITLE
feat: adding basic scaffold plugin idea

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const MetaPlugin = require('./plugins/meta-plugin');
 
 const META_DESCRIPTION = 'A modern and performant static site generator supporting Web Component based development';
 const FAVICON_HREF = '/assets/favicon.ico';
@@ -16,5 +17,8 @@ module.exports = {
     { property: 'og:description', content: META_DESCRIPTION },
     { rel: 'shortcut icon', href: FAVICON_HREF },
     { rel: 'icon', href: FAVICON_HREF }
+  ],
+  plugins: [
+    MetaPlugin
   ]
 };

--- a/packages/cli/lifecycles/config.js
+++ b/packages/cli/lifecycles/config.js
@@ -20,11 +20,11 @@ module.exports = readAndMergeConfig = async() => {
     try {
       // deep clone of default config
       let customConfig = JSON.parse(JSON.stringify(defaultConfig));
-      
+
       if (fs.existsSync(path.join(process.cwd(), 'greenwood.config.js'))) {
-        const userCfgFile = require(path.join(process.cwd(), 'greenwood.config.js'));        
-        const { workspace, devServer, publicPath, title, meta, themeFile } = userCfgFile;
-          
+        const userCfgFile = require(path.join(process.cwd(), 'greenwood.config.js'));
+        const { workspace, devServer, publicPath, title, meta, plugins, themeFile } = userCfgFile;
+
         // workspace validation
         if (workspace) {
           if (typeof workspace !== 'string') {
@@ -43,7 +43,7 @@ module.exports = readAndMergeConfig = async() => {
 
           if (!fs.existsSync(customConfig.workspace)) {
             reject('Error: greenwood.config.js workspace doesn\'t exist! \n' +
-              'common issues to check might be: \n' + 
+              'common issues to check might be: \n' +
               '- typo in your workspace directory name, or in greenwood.config.js \n' +
               '- if using relative paths, make sure your workspace is in the same cwd as _greenwood.config.js_ \n' +
               '- consider using an absolute path, e.g. path.join(__dirname, \'my\', \'custom\', \'path\') // <__dirname>/my/custom/path/ ');
@@ -70,6 +70,10 @@ module.exports = readAndMergeConfig = async() => {
           customConfig.meta = meta;
         }
 
+        if (plugins && plugins.length > 0) {
+          customConfig.plugins = plugins;
+        }
+
         if (themeFile) {
           if (typeof themeFile !== 'string' && themeFile.indexOf('.') < 1) {
             reject(`Error: greenwood.config.js themeFile must be a valid filename. got ${themeFile} instead.`);
@@ -78,7 +82,7 @@ module.exports = readAndMergeConfig = async() => {
         }
 
         if (devServer && Object.keys(devServer).length > 0) {
-          
+
           if (devServer.host) {
             // eslint-disable-next-line max-depth
             if (url.parse(devServer.host).hostname === null) {

--- a/packages/plugin/index.js
+++ b/packages/plugin/index.js
@@ -1,0 +1,25 @@
+/*
+*  Base class for all Greenwood plugins
+*
+*/
+
+class GreenwoodPlugin {
+
+  constructor() {
+
+  }
+
+  scaffoldMultiHook(result, replacements) {
+    replacements.forEach(({ regex, replace }) => {
+      result = this.scaffoldHook(result, regex, replace);
+    });
+    return result;
+  }
+
+  scaffoldHook(result, regex, replace) {
+    return result.replace(regex, replace);
+  }
+
+}
+
+module.exports = GreenwoodPlugin;

--- a/plugins/meta-plugin/index.js
+++ b/plugins/meta-plugin/index.js
@@ -1,0 +1,48 @@
+const path = require('path');
+const GreenwoodPlugin = require('../../packages/plugin');
+const metaComponent = path.join(__dirname, 'metacomponent');
+
+/* Plugin could be packaged as @greenwood/meta-plugin */
+
+class MetaPlugin extends GreenwoodPlugin {
+  constructor() {
+    super();
+  }
+
+  scaffold(file, result, compilation) {
+    return new Promise((resolve, reject) => {
+
+      try {
+
+        const { title, meta, route } = file;
+        const metadata = {
+          title,
+          meta,
+          route
+        };
+
+        const regexArr = [
+          {
+            regex: /METAIMPORT/,
+            replace: `import '${metaComponent}'`
+          },
+          {
+            regex: /METADATA/,
+            replace: `const metadata = ${JSON.stringify(metadata)}`
+          },
+          {
+            regex: /METAELEMENT/,
+            replace: '<eve-meta .attributes=\${metadata}></eve-meta>'
+          }
+        ];
+
+        result = this.scaffoldMultiHook(result, regexArr);
+        resolve(result);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+}
+
+module.exports = MetaPlugin;

--- a/plugins/meta-plugin/metacomponent.js
+++ b/plugins/meta-plugin/metacomponent.js
@@ -1,0 +1,71 @@
+import { LitElement } from 'lit-element';
+
+/*
+* Take an attributes object with an array of meta objects, add them to an element and replace/add the element to DOM
+*  {
+*   title: 'my title',
+*   meta: [
+*     { property: 'og:site', content: 'greenwood' },
+*     { name: 'twitter:site', content: '@PrjEvergreen' },
+*     { rel: 'icon', href: '/assets/favicon.ico ' }
+*   ]
+*  }
+*/
+
+class meta extends LitElement {
+
+  static get properties() {
+    return {
+      attributes: {
+        type: Object
+      }
+    };
+  }
+
+  firstUpdated() {
+    if (this.attributes) {
+      let header = document.head;
+
+      // handle <meta> + <link> tags
+      this.attributes.meta.forEach(metaItem => {
+        const metaType = Object.keys(metaItem)[0]; // property or name attribute
+        const metaTypeValue = metaItem[metaType]; // value of the attribute
+        let meta = document.createElement('meta');
+
+        if (metaType === 'rel') {
+          // change to a <link> tag instead
+          meta = document.createElement('link');
+
+          meta.setAttribute(metaType, metaTypeValue);
+          meta.setAttribute('href', metaItem.href);
+        } else {
+          const metaContent = metaTypeValue === 'og:url'
+            ? `${metaItem.content}${this.attributes.route}`
+            : metaItem.content;
+
+          meta.setAttribute(metaType, metaTypeValue);
+          meta.setAttribute('content', metaContent);
+        }
+
+        const oldmeta = header.querySelector(`[${metaType}="${metaTypeValue}"]`);
+
+        // rehydration
+        if (oldmeta) {
+          header.replaceChild(meta, oldmeta);
+        } else {
+          header.appendChild(meta);
+        }
+      });
+
+      // handle <title> tag
+      let title = document.createElement('title');
+
+      title.innerText = this.attributes.title;
+      const oldTitle = document.head.querySelector('title');
+
+      header.replaceChild(title, oldTitle);
+    }
+  }
+}
+
+customElements.define('eve-meta', meta);


### PR DESCRIPTION
## Related Issue
Related to issue #17 

## Summary of Changes
This idea shows how a single scaffold plugin can be used for meta instead of including it by default.

This could be extended to many other plugins fairly easily. This is simply the bare minimum PoC for an idea I discussed in issue #17.  I'm putting this up to explore the issue and hear what others think.

1. Created a `MetaPlugin` which extends a base class of `GreenwoodPlugin` (hopefully a class we will use frequently for all our plugins)
2. Imported that plugin into our `greenwood.config.js` within a plugins array
3. `config.js` is modified to accept the plugins key
4. `scaffold.js` is modified to loop through all plugins and call the `scaffold()` hook. This will need some hardening but this is just a proof of concept.