### PR TITLE
Bug/issue 210 hooks plugins not working

### DIFF
--- a/packages/cli/src/config/webpack.config.common.js
+++ b/packages/cli/src/config/webpack.config.common.js
@@ -39,18 +39,6 @@ module.exports = ({ config, context }) => {
     from: context.assetDir,
     to: path.join(context.publicDir, 'assets')
   }] : [];
-
-  // gets Index Hooks to pass as options to HtmlWebpackPlugin
-  const customOptions = Object.assign({}, ...config.plugins
-    .filter((plugin) => plugin.type === 'index')
-    .map((plugin) => plugin.provider({ config, context }))
-    .filter((providerResult) => {
-      return Object.keys(providerResult).map((key) => {
-        if (key !== 'type') {
-          return providerResult[key];
-        }
-      });
-    }));
       
   const commonCssLoaders = [
     { loader: 'css-loader' },
@@ -63,6 +51,18 @@ module.exports = ({ config, context }) => {
       }
     }
   ];
+
+  // gets Index Hooks to pass as options to HtmlWebpackPlugin
+  const customOptions = Object.assign({}, ...config.plugins
+    .filter((plugin) => plugin.type === 'index')
+    .map((plugin) => plugin.provider({ config, context }))
+    .filter((providerResult) => {
+      return Object.keys(providerResult).map((key) => {
+        if (key !== 'type') {
+          return providerResult[key];
+        }
+      });
+    }));
 
   // utilizes webpack plugins passed in directly by the user
   const customWebpackPlugins = config.plugins

--- a/packages/cli/src/config/webpack.config.common.js
+++ b/packages/cli/src/config/webpack.config.common.js
@@ -1,6 +1,5 @@
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const fs = require('fs');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 const webpack = require('webpack');
 
@@ -51,18 +50,6 @@ module.exports = ({ config, context }) => {
       }
     }
   ];
-
-  // gets Index Hooks to pass as options to HtmlWebpackPlugin
-  const customOptions = Object.assign({}, ...config.plugins
-    .filter((plugin) => plugin.type === 'index')
-    .map((plugin) => plugin.provider({ config, context }))
-    .filter((providerResult) => {
-      return Object.keys(providerResult).map((key) => {
-        if (key !== 'type') {
-          return providerResult[key];
-        }
-      });
-    }));
 
   // utilizes webpack plugins passed in directly by the user
   const customWebpackPlugins = config.plugins
@@ -124,13 +111,6 @@ module.exports = ({ config, context }) => {
           resource.request = resource.request.replace(/^\.\//, context.pagesDir);
         }
       ),
-
-      new HtmlWebpackPlugin({
-        filename: path.join(context.publicDir, context.indexPageTemplate),
-        template: path.join(context.scratchDir, context.indexPageTemplate),
-        chunksSortMode: 'dependency',
-        ...customOptions
-      }),
 
       ...customWebpackPlugins
     ]

--- a/packages/cli/src/config/webpack.config.common.js
+++ b/packages/cli/src/config/webpack.config.common.js
@@ -39,7 +39,7 @@ module.exports = ({ config, context }) => {
     from: context.assetDir,
     to: path.join(context.publicDir, 'assets')
   }] : [];
-      
+
   const commonCssLoaders = [
     { loader: 'css-loader' },
     {

--- a/packages/cli/src/config/webpack.config.common.js
+++ b/packages/cli/src/config/webpack.config.common.js
@@ -30,6 +30,16 @@ const mapUserWorkspaceDirectory = (userPath) => {
 };
 
 module.exports = ({ config, context }) => {
+  // dynamically map all the user's workspace directories for resolution by webpack
+  // this essentially helps us keep watch over changes from the user, and greenwood's build pipeline
+  const mappedUserDirectoriesForWebpack = getUserWorkspaceDirectories(context.userWorkspace).map(mapUserWorkspaceDirectory);
+
+  // if user has an assets/ directory in their workspace, automatically copy it for them
+  const userAssetsDirectoryForWebpack = fs.existsSync(context.assetDir) ? [{
+    from: context.assetDir,
+    to: path.join(context.publicDir, 'assets')
+  }] : [];
+
   // gets Index Hooks to pass as options to HtmlWebpackPlugin
   const customOptions = Object.assign({}, ...config.plugins
     .filter((plugin) => plugin.type === 'index')
@@ -41,17 +51,7 @@ module.exports = ({ config, context }) => {
         }
       });
     }));
