### PR TITLE
Bug/issue 220 puppeteer external requests

### DIFF
--- a/packages/plugin-google-analytics/test/cases/default/default.spec.js
+++ b/packages/plugin-google-analytics/test/cases/default/default.spec.js
@@ -48,7 +48,8 @@ describe('Build Greenwood With: ', async function() {
     runSmokeTest(['public', 'index', 'not-found', 'hello'], LABEL);
 
     describe('Initialization script at the end of the <body> tag', function() {
-      let inlineScript;
+      let inlineScript = [];
+      let scriptSrcTags = [];
 
       beforeEach(async function() {
         const dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, 'index.html'));
@@ -56,6 +57,10 @@ describe('Build Greenwood With: ', async function() {
 
         inlineScript = Array.prototype.slice.call(scriptTags).filter(script => {
           return !script.src;
+        });
+
+        scriptSrcTags = Array.prototype.slice.call(scriptTags).filter(script => {
+          return script.src && script.src.indexOf('google') >= 0;
         });
 
       });
@@ -84,6 +89,10 @@ describe('Build Greenwood With: ', async function() {
         `;
 
         expect(inlineScript[0].textContent).to.contain(expectedContent);
+      });
+
+      it('should only have one external Google script tag', function() {
+        expect(scriptSrcTags.length).to.be.equal(1);
       });
     });
 

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -91,7 +91,7 @@ function defaultIndex(label) {
         const bundleScripts = Array.prototype.slice.call(scriptTags).filter(script => {
           const src = script.src;
 
-          return src.indexOf('index.') >= 0 && src.indexOf('.bundle.js') >= 0;
+          return src.indexOf('index') >= 0 && src.indexOf('bundle') >= 0;
         });
 
         expect(bundleScripts.length).to.be.equal(1);


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #220 

## Summary of Changes
1. From #212 , introduced request interception to prevent unnecessary network requests. This prevents puppeteer from loading scripts and libraries (other than those we whitelist)
1. Strength unit tests for script tags

Now now analytics code pre-loading in our generated output 👍 
<img width="1511" alt="Screen Shot 2019-10-13 at 9 54 54 AM" src="https://user-images.githubusercontent.com/895923/66716795-feaf6000-ed9f-11e9-81c1-e928eeb49cb9.png">
