### PR TITLE
silence browserslists when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "build": "yarn clean && node . build",
     "serve": "yarn build && cd ./public && ws",
     "develop": "yarn clean && node . develop",
-    "test": "yarn clean && nyc mocha ./packages/**/test/**/**/*.spec.js --timeout 30000",
-    "test:tdd": "yarn clean && mocha --watch ./packages/**/test/**/**/*.spec.js --timeout 15000"
+    "test": "export BROWSERSLIST_IGNORE_OLD_DATA=true && yarn clean && nyc mocha ./packages/**/test/**/**/*.spec.js --timeout 30000",
+    "test:tdd": "export BROWSERSLIST_IGNORE_OLD_DATA=true  && yarn clean && mocha --watch ./packages/**/test/**/**/*.spec.js --timeout 15000"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #281 

## Summary of Changes
1. Added `export BROWSERSLIST_IGNORE_OLD_DATA=true` to silence browserslist console output that was preventing specs from running

Note: I confirmed this doesn't happen in consuming projects.  From the **greenwood-getting-started** repo, using latest version of Greenwood
```shell
$ cd project-evergreen/repos/greenwood-getting-started/
$ yarn build
yarn run v1.12.3
$ greenwood build
-------------------------------------------------------
Welcome to Greenwood ♻️
-------------------------------------------------------
Reading project config
Initializing project workspace contexts
Generating graph of workspace files...
Scaffolding out project files...
Generate pages from templates...
Writing imports for md...
Writing Lit routes...
setup index page and html
Scaffolding complete.
Building project for production.
Building SPA from compilation...
webpack build complete
...................................
Static site generation complete!
...................................
✨  Done in 10.63s.
$ npm ls @greenwood/cli
greenwood-getting-started@1.0.0 /Users/owenbuckley/Workspace/project-evergreen/repos/greenwood-getting-started
└── @greenwood/cli@0.4.2
```