### PR TITLE
[WIP] External Data Sources - Headless Wordpress PoC

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.3'
+
+services:
+  db:
+    container_name: 'mariadb'
+    image: mariadb:latest
+    volumes:
+      # - db_data:/var/lib/mysql
+      - ./wordpress.sql:/docker-entrypoint-initdb.d/wordpress.sql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: somewordpress
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+
+  wordpress:
+    container_name: 'wordpress'
+    depends_on:
+      - db
+    image: wordpress:latest
+    ports:
+      - '8004:80'
+    restart: always
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+# volumes:
+#   db_data: {}

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -6,6 +6,7 @@ const FAVICON_HREF = '/assets/favicon.ico';
 module.exports = {
   workspace: path.join(__dirname, 'www'),
   title: 'Greenwood',
+  wpSource: 'http://127.0.0.1/wp',
   meta: [
     { name: 'description', content: META_DESCRIPTION },
     { name: 'twitter:site', content: '@PrjEvergreen' },

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -6,7 +6,7 @@ const FAVICON_HREF = '/assets/favicon.ico';
 module.exports = {
   workspace: path.join(__dirname, 'www'),
   title: 'Greenwood',
-  wpSource: 'http://127.0.0.1/wp',
+  wpSource: 'http://localhost:8004',
   meta: [
     { name: 'description', content: META_DESCRIPTION },
     { name: 'twitter:site', content: '@PrjEvergreen' },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "pwa-helpers": "^0.9.1",
     "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
+    "request-promise": "^4.2.4",
     "style-loader": "^0.23.1",
     "wc-markdown-loader": "^0.1.2",
     "webpack": "^4.29.6",

--- a/packages/cli/lifecycles/compile.js
+++ b/packages/cli/lifecycles/compile.js
@@ -24,15 +24,15 @@ module.exports = generateCompilation = () => {
       compilation.context = await initContext(compilation);
 
       // generate a graph of all pages / components to build
-      // console.log('Generating graph of workspace files...');
-      // compilation = await generateGraph(compilation);
+      console.log('Generating graph of workspace files...');
+      compilation = await generateGraph(compilation);
 
       console.log('Scaffolding from sources....');
-      await generateFromSources(compilation);
+      compilation = await generateFromSources(compilation);
 
       // generate scaffolding
-      // console.log('Scaffolding out project files...');
-      // await generateScaffolding(compilation);
+      console.log('Scaffolding out project files...');
+      await generateScaffolding(compilation);
 
       resolve(compilation);
     } catch (err) {

--- a/packages/cli/lifecycles/compile.js
+++ b/packages/cli/lifecycles/compile.js
@@ -3,6 +3,7 @@ const initConfig = require('./config');
 const initContext = require('./context');
 const generateGraph = require('./graph');
 const generateScaffolding = require('./scaffold');
+const generateFromSources = require('./sources');
 
 module.exports = generateCompilation = () => {
   return new Promise(async (resolve, reject) => {
@@ -12,7 +13,7 @@ module.exports = generateCompilation = () => {
         graph: [],
         context: {},
         config: {}
-      };      
+      };
 
       // read from defaults/config file
       console.log('Reading project config');
@@ -23,12 +24,15 @@ module.exports = generateCompilation = () => {
       compilation.context = await initContext(compilation);
 
       // generate a graph of all pages / components to build
-      console.log('Generating graph of workspace files...');
-      compilation = await generateGraph(compilation);
-    
+      // console.log('Generating graph of workspace files...');
+      // compilation = await generateGraph(compilation);
+
+      console.log('Scaffolding from sources....');
+      await generateFromSources(compilation);
+
       // generate scaffolding
-      console.log('Scaffolding out project files...');
-      await generateScaffolding(compilation);
+      // console.log('Scaffolding out project files...');
+      // await generateScaffolding(compilation);
 
       resolve(compilation);
     } catch (err) {

--- a/packages/cli/lifecycles/config.js
+++ b/packages/cli/lifecycles/config.js
@@ -9,6 +9,7 @@ let defaultConfig = {
     host: 'localhost'
   },
   publicPath: '/',
+  wpSource: '',
   title: 'Greenwood App',
   meta: [],
   themeFile: 'theme.css'
@@ -20,11 +21,11 @@ module.exports = readAndMergeConfig = async() => {
     try {
       // deep clone of default config
       let customConfig = JSON.parse(JSON.stringify(defaultConfig));
-      
+
       if (fs.existsSync(path.join(process.cwd(), 'greenwood.config.js'))) {
-        const userCfgFile = require(path.join(process.cwd(), 'greenwood.config.js'));        
-        const { workspace, devServer, publicPath, title, meta, themeFile } = userCfgFile;
-          
+        const userCfgFile = require(path.join(process.cwd(), 'greenwood.config.js'));
+        const { workspace, devServer, publicPath, title, meta, themeFile, wpSource } = userCfgFile;
+
         // workspace validation
         if (workspace) {
           if (typeof workspace !== 'string') {
@@ -43,7 +44,7 @@ module.exports = readAndMergeConfig = async() => {
 
           if (!fs.existsSync(customConfig.workspace)) {
             reject('Error: greenwood.config.js workspace doesn\'t exist! \n' +
-              'common issues to check might be: \n' + 
+              'common issues to check might be: \n' +
               '- typo in your workspace directory name, or in greenwood.config.js \n' +
               '- if using relative paths, make sure your workspace is in the same cwd as _greenwood.config.js_ \n' +
               '- consider using an absolute path, e.g. path.join(__dirname, \'my\', \'custom\', \'path\') // <__dirname>/my/custom/path/ ');
@@ -66,6 +67,14 @@ module.exports = readAndMergeConfig = async() => {
           }
         }
 
+        if (wpSource) {
+          if (typeof wpSource !== 'string') {
+            reject('Error: greenwood.config.js wpSource must be a string');
+          } else {
+            customConfig.wpSource = wpSource;
+          }
+        }
+
         if (meta && meta.length > 0) {
           customConfig.meta = meta;
         }
@@ -78,7 +87,7 @@ module.exports = readAndMergeConfig = async() => {
         }
 
         if (devServer && Object.keys(devServer).length > 0) {
-          
+
           if (devServer.host) {
             // eslint-disable-next-line max-depth
             if (url.parse(devServer.host).pathname === null) {

--- a/packages/cli/lifecycles/graph.js
+++ b/packages/cli/lifecycles/graph.js
@@ -9,7 +9,7 @@ const createGraphFromPages = async (pagesDir, config) => {
   let pages = [];
   const readdir = util.promisify(fs.readdir);
   const readFile = util.promisify(fs.readFile);
-  
+
   return new Promise(async (resolve, reject) => {
     try {
 
@@ -44,24 +44,24 @@ const createGraphFromPages = async (pagesDir, config) => {
 
                 // get md file's name without the file extension
                 let fileRoute = subDir.substring(seperatorIndex, subDir.length - 3);
-                
+
                 // determine if this is an index file, if so set route to '/'
                 let route = fileRoute === '/index' ? '/' : fileRoute;
-                
+
                 // check if additional nested directories
                 if (seperatorIndex > 0) {
                   // get all remaining nested page directories
                   completeNestedPath = subDir.substring(0, seperatorIndex);
-                  
+
                   // set route to the nested pages path and file name(without extension)
                   route = completeNestedPath + route;
                   mdFile = `.${completeNestedPath}${fileRoute}.md`;
-                  relativeExpectedPath = `'..${completeNestedPath}/${fileName}/${fileName}.js'`; 
+                  relativeExpectedPath = `'..${completeNestedPath}/${fileName}/${fileName}.js'`;
                 } else {
                   mdFile = `.${fileRoute}.md`;
-                  relativeExpectedPath = `'../${fileName}/${fileName}.js'`; 
+                  relativeExpectedPath = `'../${fileName}/${fileName}.js'`;
                 }
-                
+
                 // generate a random element name
                 label = label || generateLabelHash(filePath);
 
@@ -77,13 +77,13 @@ const createGraphFromPages = async (pagesDir, config) => {
                 * template: page template to use as a base for a generated component (auto appended by -template.js)
                 * filePath: complete absolute path to a md file
                 * fileName: file name without extension/path, so that it can be copied to scratch dir with same name
-                * relativeExpectedPath: relative import path for generated component within a list.js file to later be 
+                * relativeExpectedPath: relative import path for generated component within a list.js file to later be
                 * imported into app.js root component
                 * title: the head <title></title> text
                 * meta: og graph meta array of objects { property/name, content }
                 */
 
-                pages.push({ mdFile, label, route, template, filePath, fileName, relativeExpectedPath, title, meta });
+                pages.push({ type: 'md', mdFile, label, route, template, filePath, fileName, relativeExpectedPath, title, meta });
               }
               if (stats.isDirectory()) {
                 await walkDirectory(filePath);
@@ -111,7 +111,7 @@ const generateLabelHash = (label) => {
   hash.update(label);
 
   let elementLabel = hash.digest('hex');
-  
+
   elementLabel = elementLabel.substring(elementLabel.length - 15, elementLabel.length);
 
   return elementLabel;

--- a/packages/cli/lifecycles/sources.js
+++ b/packages/cli/lifecycles/sources.js
@@ -3,6 +3,21 @@ const fs = require('fs');
 const path = require('path');
 const rp = require('request-promise');
 
+// insert home page
+// const fileName = 'index';
+
+// const indexGraph = {
+//   type: 'wp',
+//   meta: compilation.config.meta,
+//   template: 'page',
+//   title: 'Home Page',
+//   content: '<h1>Home Page</h1>',
+//   route: '/',
+//   relativeExpectedPath: `'../${fileName}/${fileName}.js'`,
+//   label: generateLabel(fileName),
+//   fileName
+// };
+
 let optionsList = {
   method: 'GET',
   json: true
@@ -14,7 +29,7 @@ let optionsList = {
 const fetchWPPosts = async (compilation) => {
 
   optionsList.uri = compilation.config.wpSource + '/wp-json/wp/v2/posts';
-  optionsList.body = { page: 1 };  /// pagination
+  optionsList.body = { page: 1 }; // TODO: this is just for development/testing
 
   return await rp.get(optionsList);
 };
@@ -32,6 +47,7 @@ const fetchWPPosts = async (compilation) => {
 
 //   return await rp.get(optionsList);
 // };
+
 const generateLabel = (slug) => {
   const labelHash = {
     algo: 'sha256',
@@ -55,12 +71,13 @@ const generateWPGraph = async(wpJSON, config) => {
         let { title, content, slug } = post;
         let fileName = slug.substring(0, 100);
         let graphPost = {
+          type: 'wp',
           meta: config.meta,
           template: 'page',
           title: title.rendered,
           content: content.rendered,
           route: `/${slug}/`,
-          relativeExpectedPath: `../${fileName}/${fileName}.js`,
+          relativeExpectedPath: `'../${fileName}/${fileName}.js'`,
           label: generateLabel(slug),
           fileName
         };
@@ -83,7 +100,7 @@ const writePageComponentsFromTemplate = async (compilation) => {
 
         const templateData = await fs.readFileSync(pageTemplatePath);
 
-        let result = templateData.toString().replace(/entry/g, file.content);
+        let result = templateData.toString().replace(/<entry><\/entry>/g, file.content);
 
         result = result.replace(/page-template/g, `eve-${file.label}`);
         result = result.replace(/MDIMPORT;/, '');
@@ -117,35 +134,23 @@ const writePageComponentsFromTemplate = async (compilation) => {
     });
   };
 
-  // insert home page
-  const fileName = 'index';
-
-  compilation.graph.unshift({
-    meta: compilation.config.meta,
-    template: 'page',
-    title: 'Home Page',
-    content: 'Home page',
-    route: '/',
-    relativeExpectedPath: `../${fileName}/${fileName}.js`,
-    label: generateLabel(fileName),
-    fileName
-  });
-
   return Promise.all(compilation.graph.map(file => {
     const context = compilation.context;
 
     return new Promise(async(resolve, reject) => {
       try {
-        let result = await createPageComponent(file, context);
+        if (file.type === 'wp') {
+          let result = await createPageComponent(file, context);
 
-        result = await loadPageMeta(file, result, context);
+          result = await loadPageMeta(file, result, context);
 
-        target = path.join(context.scratchDir, file.fileName);
+          target = path.join(context.scratchDir, file.fileName);
 
-        if (!fs.existsSync(target)) {
-          fs.mkdirSync(target, { recursive: true });
+          if (!fs.existsSync(target)) {
+            fs.mkdirSync(target, { recursive: true });
+          }
+          await fs.writeFileSync(path.join(target, `${file.fileName}.js`), result);
         }
-        await fs.writeFileSync(path.join(target, `${file.fileName}.js`), result);
 
         resolve();
       } catch (err) {
@@ -156,131 +161,19 @@ const writePageComponentsFromTemplate = async (compilation) => {
 
 };
 
-const writeListImportFile = async (compilation) => {
-  const importList = compilation.graph.map(file => {
-    return `import \'${file.relativeExpectedPath}\';\n`;
-  });
-
-  // Create app directory so that app-template relative imports are correct
-  const appDir = path.join(compilation.context.scratchDir, 'app');
-
-  if (!fs.existsSync(appDir)) {
-    await fs.mkdirSync(appDir);
-  }
-
-  return await fs.writeFileSync(path.join(appDir, './list.js'), importList.join(''));
-};
-
-const writeRoutes = async(compilation) => {
-  return new Promise(async (resolve, reject) => {
-    try {
-      let data = await fs.readFileSync(compilation.context.appTemplatePath);
-
-      const routes = compilation.graph.map(file => {
-        return `<lit-route path="${file.route}" component="eve-${file.label}"></lit-route>\n\t\t\t\t`;
-      });
-
-      const result = data.toString().replace(/MYROUTES/g, routes.join(''));
-
-      await fs.writeFileSync(path.join(compilation.context.scratchDir, 'app', './app.js'), result);
-
-      resolve();
-    } catch (err) {
-      reject(err);
-    }
-  });
-};
-
-// eslint-disable-next-line no-unused-vars
-const setupIndex = async({ context }) => {
-  return new Promise(async (resolve, reject) => {
-    try {
-      fs.copyFileSync(
-        context.indexPageTemplatePath,
-        path.join(context.scratchDir, context.indexPageTemplate)
-      );
-      fs.copyFileSync(
-        context.notFoundPageTemplatePath,
-        path.join(context.scratchDir, context.notFoundPageTemplate)
-      );
-      resolve();
-    } catch (err) {
-      reject(err);
-    }
-  });
-};
-
-// const generateHomePage = async(compilation) => {
-//   return new Promise(async(resolve, reject) => {
-//     try {
-
-//       const createHomePage = (compilation) => {
-//         `
-//         import { html, LitElement } from 'lit-element';
-
-//         class PageTemplate extends LitElement {
-
-//         `;
-//       };
-
-//       homePage = createHomePage(compilation);
-//       target = path.join(context.scratchDir, 'index');
-
-//       if (!fs.existsSync(target)) {
-//         fs.mkdirSync(target, { recursive: true });
-//       }
-//       await fs.writeFileSync(path.join(target, 'index.js'), homePage);
-//     } catch (err) {
-//       reject(err);
-//     }
-//   });
-// }
-
-const scaffoldFromWPGraph = async(compilation) => {
-  return new Promise(async (resolve, reject) => {
-    try {
-      console.log('Generate pages from templates...');
-      await writePageComponentsFromTemplate(compilation);
-
-      console.log('Writing imports for md...');
-      await writeListImportFile(compilation);
-
-      console.log('Writing Lit routes...');
-      await writeRoutes(compilation);
-
-      console.log('setup index page and html');
-      await setupIndex(compilation);
-
-      // console.log('generate home page');
-      // await generateHomePage(compilation);
-
-      console.log('Scaffolding complete.');
-      resolve();
-    } catch (err) {
-      reject(err);
-    }
-
-  });
-};
-
 module.exports = generateFromSources = async (compilation) => {
   return new Promise(async (resolve, reject) => {
     try {
       console.log('Fetch Wordpress Sources...');
       const wpJSON = await fetchWPPosts(compilation);
 
-      // console.log(wpJSON);
-
       console.log('Generating graph from sources...');
-      const wpGraph = await generateWPGraph(wpJSON, compilation.config);
+      compilation.graph.push(...await generateWPGraph(wpJSON, compilation.config));
 
-      // console.log(wpGraph);
-      compilation.graph = wpGraph;
+      console.log('Generate pages from templates...');
+      await writePageComponentsFromTemplate(compilation);
 
-      console.log('Scaffolding from WP Graph...');
-      await scaffoldFromWPGraph(compilation);
-
-      resolve();
+      resolve(compilation);
     } catch (err) {
       reject(err);
     }

--- a/packages/cli/lifecycles/sources.js
+++ b/packages/cli/lifecycles/sources.js
@@ -3,21 +3,6 @@ const fs = require('fs');
 const path = require('path');
 const rp = require('request-promise');
 
-// insert home page
-// const fileName = 'index';
-
-// const indexGraph = {
-//   type: 'wp',
-//   meta: compilation.config.meta,
-//   template: 'page',
-//   title: 'Home Page',
-//   content: '<h1>Home Page</h1>',
-//   route: '/',
-//   relativeExpectedPath: `'../${fileName}/${fileName}.js'`,
-//   label: generateLabel(fileName),
-//   fileName
-// };
-
 let optionsList = {
   method: 'GET',
   json: true
@@ -34,6 +19,7 @@ const fetchWPPosts = async (compilation) => {
   return await rp.get(optionsList);
 };
 
+// Future amendments for more of wordpress API
 // const fetchWPPages = async (compilation) => {
 
 //   optionsList.uri = compilation.config.wpSource + '/wp-json/wp/v2/pages';
@@ -48,6 +34,7 @@ const fetchWPPosts = async (compilation) => {
 //   return await rp.get(optionsList);
 // };
 
+// Generate a random hash based on slug
 const generateLabel = (slug) => {
   const labelHash = {
     algo: 'sha256',
@@ -69,7 +56,7 @@ const generateWPGraph = async(wpJSON, config) => {
     return new Promise((resolve, reject) => {
       try {
         let { title, content, slug } = post;
-        let fileName = slug.substring(0, 100);
+        let fileName = slug.substring(0, 100); // needs to be trimmed better this is hacky
         let graphPost = {
           type: 'wp',
           meta: config.meta,
@@ -90,6 +77,9 @@ const generateWPGraph = async(wpJSON, config) => {
   }));
 };
 
+/*
+* Note: This is the same function from our scaffold.js, with small modifications
+*/
 const writePageComponentsFromTemplate = async (compilation) => {
   const createPageComponent = async (file, context) => {
     return new Promise(async (resolve, reject) => {
@@ -100,7 +90,7 @@ const writePageComponentsFromTemplate = async (compilation) => {
 
         const templateData = await fs.readFileSync(pageTemplatePath);
 
-        let result = templateData.toString().replace(/<entry><\/entry>/g, file.content);
+        let result = templateData.toString().replace(/<entry><\/entry>/g, file.content); // modified from scaffold.js
 
         result = result.replace(/page-template/g, `eve-${file.label}`);
         result = result.replace(/MDIMPORT;/, '');
@@ -139,12 +129,13 @@ const writePageComponentsFromTemplate = async (compilation) => {
 
     return new Promise(async(resolve, reject) => {
       try {
+        // modified from scaffold.js
         if (file.type === 'wp') {
           let result = await createPageComponent(file, context);
 
           result = await loadPageMeta(file, result, context);
 
-          target = path.join(context.scratchDir, file.fileName);
+          target = path.join(context.scratchDir, file.fileName); // modified from scaffold.js
 
           if (!fs.existsSync(target)) {
             fs.mkdirSync(target, { recursive: true });

--- a/packages/cli/lifecycles/sources.js
+++ b/packages/cli/lifecycles/sources.js
@@ -1,0 +1,289 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const rp = require('request-promise');
+
+let optionsList = {
+  method: 'GET',
+  json: true
+};
+
+// Wordpress API Reference
+// https://developer.wordpress.org/rest-api/reference/
+
+const fetchWPPosts = async (compilation) => {
+
+  optionsList.uri = compilation.config.wpSource + '/wp-json/wp/v2/posts';
+  optionsList.body = { page: 1 };  /// pagination
+
+  return await rp.get(optionsList);
+};
+
+// const fetchWPPages = async (compilation) => {
+
+//   optionsList.uri = compilation.config.wpSource + '/wp-json/wp/v2/pages';
+
+//   return await rp.get(optionsList);
+// };
+
+// const fetchWPCategories = async (compilation) => {
+
+//   optionsList.uri = compilation.config.wpSource + '/wp-json/wp/v2/categories';
+
+//   return await rp.get(optionsList);
+// };
+const generateLabel = (slug) => {
+  const labelHash = {
+    algo: 'sha256',
+    trim: 15
+  };
+  let elementLabel = '';
+  const hash = crypto.createHash(labelHash.algo);
+
+  hash.update(slug || '');
+  elementLabel = hash.digest('hex');
+  const labelLength = elementLabel.length;
+
+  return elementLabel.substring(labelLength - labelHash.trim, labelLength);
+};
+
+const generateWPGraph = async(wpJSON, config) => {
+
+  return Promise.all(wpJSON.map(async (post) => {
+    return new Promise((resolve, reject) => {
+      try {
+        let { title, content, slug } = post;
+        let fileName = slug.substring(0, 100);
+        let graphPost = {
+          meta: config.meta,
+          template: 'page',
+          title: title.rendered,
+          content: content.rendered,
+          route: `/${slug}/`,
+          relativeExpectedPath: `../${fileName}/${fileName}.js`,
+          label: generateLabel(slug),
+          fileName
+        };
+
+        resolve(graphPost);
+      } catch (err) {
+        reject();
+      }
+    });
+  }));
+};
+
+const writePageComponentsFromTemplate = async (compilation) => {
+  const createPageComponent = async (file, context) => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const pageTemplatePath = file.template === 'page'
+          ? context.pageTemplatePath
+          : path.join(context.templatesDir, `${file.template}-template.js`);
+
+        const templateData = await fs.readFileSync(pageTemplatePath);
+
+        let result = templateData.toString().replace(/entry/g, file.content);
+
+        result = result.replace(/page-template/g, `eve-${file.label}`);
+        result = result.replace(/MDIMPORT;/, '');
+
+        resolve(result);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  };
+
+  const loadPageMeta = async (file, result, { metaComponent }) => {
+
+    return new Promise((resolve, reject) => {
+      try {
+        const { title, meta, route } = file;
+        const metadata = {
+          title,
+          meta,
+          route
+        };
+
+        result = result.replace(/METAIMPORT/, `import '${metaComponent}'`);
+        result = result.replace(/METADATA/, `const metadata = ${JSON.stringify(metadata)}`);
+        result = result.replace(/METAELEMENT/, '<eve-meta .attributes=\${metadata}></eve-meta>');
+
+        resolve(result);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  };
+
+  // insert home page
+  const fileName = 'index';
+
+  compilation.graph.unshift({
+    meta: compilation.config.meta,
+    template: 'page',
+    title: 'Home Page',
+    content: 'Home page',
+    route: '/',
+    relativeExpectedPath: `../${fileName}/${fileName}.js`,
+    label: generateLabel(fileName),
+    fileName
+  });
+
+  return Promise.all(compilation.graph.map(file => {
+    const context = compilation.context;
+
+    return new Promise(async(resolve, reject) => {
+      try {
+        let result = await createPageComponent(file, context);
+
+        result = await loadPageMeta(file, result, context);
+
+        target = path.join(context.scratchDir, file.fileName);
+
+        if (!fs.existsSync(target)) {
+          fs.mkdirSync(target, { recursive: true });
+        }
+        await fs.writeFileSync(path.join(target, `${file.fileName}.js`), result);
+
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }));
+
+};
+
+const writeListImportFile = async (compilation) => {
+  const importList = compilation.graph.map(file => {
+    return `import \'${file.relativeExpectedPath}\';\n`;
+  });
+
+  // Create app directory so that app-template relative imports are correct
+  const appDir = path.join(compilation.context.scratchDir, 'app');
+
+  if (!fs.existsSync(appDir)) {
+    await fs.mkdirSync(appDir);
+  }
+
+  return await fs.writeFileSync(path.join(appDir, './list.js'), importList.join(''));
+};
+
+const writeRoutes = async(compilation) => {
+  return new Promise(async (resolve, reject) => {
+    try {
+      let data = await fs.readFileSync(compilation.context.appTemplatePath);
+
+      const routes = compilation.graph.map(file => {
+        return `<lit-route path="${file.route}" component="eve-${file.label}"></lit-route>\n\t\t\t\t`;
+      });
+
+      const result = data.toString().replace(/MYROUTES/g, routes.join(''));
+
+      await fs.writeFileSync(path.join(compilation.context.scratchDir, 'app', './app.js'), result);
+
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+};
+
+// eslint-disable-next-line no-unused-vars
+const setupIndex = async({ context }) => {
+  return new Promise(async (resolve, reject) => {
+    try {
+      fs.copyFileSync(
+        context.indexPageTemplatePath,
+        path.join(context.scratchDir, context.indexPageTemplate)
+      );
+      fs.copyFileSync(
+        context.notFoundPageTemplatePath,
+        path.join(context.scratchDir, context.notFoundPageTemplate)
+      );
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+  });
+};
+
+// const generateHomePage = async(compilation) => {
+//   return new Promise(async(resolve, reject) => {
+//     try {
+
+//       const createHomePage = (compilation) => {
+//         `
+//         import { html, LitElement } from 'lit-element';
+
+//         class PageTemplate extends LitElement {
+
+//         `;
+//       };
+
+//       homePage = createHomePage(compilation);
+//       target = path.join(context.scratchDir, 'index');
+
+//       if (!fs.existsSync(target)) {
+//         fs.mkdirSync(target, { recursive: true });
+//       }
+//       await fs.writeFileSync(path.join(target, 'index.js'), homePage);
+//     } catch (err) {
+//       reject(err);
+//     }
+//   });
+// }
+
+const scaffoldFromWPGraph = async(compilation) => {
+  return new Promise(async (resolve, reject) => {
+    try {
+      console.log('Generate pages from templates...');
+      await writePageComponentsFromTemplate(compilation);
+
+      console.log('Writing imports for md...');
+      await writeListImportFile(compilation);
+
+      console.log('Writing Lit routes...');
+      await writeRoutes(compilation);
+
+      console.log('setup index page and html');
+      await setupIndex(compilation);
+
+      // console.log('generate home page');
+      // await generateHomePage(compilation);
+
+      console.log('Scaffolding complete.');
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+
+  });
+};
+
+module.exports = generateFromSources = async (compilation) => {
+  return new Promise(async (resolve, reject) => {
+    try {
+      console.log('Fetch Wordpress Sources...');
+      const wpJSON = await fetchWPPosts(compilation);
+
+      // console.log(wpJSON);
+
+      console.log('Generating graph from sources...');
+      const wpGraph = await generateWPGraph(wpJSON, compilation.config);
+
+      // console.log(wpGraph);
+      compilation.graph = wpGraph;
+
+      console.log('Scaffolding from WP Graph...');
+      await scaffoldFromWPGraph(compilation);
+
+      resolve();
+    } catch (err) {
+      reject(err);
+    }
+
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1506,15 +1506,15 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
+bluebird@^3.5.0, bluebird@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
+
 bluebird@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
   integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
-
-bluebird@^3.5.5:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
-  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
@@ -8218,6 +8218,16 @@ request-promise-native@^1.0.5:
   resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.7.tgz#a49868a624bdea5069f1251d0a836e0d89aa2c59"
   integrity sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==
   dependencies:
+    request-promise-core "1.1.2"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
+
+request-promise@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.4.tgz#1c5ed0d71441e38ad58c7ce4ea4ea5b06d54b310"
+  integrity sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==
+  dependencies:
+    bluebird "^3.5.0"
     request-promise-core "1.1.2"
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"


### PR DESCRIPTION
## Related Issue
Resolves #21 

## Summary of Changes

Created a new lifecycle called sources, which simply pulls from sources, populates a graph, and then scaffolds out components from each post.  In this example, I'm pulling posts from a wordpress instance into graph, creating components and routes, rendering statically using greenwood.  This could be applied to other wordpress features, or any other CMS.

## Development

You can now test this out using docker via `docker-compose`.

```
# to run in detached mode add -d argument
$ docker-compose up

# wait a few minutes for containers to start up and connect to each other
# wordpress should be accessible via http://localhost:8004
# in another shell or same (if running detached)
$ yarn serve
```

You should now see the wordpress post from http://localhost:8004/test-greenwood-headless-1/ available at  http://localhost:8000/test-greenwood-headless-1/  within greenwood

A second post http://localhost:8004/test-greenwood-headless-2/ should be available at  http://localhost:8000/test-greenwood-headless-2/  within greenwood

our test wordpress container has a username and password: `greenwood` which should be set by default with the included sql dump.

## TODO

- [x] Working PoC of basic posts in greenwood from a wordpress instance
- [x] Merge and apply conditions so that it works alongside wc-md-loader
- [x] Create an easy to duplicate development environment with wordpress using docker
- [ ] refine and modularize lifecycles API so that it can be made into a wordpress plugin, seperate from greenwood core.
