### PR TITLE
Enhancement/issue 186 google analytics plugin

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -16,7 +16,8 @@ module.exports = {
     { property: 'og:image', content: 'https://s3.amazonaws.com/hosted.greenwoodjs.io/greenwood-logo.png' },
     { property: 'og:description', content: META_DESCRIPTION },
     { rel: 'shortcut icon', href: FAVICON_HREF },
-    { rel: 'icon', href: FAVICON_HREF }
+    { rel: 'icon', href: FAVICON_HREF },
+    { name: 'google-site-verification', content: '4rYd8k5aFD0jDnN0CCFgUXNe4eakLP4NnA18mNnK5P0' }
   ],
   plugins: [
     ...googleAnalyticsPlugin({

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -1,3 +1,4 @@
+const googleAnalyticsPlugin = require('./packages/plugin-google-analytics/src/index');
 const path = require('path');
 
 const META_DESCRIPTION = 'A modern and performant static site generator supporting Web Component based development';
@@ -16,5 +17,8 @@ module.exports = {
     { property: 'og:description', content: META_DESCRIPTION },
     { rel: 'shortcut icon', href: FAVICON_HREF },
     { rel: 'icon', href: FAVICON_HREF }
+  ],
+  plugins: [
+    ...googleAnalyticsPlugin('UA-147204327-1')
   ]
 };

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -19,6 +19,8 @@ module.exports = {
     { rel: 'icon', href: FAVICON_HREF }
   ],
   plugins: [
-    ...googleAnalyticsPlugin('UA-147204327-1')
+    ...googleAnalyticsPlugin({
+      analyticsId: 'UA-147204327-1'
+    })
   ]
 };

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -6,7 +6,8 @@ module.exports = {
     'packages/cli/src/lib/*.js',
     'packages/cli/src/lifecycles/*.js',
     'packages/cli/src/plugins/*.js',
-    'packages/cli/src/tasks/*.js'
+    'packages/cli/src/tasks/*.js',
+    'packages/plugin-*/src/*.js'
   ],
 
   reporter: [

--- a/packages/cli/src/templates/index.html
+++ b/packages/cli/src/templates/index.html
@@ -14,14 +14,14 @@
     <!-- Error is a known issue: https://github.com/webcomponents/webcomponentsjs/issues/749 -->
     <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.0.2/custom-elements-es5-adapter.js"></script> -->
 
+    <%= htmlWebpackPlugin.options.hookAnalytics %>
+    
     <%= htmlWebpackPlugin.options.hookSpaIndexFallback %>
   </head>
 
   <body>
   
     <eve-app></eve-app>
-
-    <%= htmlWebpackPlugin.options.hookAnalytics %>
 
     <%= htmlWebpackPlugin.options.hookPolyfills %>
 

--- a/packages/plugin-google-analytics/README.md
+++ b/packages/plugin-google-analytics/README.md
@@ -29,9 +29,15 @@ module.exports = {
   ...
 
   plugins: [
-    ...googleAnalyticsPlugin('UA-XXXXXX')
+    ...googleAnalyticsPlugin({
+      analyticsId: 'UA-XXXXXX'
+    })
   ]
 }
 ```
 
 This will then add the Google Analytics [JavaScript tracker snippet](https://developers.google.com/analytics/devguides/collection/analyticsjs/) to your project's _index.html_.
+
+### Options
+- `analyticsId` (required) - Your Google Analytics ID
+- `anonymous` (optional) - If tracking of IPs should be done anonymously.  Defaults to `true`

--- a/packages/plugin-google-analytics/README.md
+++ b/packages/plugin-google-analytics/README.md
@@ -1,0 +1,37 @@
+# @greenwood/plugin-google-analytics
+
+## Overview
+A composite plugin for Greenwood for adding support for [Google Analytics](https://developers.google.com/analytics/) JavaScript tracker. For more information and complete docs about Greenwood, please visit the [Greenwood website](https://www.greenwoodjs.io/docs).  
+
+> This package assumes you already have `@greenwood/cli` installed.
+
+## Installation
+You can use your favorite JavaScript package manager to install this package.
+
+_examples:_
+```bash
+# npm
+npm -i @greenwood/plugin-google-analytics --save-dev
+
+# yarn
+yarn add @greenwood/plugin-google-analytics --dev
+```
+
+## Usage
+Use this plugin in your _greenwood.config.js_ and simply pass in your Google Analytics ID, e.g. `UA-XXXXX`.
+
+> As this is a composite plugin, you will need to spread the result.
+
+```javascript
+const googleAnalyticsPlugin = require('@greenwood/plugin-google-analytics');
+
+module.exports = {
+  ...
+
+  plugins: [
+    ...googleAnalyticsPlugin('UA-XXXXXX')
+  ]
+}
+```
+
+This will then add the Google Analytics [JavaScript tracker snippet](https://developers.google.com/analytics/devguides/collection/analyticsjs/) to your project's _index.html_.

--- a/packages/plugin-google-analytics/package.json
+++ b/packages/plugin-google-analytics/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@greenwood/plugin-google-analytics",
+  "version": "0.3.6",
+  "description": "A composite plugin for Greenwood for adding support for Google Analytics.",
+  "repository": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-google-analytics",
+  "author": "Owen Buckley <owen@thegreenhouse.io>",
+  "license": "MIT",
+  "main": "src/index.js",
+  "files": [
+    "src/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@greenwood/cli": "^0.3.6"
+  },
+  "dependencies": {
+
+  }
+}

--- a/packages/plugin-google-analytics/package.json
+++ b/packages/plugin-google-analytics/package.json
@@ -14,8 +14,5 @@
   },
   "peerDependencies": {
     "@greenwood/cli": "^0.3.6"
-  },
-  "dependencies": {
-
   }
 }

--- a/packages/plugin-google-analytics/src/index.js
+++ b/packages/plugin-google-analytics/src/index.js
@@ -1,4 +1,10 @@
 module.exports = (analyticsId) => {
+  const validId = analyticsId && typeof analyticsId === 'string';
+
+  if (!validId) {
+    throw new Error(`Error: analyticsId should be of type string.  get "${typeof analyticsId}" instead.`);
+  }
+
   return [{
     type: 'index',
     provider: () => {

--- a/packages/plugin-google-analytics/src/index.js
+++ b/packages/plugin-google-analytics/src/index.js
@@ -1,5 +1,8 @@
-module.exports = (analyticsId) => {
+module.exports = (options = {}) => {
+  const { analyticsId, anonymous } = options;
+
   const validId = analyticsId && typeof analyticsId === 'string';
+  const trackAnon = typeof anonymous === 'boolean' ? anonymous : true;
 
   if (!validId) {
     throw new Error(`Error: analyticsId should be of type string.  get "${typeof analyticsId}" instead.`);
@@ -17,6 +20,7 @@ module.exports = (analyticsId) => {
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
 
+            gtag('config', '${analyticsId}', { 'anonymize_ip': ${trackAnon} });
             gtag('config', '${analyticsId}');
           </script>
         `

--- a/packages/plugin-google-analytics/src/index.js
+++ b/packages/plugin-google-analytics/src/index.js
@@ -1,0 +1,20 @@
+module.exports = (analyticsId) => {
+  return [{
+    type: 'index',
+    provider: () => {
+      return {
+        hookAnalytics: `
+          <!-- Google Analytics -->
+          <script>
+            window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+            ga('create', '${analyticsId}', 'auto');
+            ga('send', 'pageview');
+          </script>
+          
+          <script async src='https://www.google-analytics.com/analytics.js'></script>
+          <!-- End Google Analytics -->
+        `
+      };
+    }
+  }];
+};

--- a/packages/plugin-google-analytics/src/index.js
+++ b/packages/plugin-google-analytics/src/index.js
@@ -10,15 +10,15 @@ module.exports = (analyticsId) => {
     provider: () => {
       return {
         hookAnalytics: `
-          <!-- Google Analytics -->
-          <script>
-            window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-            ga('create', '${analyticsId}', 'auto');
-            ga('send', 'pageview');
-          </script>
+          <script async src="https://www.googletagmanager.com/gtag/js?id=${analyticsId}"></script>
           
-          <script async src='https://www.google-analytics.com/analytics.js'></script>
-          <!-- End Google Analytics -->
+          <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', '${analyticsId}');
+          </script>
         `
       };
     }

--- a/packages/plugin-google-analytics/test/cases/default/default.spec.js
+++ b/packages/plugin-google-analytics/test/cases/default/default.spec.js
@@ -9,16 +9,11 @@
  * greenwood build
  * 
  * User Config
+ * const googleAnalyticsPlugin = require('@greenwod/plugin-google-analytics');
+ * 
  * {
  *   plugins: [{
- *     type: 'index',
- *     provider: () => {
- *       return {
- *         hookAnalytics: `
- *           <!-- Google Analytics setup script -->
- *         `
- *       };
- *     }
+ *     ...googleAnalyticsPlugin()
  *  }]
  * 
  * }
@@ -32,7 +27,7 @@ const path = require('path');
 const runSmokeTest = require('../../../../../test/smoke-test');
 const TestBed = require('../../../../../test/test-bed');
 
-describe.only('Build Greenwood With: ', async function() {
+describe('Build Greenwood With: ', async function() {
   const LABEL = 'Google Analytics Plugin and Default Workspace';
   let setup;
 

--- a/packages/plugin-google-analytics/test/cases/default/default.spec.js
+++ b/packages/plugin-google-analytics/test/cases/default/default.spec.js
@@ -29,6 +29,8 @@ const TestBed = require('../../../../../test/test-bed');
 
 describe('Build Greenwood With: ', async function() {
   const LABEL = 'Google Analytics Plugin and Default Workspace';
+  const analyticsId = 'UA-123456-1';
+
   let setup;
 
   before(async function() {
@@ -48,7 +50,7 @@ describe('Build Greenwood With: ', async function() {
 
       beforeEach(async function() {
         const dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, 'index.html'));
-        const scriptTags = dom.window.document.querySelectorAll('body eve-app ~ script');
+        const scriptTags = dom.window.document.querySelectorAll('head script');
 
         inlineScript = Array.prototype.slice.call(scriptTags).filter(script => {
           return !script.src;
@@ -62,9 +64,11 @@ describe('Build Greenwood With: ', async function() {
 
       it('should have the expected code with users analyicsId', function() {
         const expectedContent = `
-            window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-            ga('create', 'UA-123456', 'auto');
-            ga('send', 'pageview');
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+
+            gtag('config', '${analyticsId}');
         `;
 
         expect(inlineScript[0].textContent).to.contain(expectedContent);
@@ -76,10 +80,10 @@ describe('Build Greenwood With: ', async function() {
 
       beforeEach(async function() {
         const dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, 'index.html'));
-        const scriptTags = dom.window.document.querySelectorAll('body eve-app ~ script');
+        const scriptTags = dom.window.document.querySelectorAll('head script');
         
         trackingScript = Array.prototype.slice.call(scriptTags).filter(script => {
-          return script.src === 'https://www.google-analytics.com/analytics.js';
+          return script.src === `https://www.googletagmanager.com/gtag/js?id=${analyticsId}`;
         });
       });
 

--- a/packages/plugin-google-analytics/test/cases/default/default.spec.js
+++ b/packages/plugin-google-analytics/test/cases/default/default.spec.js
@@ -1,0 +1,107 @@
+/*
+ * Use Case
+ * Run Greenwood with Google Analytics composite plugin.
+ * 
+ * Uaer Result
+ * Should generate a bare bones Greenwood build with certain plugins injected into index.html.
+ * 
+ * User Command
+ * greenwood build
+ * 
+ * User Config
+ * {
+ *   plugins: [{
+ *     type: 'index',
+ *     provider: () => {
+ *       return {
+ *         hookAnalytics: `
+ *           <!-- Google Analytics setup script -->
+ *         `
+ *       };
+ *     }
+ *  }]
+ * 
+ * }
+ * 
+ * User Workspace
+ * Greenwood default (src/)
+ */
+const expect = require('chai').expect;
+const { JSDOM } = require('jsdom');
+const path = require('path');
+const runSmokeTest = require('../../../../../test/smoke-test');
+const TestBed = require('../../../../../test/test-bed');
+
+describe.only('Build Greenwood With: ', async function() {
+  const LABEL = 'Google Analytics Plugin and Default Workspace';
+  let setup;
+
+  before(async function() {
+    setup = new TestBed();
+    this.context = setup.setupTestBed(__dirname);
+  });
+  
+  describe(LABEL, function() {
+    before(async function() {     
+      await setup.runGreenwoodCommand('build');
+    });
+    
+    runSmokeTest(['public', 'index', 'not-found', 'hello'], LABEL);
+
+    describe('Initialization script at the end of the <body> tag', function() {
+      let inlineScript;
+
+      beforeEach(async function() {
+        const dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, 'index.html'));
+        const scriptTags = dom.window.document.querySelectorAll('body eve-app ~ script');
+
+        inlineScript = Array.prototype.slice.call(scriptTags).filter(script => {
+          return !script.src;
+        });
+
+      });
+
+      it('should be one inline <script> tag', function() {
+        expect(inlineScript.length).to.be.equal(1);
+      });
+
+      it('should have the expected code with users analyicsId', function() {
+        const expectedContent = `
+            window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+            ga('create', 'UA-123456', 'auto');
+            ga('send', 'pageview');
+        `;
+
+        expect(inlineScript[0].textContent).to.contain(expectedContent);
+      });
+    });
+
+    describe('Tracking script at the end of the <body> tag', function() {
+      let trackingScript; 
+
+      beforeEach(async function() {
+        const dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, 'index.html'));
+        const scriptTags = dom.window.document.querySelectorAll('body eve-app ~ script');
+        
+        trackingScript = Array.prototype.slice.call(scriptTags).filter(script => {
+          return script.src === 'https://www.google-analytics.com/analytics.js';
+        });
+      });
+
+      it('should have one <script> tag for loading the Google Analytics tracker', function() {
+        expect(trackingScript.length).to.be.equal(1);
+      });
+
+      it('should be an async <script> tag for loading the Google Analytics tracker', function() {
+        const isAsync = trackingScript[0].async !== null;
+
+        expect(isAsync).to.be.equal(true);
+      });
+    });
+  });
+  
+  after(function() {
+    setup.teardownTestBed();
+  });
+
+});

--- a/packages/plugin-google-analytics/test/cases/default/greenwood.config.js
+++ b/packages/plugin-google-analytics/test/cases/default/greenwood.config.js
@@ -1,0 +1,7 @@
+const googleAnalyticsPlugin = require('../../../src/index');
+
+module.exports = {
+  plugins: [
+    ...googleAnalyticsPlugin('UA-123456')
+  ]
+};

--- a/packages/plugin-google-analytics/test/cases/default/greenwood.config.js
+++ b/packages/plugin-google-analytics/test/cases/default/greenwood.config.js
@@ -2,6 +2,6 @@ const googleAnalyticsPlugin = require('../../../src/index');
 
 module.exports = {
   plugins: [
-    ...googleAnalyticsPlugin('UA-123456')
+    ...googleAnalyticsPlugin('UA-123456-1')
   ]
 };

--- a/packages/plugin-google-analytics/test/cases/error-analytics-id/error-analytics-id.spec.js
+++ b/packages/plugin-google-analytics/test/cases/error-analytics-id/error-analytics-id.spec.js
@@ -1,0 +1,49 @@
+/*
+ * Use Case
+ * Run Greenwood with Google Analytics composite plugin.
+ * 
+ * Uaer Result
+ * Should generate an error when not passing in a valid analyticsId.
+ * 
+ * User Command
+ * greenwood build
+ * 
+ * User Config
+ * const googleAnalyticsPlugin = require('@greenwod/plugin-google-analytics');
+ * 
+ * {
+ *   plugins: [{
+ *     ...googleAnalyticsPlugin()
+ *  }]
+ * 
+ * }
+ * 
+ * User Workspace
+ * Greenwood default (src/)
+ */
+const expect = require('chai').expect;
+const TestBed = require('../../../../../test/test-bed');
+
+describe('Build Greenwood With: ', async function() {
+  let setup;
+
+  before(async function() {
+    setup = new TestBed();
+    this.context = setup.setupTestBed(__dirname);
+  });
+    
+  describe('Google Analytics Plugin with a bad value for analyticsId', () => {
+    it('should throw an error that analyticsId must be a string', async () => {
+      try { 
+        await setup.runGreenwoodCommand('build');
+      } catch (err) {
+        expect(err).to.contain('analyticsId should be of type string.  get "undefined" instead.');
+      }
+    });
+  });
+  
+  after(function() {
+    setup.teardownTestBed();
+  });
+
+});

--- a/packages/plugin-google-analytics/test/cases/error-analytics-id/greenwood.config.js
+++ b/packages/plugin-google-analytics/test/cases/error-analytics-id/greenwood.config.js
@@ -1,0 +1,7 @@
+const googleAnalyticsPlugin = require('../../../src/index');
+
+module.exports = {
+  plugins: [
+    googleAnalyticsPlugin()
+  ]
+};

--- a/packages/plugin-google-analytics/test/cases/error-analytics-id/greenwood.config.js
+++ b/packages/plugin-google-analytics/test/cases/error-analytics-id/greenwood.config.js
@@ -2,6 +2,6 @@ const googleAnalyticsPlugin = require('../../../src/index');
 
 module.exports = {
   plugins: [
-    googleAnalyticsPlugin()
+    ...googleAnalyticsPlugin()
   ]
 };

--- a/packages/plugin-google-analytics/test/cases/option-anonymous/greenwood.config.js
+++ b/packages/plugin-google-analytics/test/cases/option-anonymous/greenwood.config.js
@@ -3,7 +3,8 @@ const googleAnalyticsPlugin = require('../../../src/index');
 module.exports = {
   plugins: [
     ...googleAnalyticsPlugin({
-      analyticsId: 'UA-123456-1'
+      analyticsId: 'UA-123456-1',
+      anonymous: false
     })
   ]
 };

--- a/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
+++ b/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
@@ -1,6 +1,6 @@
 /*
  * Use Case
- * Run Greenwood with Google Analytics composite plugin with default options.
+ * Run Greenwood with Google Analytics composite plugin with IP anonymization set to false.
  * 
  * Uaer Result
  * Should generate a bare bones Greenwood build with certain plugins injected into index.html.
@@ -14,7 +14,8 @@
  * {
  *   plugins: [{
  *     ...googleAnalyticsPlugin({
- *       analyticsId: 'UA-123456-1'
+ *       analyticsId: 'UA-123456-1',
+ *       anonymouse: false
  *     })
  *  }]
  * 
@@ -30,7 +31,7 @@ const runSmokeTest = require('../../../../../test/smoke-test');
 const TestBed = require('../../../../../test/test-bed');
 
 describe('Build Greenwood With: ', async function() {
-  const LABEL = 'Google Analytics Plugin with default options and Default Workspace';
+  const LABEL = 'Google Analytics Plugin with IP Anonymization tracking set to false and Default Workspace';
   const mockAnalyticsId = 'UA-123456-1';
 
   let setup;
@@ -70,7 +71,7 @@ describe('Build Greenwood With: ', async function() {
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
 
-            gtag('config', '${mockAnalyticsId}', { 'anonymize_ip': true });
+            gtag('config', '${mockAnalyticsId}', { 'anonymize_ip': false });
             gtag('config', '${mockAnalyticsId}');
         `;
 

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -86,14 +86,8 @@ function defaultIndex(label) {
         expect(title).to.be.equal('Greenwood App');
       });
 
-      it('should have three <script> tags in the <body>', function() {
-        const scriptTag = dom.window.document.querySelectorAll('body script');
-
-        expect(scriptTag.length).to.be.equal(3);
-      });
-
-      it('should have two polyfill <script> tags in the <body>', function() {
-        const scriptTags = dom.window.document.querySelectorAll('body script');
+      it('should have two <script> tags for polyfills loaded at the end of the <body> tag', function() {
+        const scriptTags = dom.window.document.querySelectorAll('body eve-app ~ script');
         const polyfillScriptTags = Array.prototype.slice.call(scriptTags).filter(script => {
           return script.src.indexOf('//cdnjs.cloudflare.com') >= 0;
         });
@@ -101,8 +95,8 @@ function defaultIndex(label) {
         expect(polyfillScriptTags.length).to.be.equal(2);
       });
 
-      it('should have one bundle <script> tag in the <body>', function() {
-        const scriptTags = dom.window.document.querySelectorAll('body script');
+      it('should have <script> tag for loading main JavaScript bundle at the end of the <body> tag', function() {
+        const scriptTags = dom.window.document.querySelectorAll('body eve-app ~ script');
         const bundleScripts = Array.prototype.slice.call(scriptTags).filter(script => {
           const src = script.src;
 

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -86,6 +86,12 @@ function defaultIndex(label) {
         expect(title).to.be.equal('Greenwood App');
       });
 
+      it('should have three <script> tags in the <body>', function() {
+        const scriptTag = dom.window.document.querySelectorAll('body script');
+
+        expect(scriptTag.length).to.be.equal(3);
+      });
+      
       it('should have two <script> tags for polyfills loaded at the end of the <body> tag', function() {
         const scriptTags = dom.window.document.querySelectorAll('body eve-app ~ script');
         const polyfillScriptTags = Array.prototype.slice.call(scriptTags).filter(script => {

--- a/www/components/shelf/plugins.json
+++ b/www/components/shelf/plugins.json
@@ -3,5 +3,10 @@
     "index": 0,
     "name": "Index Hooks",
     "path": "/plugins/index-hooks"
+  },
+  {
+    "index": 1,
+    "name": "Custom Plugins",
+    "path": "/plugins/custom-plugins"
   }
 ]

--- a/www/components/shelf/plugins.json
+++ b/www/components/shelf/plugins.json
@@ -6,7 +6,7 @@
   },
   {
     "index": 1,
-    "name": "Custom Plugins",
-    "path": "/plugins/custom-plugins"
+    "name": "Composite Plugins",
+    "path": "/plugins/composite-plugins"
   }
 ]

--- a/www/pages/plugins/composite-plugins.md
+++ b/www/pages/plugins/composite-plugins.md
@@ -1,0 +1,10 @@
+## Compostie Plugins
+Greenwood provides some custom "composite" plugins that are tasked with providing specific functionality to your project, built using the available plugin types already provided by Greenwood.  
+
+The available plugins built and maintained by Greenwood team and contibutors have been provided in the table below, with links to their README with the appropriate installation and usage steps.
+
+| Name  | Description  |
+|---|---|
+| [Google Analytics](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-google-analytics) | Easily add usage tracking to your site with Google Analytics. |
+
+> See something missing?  Please review our [open issues](https://github.com/ProjectEvergreen/greenwood/issues), we might be [working on it](https://github.com/ProjectEvergreen/greenwood/projects)!  Or if not, please request it, we would be interested to learn how you need to use Greenwod and how the team can help!

--- a/www/pages/plugins/custom-plugins.md
+++ b/www/pages/plugins/custom-plugins.md
@@ -1,8 +1,0 @@
-## Custom Plugins
-To support development of Greenwood based projects, Greenwood provides some custom "composite" plugins that you can use to quickly build out your project.  The following components that are built and maintained by the Greenwood team have been provided in the table below, with links to their README's that includes installation and usage steps.
-
-| Name  | Description  |
-|---|---|
-| [Google Analytics](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-google-analytics) | Easily add usage tracking to your site with Google Analytics. |
-
-> See something missing that you would like to have?  Please [request it](https://github.com/ProjectEvergreen/greenwood/issues)!

--- a/www/pages/plugins/custom-plugins.md
+++ b/www/pages/plugins/custom-plugins.md
@@ -1,0 +1,8 @@
+## Custom Plugins
+To support development of Greenwood based projects, Greenwood provides some custom "composite" plugins that you can use to quickly build out your project.  The following components that are built and maintained by the Greenwood team have been provided in the table below, with links to their README's that includes installation and usage steps.
+
+| Name  | Description  |
+|---|---|
+| [Google Analytics](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-google-analytics) | Easily add usage tracking to your site with Google Analytics. |
+
+> See something missing that you would like to have?  Please [request it](https://github.com/ProjectEvergreen/greenwood/issues)!

--- a/www/styles/page.css
+++ b/www/styles/page.css
@@ -66,4 +66,16 @@
       height: 100%;
     }
   }
+
+  & table {
+    border: 1px solid #020202;
+    width: 100%;
+    text-align: center;
+    margin-bottom: 20px;
+  }
+
+  & table th {
+    background-color: #f9e7ca;
+    text-decoration: underline;
+  }
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #186 

## Summary of Changes
1. Created a new package **@greenwood/plugin-google-analytics**
1. Added tests and README docs
1. Created a page for _Composite Plugins_ to the Plugins section of the website
1. Integrated the plugin into the Greenwood website
1. Added support for Google SEO

As part of #179, would like to determine a more ergonomic API for composite plugins.  Maybe just accept an `Array` directly, and Greenwood and can spread it instead?

## TODO
1. ~~Check GA and make sure it is filtering for only hits from www.greenwoodjs.io~~
1. Will probably make an issue for this, but it would be cool if there was a way through a plugin that we could point to a directory of _.md_ files, like in _packages/_ and make a page out of it and / or put it into the graph so that we can generate the `<table>` in the _Composite Plugins_ page dynamically.