-
-  // dynamically map all the user's workspace directories for resolution by webpack
-  // this essentially helps us keep watch over changes from the user, and greenwood's build pipeline
-  const mappedUserDirectoriesForWebpack = getUserWorkspaceDirectories(context.userWorkspace).map(mapUserWorkspaceDirectory);
-
-  // if user has an assets/ directory in their workspace, automatically copy it for them
-  const userAssetsDirectoryForWebpack = fs.existsSync(context.assetDir) ? [{
-    from: context.assetDir,
-    to: path.join(context.publicDir, 'assets')
-  }] : [];
-
+      
   const commonCssLoaders = [
     { loader: 'css-loader' },
     {

--- a/packages/cli/src/config/webpack.config.prod.js
+++ b/packages/cli/src/config/webpack.config.prod.js
@@ -1,21 +1,7 @@
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const path = require('path');
 const webpackMerge = require('webpack-merge');
 const commonConfig = require('./webpack.config.common.js');
 
 module.exports = ({ config, context, graph }) => {
-  // gets Index Hooks to pass as options to HtmlWebpackPlugin
-  const customOptions = Object.assign({}, ...config.plugins
-    .filter((plugin) => plugin.type === 'index')
-    .map((plugin) => plugin.provider({ config, context }))
-    .filter((providerResult) => {
-      return Object.keys(providerResult).map((key) => {
-        if (key !== 'type') {
-          return providerResult[key];
-        }
-      });
-    }));
-
   const configWithContext = commonConfig({ config, context, graph });
 
   return webpackMerge(configWithContext, {
@@ -24,22 +10,8 @@ module.exports = ({ config, context, graph }) => {
 
     performance: {
       hints: 'warning'
-    },
+    }
 
-    plugins: [
-      new HtmlWebpackPlugin({
-        filename: path.join(context.publicDir, context.indexPageTemplate),
-        template: path.join(context.scratchDir, context.indexPageTemplate),
-        chunksSortMode: 'dependency',
-        ...customOptions
-      }),
-      new HtmlWebpackPlugin({
-        filename: path.join(context.publicDir, context.notFoundPageTemplate),
-        template: path.join(context.scratchDir, context.notFoundPageTemplate),
-        chunksSortMode: 'dependency',
-        ...customOptions
-      })
-    ]
   });
 
 };

--- a/packages/cli/src/config/webpack.config.prod.js
+++ b/packages/cli/src/config/webpack.config.prod.js
@@ -4,6 +4,18 @@ const webpackMerge = require('webpack-merge');
 const commonConfig = require('./webpack.config.common.js');
 
 module.exports = ({ config, context, graph }) => {
+  // gets Index Hooks to pass as options to HtmlWebpackPlugin
+  const customOptions = Object.assign({}, ...config.plugins
+    .filter((plugin) => plugin.type === 'index')
+    .map((plugin) => plugin.provider({ config, context }))
+    .filter((providerResult) => {
+      return Object.keys(providerResult).map((key) => {
+        if (key !== 'type') {
+          return providerResult[key];
+        }
+      });
+    }));
+
   const configWithContext = commonConfig({ config, context, graph });
 
   return webpackMerge(configWithContext, {
@@ -16,9 +28,16 @@ module.exports = ({ config, context, graph }) => {
 
     plugins: [
       new HtmlWebpackPlugin({
+        filename: path.join(context.publicDir, context.indexPageTemplate),
+        template: path.join(context.scratchDir, context.indexPageTemplate),
+        chunksSortMode: 'dependency',
+        ...customOptions
+      }),
+      new HtmlWebpackPlugin({
         filename: path.join(context.publicDir, context.notFoundPageTemplate),
         template: path.join(context.scratchDir, context.notFoundPageTemplate),
-        publicPath: configWithContext.output.publicPath
+        chunksSortMode: 'dependency',
+        ...customOptions
       })
     ]
   });

--- a/packages/cli/test/cases/build.config.public-path/build.config.public-path.spec.js
+++ b/packages/cli/test/cases/build.config.public-path/build.config.public-path.spec.js
@@ -21,7 +21,7 @@ const runSmokeTest = require('../../../../../test/smoke-test');
 const TestBed = require('../../../../../test/test-bed');
 
 describe('Build Greenwood With: ', async function() {
-  const LABEL = 'Custom Title Configuration and Default Workspace';
+  const LABEL = 'Custom Public Path Configuration and Default Workspace';
   let setup;
 
   before(async function() {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #210  (and #197 🌟 )

## Summary of Changes
1. Instances of `HtmlWebpackPlugin` were overwriting each other.  Instead, just explicitly instantiating the instances that we need in **webpack** config common, and then we can override the configuration options per **webpack** config as needed.

~~Note: As expected, there is some duplication but not sure the best way to abstract it, without it being clunky.  Maybe in [_cli/lifecycles/config.js_ for `plugins`](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/cli/src/lifecycles/config.js#L14)?~~