### PR TITLE
show stats and progress

### DIFF
--- a/packages/cli/src/config/webpack.config.prod.js
+++ b/packages/cli/src/config/webpack.config.prod.js
@@ -11,11 +11,11 @@ module.exports = ({ config, context, graph }) => {
 
     performance: {
       hints: 'warning'
-    },
+    }
 
-    plugins: [
-      new webpack.ProgressPlugin()
-    ]
+    // plugins: [
+    //   new webpack.ProgressPlugin()
+    // ]
 
   });
 

--- a/packages/cli/src/config/webpack.config.prod.js
+++ b/packages/cli/src/config/webpack.config.prod.js
@@ -1,3 +1,4 @@
+const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 const commonConfig = require('./webpack.config.common.js');
 
@@ -10,7 +11,11 @@ module.exports = ({ config, context, graph }) => {
 
     performance: {
       hints: 'warning'
-    }
+    },
+
+    plugins: [
+      new webpack.ProgressPlugin()
+    ]
 
   });
 

--- a/packages/cli/src/config/webpack.config.prod.js
+++ b/packages/cli/src/config/webpack.config.prod.js
@@ -1,4 +1,4 @@
-const webpack = require('webpack');
+// const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 const commonConfig = require('./webpack.config.common.js');
 

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -90,10 +90,11 @@ module.exports = readAndMergeConfig = async() => {
         }
 
         if (themeFile) {
-          if (typeof themeFile !== 'string' && themeFile.indexOf('.') < 1) {
+          if (typeof themeFile === 'string' && themeFile.indexOf('.') > 0) {
+            customConfig.themeFile = themeFile;
+          } else {
             reject(`Error: greenwood.config.js themeFile must be a valid filename. got ${themeFile} instead.`);
           }
-          customConfig.themeFile = themeFile;
         }
 
         if (devServer && Object.keys(devServer).length > 0) {
@@ -119,6 +120,7 @@ module.exports = readAndMergeConfig = async() => {
           }
         }
       }
+
       resolve({ ...defaultConfig, ...customConfig });
     } catch (err) {
       reject(err);

--- a/packages/cli/src/tasks/build.js
+++ b/packages/cli/src/tasks/build.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk');
 const path = require('path');
 const webpack = require('webpack');
 const serializeBuild = require('../lifecycles/serialize');
@@ -32,6 +33,11 @@ const runWebpack = async (compilation) => {
           reject(err);
         } else {
           console.log('webpack build complete');
+
+          if (stats && stats.hasWarnings()) {
+            console.log(`${chalk.rgb(255, 255, 71)(stats.toJson('minimal').warnings[0])}`);
+          }
+
           resolve();
         }
       });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #260 

Now output looks like this
```shell
$ yarn build
yarn run v1.12.3
$ yarn clean && node . build
$ rimraf ./**/.greenwood/** && rimraf ./**/public/** && rimraf ./coverage
-------------------------------------------------------
Welcome to Greenwood ♻️
-------------------------------------------------------
Reading project config
Initializing project workspace contexts
Generating graph of workspace files...
Scaffolding out project files...
Generate pages from templates...
Writing imports for md...
Writing Lit routes...
setup index page and html
Scaffolding complete.
Building project for production.
Building SPA from compilation...
25% building 131/144 modules 13 active ...reen/repos/greenwood/node_modules/@evergreen-wc/eve-button/src/eve-button.css
...
webpack build complete
asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets:
  index.6e6dde8f7130188345bc.bundle.js (286 KiB)
...................................
Static site generation complete!
...................................
✨  Done in 21.34s.
```

## Summary of Changes
1. Log warning stats
1. Enable `webpack.ProgressPlugin` *
!. Add [**webpack-bundle-analyzer**](https://github.com/webpack-contrib/webpack-bundle-analyzer) ?