### PR TITLE
setting nodejs engines in npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,14 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node: [10, 12]
 
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ matrix.node }}
     - name: Installing project dependencies
       run: |
         yarn install  --frozen-lockfile && yarn lerna bootstrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [10.x, 12.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "Static Site Generator"
   ],
   "engines" : { 
-    "node" : ">=10.x <=12.x." 
+    "node" : ">=10.x" 
   },
   "bin": {
     "greenwood": "./src/index.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,9 @@
     "Lit Html",
     "Static Site Generator"
   ],
+  "engines" : { 
+    "node" : ">=10.x <=12.x." 
+  },
   "bin": {
     "greenwood": "./src/index.js"
   },


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #180 

## Summary of Changes
On the home page for NodeJS we say we support latest LTS NodeJS, but CI was only running against 10.x.
1. Set CI Action to run against 10.x and 12.x versions
1. Set minimum NodeJS version for `engines` in _package.json_ for `@greenwood/cli`
1. Set Master Action to build using 12.x (LTS)

**Question**
Should we set an upper bound, or just a minimum?  I think minimum is better since CI will tell us if we introduce a breaking change.