### PR TITLE
remove resolve inside recursive walk directory call

### DIFF
--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -6,7 +6,7 @@ const path = require('path');
 const util = require('util');
 
 const createGraphFromPages = async (pagesDir, config) => {
-  let pages = [];
+  let graph = [];
   const readdir = util.promisify(fs.readdir);
   const readFile = util.promisify(fs.readFile);
   
@@ -83,11 +83,11 @@ const createGraphFromPages = async (pagesDir, config) => {
                 * meta: og graph meta array of objects { property/name, content }
                 */
 
-                pages.push({ mdFile, label, route, template, filePath, fileName, relativeExpectedPath, title, meta });
+                graph.push({ mdFile, label, route, template, filePath, fileName, relativeExpectedPath, title, meta });
               }
               if (stats.isDirectory()) {
                 await walkDirectory(filePath);
-                resolve();
+                // resolve();
               }
               resolve();
             } catch (err) {
@@ -98,7 +98,8 @@ const createGraphFromPages = async (pagesDir, config) => {
       };
 
       await walkDirectory(pagesDir);
-      resolve(pages);
+      
+      resolve(graph);
     } catch (err) {
       reject(err);
     }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #213 

## Summary of Changes
Seeing if this will help at all.  

Anther thought I will try in a separate PR is to audit the code and make sure all usage of `async / await` is consistent as I see us using it even with sync based `fs` tasks.