### PR TITLE
[WIP] task/issue-275 Create Extensible Menus Query

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,6 +55,7 @@
     "lit-element": "^2.0.1",
     "lit-redux-router": "^0.9.3",
     "local-web-server": "^2.6.1",
+    "markdown-toc": "^1.2.0",
     "node-fetch": "^2.6.0",
     "postcss-loader": "^3.0.0",
     "postcss-nested": "^4.1.2",

--- a/packages/cli/src/data/queries/menu.gql
+++ b/packages/cli/src/data/queries/menu.gql
@@ -1,0 +1,20 @@
+query($menu: String!, $route: String) {
+  menu(filter: $menu, pathname: $route) {
+    item {
+      label,
+      link
+    }
+    children {
+      item {
+        label,
+        link
+      },
+      children {
+        item {
+          label,
+          link
+        }
+      }
+    }
+  }
+}

--- a/packages/cli/src/data/queries/navigation.gql
+++ b/packages/cli/src/data/queries/navigation.gql
@@ -1,6 +1,0 @@
-query {
-  navigation{
-    label,
-    link
-  }
-}

--- a/packages/cli/src/data/schema/graph.js
+++ b/packages/cli/src/data/schema/graph.js
@@ -18,8 +18,7 @@ const getMenuFromGraph = async (root, { pathname, filter = '' }, context) => {
           let baseRoute = pathname.substring(0, baseRouteIndex + 1);
 
           if (route.includes(baseRoute)) {
-            children = getFormattedHeadings(tableOfContents);
-            items.push({ item: { link: route, label: title }, children });
+            items.push({ item: { link: route, label: title }, children: getParsedHeadingsFromPage(tableOfContents) });
           }
         } else {
           items.push({ item: { link: route, label: title }, children });
@@ -30,7 +29,7 @@ const getMenuFromGraph = async (root, { pathname, filter = '' }, context) => {
   return { label: filter, link: 'na', children: items };
 };
 
-const getFormattedHeadings = (tableOfContents) => {
+const getParsedHeadingsFromPage = (tableOfContents) => {
   let children = [];
 
   if (tableOfContents.length > 0) {

--- a/packages/cli/src/data/schema/graph.js
+++ b/packages/cli/src/data/schema/graph.js
@@ -4,6 +4,8 @@ const getMenuFromGraph = async (root, { pathname, filter = '' }, context) => {
   const { graph } = context;
   let items = [];
 
+  // TODO Issue #271 https://github.com/ProjectEvergreen/greenwood/issues/271
+  // Sort menus by label/index asc/desc
   graph
     .forEach((page) => {
       const { route, menu, title, tableOfContents } = page;
@@ -16,13 +18,7 @@ const getMenuFromGraph = async (root, { pathname, filter = '' }, context) => {
           let baseRoute = pathname.substring(0, baseRouteIndex + 1);
 
           if (route.includes(baseRoute)) {
-            if (tableOfContents.length > 0) {
-              tableOfContents.forEach(({ content, slug, lvl }) => {
-                if (lvl === 3) {
-                  children.push({ item: { label: content, link: '#' + slug }, children: [] });
-                }
-              });
-            }
+            children = getFormattedHeadings(tableOfContents);
             items.push({ item: { link: route, label: title }, children });
           }
         } else {
@@ -32,6 +28,20 @@ const getMenuFromGraph = async (root, { pathname, filter = '' }, context) => {
     });
 
   return { label: filter, link: 'na', children: items };
+};
+
+const getFormattedHeadings = (tableOfContents) => {
+  let children = [];
+
+  if (tableOfContents.length > 0) {
+    tableOfContents.forEach(({ content, slug, lvl }) => {
+      // make sure we only add h3 links to menu
+      if (lvl === 3) {
+        children.push({ item: { label: content, link: '#' + slug }, children: [] });
+      }
+    });
+  }
+  return children;
 };
 
 const getDeriveMetaFromRoute = (route) => {

--- a/packages/cli/src/data/schema/graph.js
+++ b/packages/cli/src/data/schema/graph.js
@@ -1,6 +1,6 @@
 const { gql } = require('apollo-server-express');
 
-const menu = async (root, { pathname, filter = '' }, context) => {
+const getMenuFromGraph = async (root, { pathname, filter = '' }, context) => {
   const { graph } = context;
   let items = [];
 
@@ -124,7 +124,7 @@ const graphTypeDefs = gql`
 
   type Query {
     graph: [Page]
-    menu(filter: String, pathname: String): Menu
+    menu(filter: String, pathname: String, orderBy: MenuOrderBy): Menu
     children(parent: String): [Page]
   }
 
@@ -136,12 +136,10 @@ const graphTypeDefs = gql`
   }
 `;
 
-//  menu(filter: String, orderBy: MenuOrderBy): Menu
-
 const graphResolvers = {
   Query: {
     graph: getPagesFromGraph,
-    menu: menu,
+    menu: getMenuFromGraph,
     children: getChildrenFromParentRoute
   }
 };

--- a/packages/cli/src/data/schema/graph.js
+++ b/packages/cli/src/data/schema/graph.js
@@ -4,15 +4,12 @@ const getMenuFromGraph = async (root, { pathname, filter = '' }, context) => {
   const { graph } = context;
   let items = [];
 
-  // TODO: Issue #271 sorting ascending/descending label/index
-  // https://github.com/ProjectEvergreen/greenwood/issues/271
   graph
     .forEach((page) => {
       const { route, menu, title, tableOfContents } = page;
       let children = [];
 
       if (menu && menu.search(filter) > -1) {
-
         if (menu === 'side') {
           // check we're querying only pages that contain base route
           let baseRouteIndex = pathname.substring(1, pathname.length).indexOf('/');
@@ -20,8 +17,10 @@ const getMenuFromGraph = async (root, { pathname, filter = '' }, context) => {
 
           if (route.includes(baseRoute)) {
             if (tableOfContents.length > 0) {
-              children = tableOfContents.map(({ content, slug }) => {
-                return { item: { label: content, link: '#' + slug }, children: [] };
+              tableOfContents.forEach(({ content, slug, lvl }) => {
+                if (lvl === 3) {
+                  children.push({ item: { label: content, link: '#' + slug }, children: [] });
+                }
               });
             }
             items.push({ item: { link: route, label: title }, children });
@@ -32,7 +31,7 @@ const getMenuFromGraph = async (root, { pathname, filter = '' }, context) => {
       }
     });
 
-  return { label: menu, link: 'na', children: items };
+  return { label: filter, link: 'na', children: items };
 };
 
 const getDeriveMetaFromRoute = (route) => {

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -3,6 +3,7 @@ const fs = require('fs-extra');
 const crypto = require('crypto');
 const fm = require('front-matter');
 const path = require('path');
+const toc = require('markdown-toc');
 
 const createGraphFromPages = async (pagesDir, config) => {
   let pages = [];
@@ -23,9 +24,9 @@ const createGraphFromPages = async (pagesDir, config) => {
               if (isMdFile && !stats.isDirectory()) {
                 const fileContents = await fs.readFile(filePath, 'utf8');
                 const { attributes } = fm(fileContents);
-                let { label, template, title } = attributes;
+                let { label, template, title, menu, index, linkheadings } = attributes;
                 let { meta } = config;
-                let mdFile = '';
+                let mdFile = '', tableOfContents = [];
 
                 // if template not set, use default
                 template = template || 'page';
@@ -65,6 +66,20 @@ const createGraphFromPages = async (pagesDir, config) => {
                 // set <title></title> element text, override with markdown title
                 title = title || config.title;
 
+                // set specific menu to place this page
+                menu = menu || '';
+
+                // set specific index list priority of this item within a menu
+                index = index || '';
+
+                // set flag whether to gather a list of headings on a page as menu items
+                linkheadings = linkheadings || false;
+
+                if (linkheadings) {
+                  // parse markdown for table of contents and output to json
+                  tableOfContents = toc(fileContents).json;
+                }
+
                 /*
                 * Variable Definitions
                 *----------------------
@@ -77,10 +92,14 @@ const createGraphFromPages = async (pagesDir, config) => {
                 * relativeExpectedPath: relative import path for generated component within a list.js file to later be
                 * imported into app.js root component
                 * title: the head <title></title> text
+                * menu: the name of the menu in which this item can be listed and queried
+                * index: the index of this list item within a menu
+                * tableOfContents: json object containing page's table of contents(list of headings)
                 * meta: og graph meta array of objects { property/name, content }
                 */
 
-                pages.push({ mdFile, label, route, template, filePath, fileName, relativeExpectedPath, title, meta });
+                pages.push({ mdFile, label, route, template, filePath, fileName, relativeExpectedPath,
+                  title, menu, index, tableOfContents, meta });
               }
               if (stats.isDirectory()) {
                 await walkDirectory(filePath);

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -78,6 +78,7 @@ const createGraphFromPages = async (pagesDir, config) => {
                 if (linkheadings) {
                   // parse markdown for table of contents and output to json
                   tableOfContents = toc(fileContents).json;
+                  tableOfContents.shift();
                 }
 
                 /*

--- a/www/components/header/header.js
+++ b/www/components/header/header.js
@@ -1,13 +1,13 @@
 import { LitElement, html } from 'lit-element';
 import client from '@greenwood/cli/data/client';
-import NavigationQuery from '@greenwood/cli/data/queries/navigation';
+import MenuQuery from '@greenwood/cli/data/queries/menu';
 import '@evergreen-wc/eve-container';
 import headerCss from './header.css';
 import brand from '../../assets/brand.png';
 import '../components/social-icons/social-icons';
 
 class HeaderComponent extends LitElement {
-  
+
   static get properties() {
     return {
       navigation: {
@@ -25,10 +25,14 @@ class HeaderComponent extends LitElement {
     super.connectedCallback();
 
     const response = await client.query({
-      query: NavigationQuery
+      query: MenuQuery,
+      variables: {
+        menu: 'navigation'
+      }
     });
 
-    this.navigation = response.data.navigation;
+    this.navigation = response.data.menu.children;
+    console.log(this.navigation);
   }
 
   /* eslint-disable indent */
@@ -42,7 +46,7 @@ class HeaderComponent extends LitElement {
       <header class="header">
         <eve-container fluid>
           <div class="head-wrap">
-            
+
             <div class="brand">
               <a href="https://projectevergreen.github.io" target="_blank" rel="noopener noreferrer"
                 @onclick="getOutboundLink('https://projectevergreen.github.io'); return false;" >
@@ -55,7 +59,7 @@ class HeaderComponent extends LitElement {
 
             <nav>
               <ul>
-                ${navigation.map((item) => {
+                ${navigation.map(({ item }) => {
                   return html`
                     <li><a href="${item.link}" title="Click to visit the ${item.label} page">${item.label}</a></li>
                   `;

--- a/www/components/shelf/shelf.js
+++ b/www/components/shelf/shelf.js
@@ -1,6 +1,6 @@
 import { LitElement, html } from 'lit-element';
 import client from '@greenwood/cli/data/client';
-import ChildrenQuery from '@greenwood/cli/data/queries/children';
+import MenuQuery from '@greenwood/cli/data/queries/menu';
 import css from './shelf.css';
 import chevronRt from '../icons/chevron-right/chevron-right';
 import chevronDwn from '../icons/chevron-down/chevron-down';
@@ -29,21 +29,17 @@ class Shelf extends LitElement {
   }
 
   async setupShelf(page) {
-    console.log('setupShelf for page =>', page);
-
     if (page && page !== '' && page !== '/') {
-      // TODO remove require call - #275
-      this.shelfList = require(`./${page}.json`);
-
-      // TODO not actually integrated, still using .json files - #271
       const response = await client.query({
-        query: ChildrenQuery,
+        query: MenuQuery,
         variables: {
-          parent: page
+          menu: 'side',
+          route: window.location.pathname
         }
       });
 
-      console.log('response from the shelf (data.children)', response.data.children);
+      console.log('shelf =>', response.data.menu.children);
+      this.shelfList = response.data.menu.children;
     }
   }
 

--- a/www/components/shelf/shelf.js
+++ b/www/components/shelf/shelf.js
@@ -22,14 +22,9 @@ class Shelf extends LitElement {
     this.page = '';
   }
 
-  connectedCallback() {
+  async connectedCallback() {
     super.connectedCallback();
-    this.collapseAll();
-    this.expandRoute(window.location.pathname);
-  }
-
-  async setupShelf(page) {
-    if (page && page !== '' && page !== '/') {
+    if (this.page !== '' && this.page !== '/') {
       const response = await client.query({
         query: MenuQuery,
         variables: {
@@ -40,7 +35,11 @@ class Shelf extends LitElement {
 
       console.log('shelf =>', response.data.menu.children);
       this.shelfList = response.data.menu.children;
+      this.requestUpdate();
     }
+
+    this.collapseAll();
+    // this.expandRoute(window.location.pathname);
   }
 
   goTo(path) {
@@ -106,12 +105,12 @@ class Shelf extends LitElement {
     const renderListItems = (list) => {
       let listItems = '';
 
-      if (list.items && list.items.length > 0) {
+      if (list && list.length > 0) {
         listItems = html`
           <ul>
-            ${list.items.map((item, index) => {
+            ${list.map(({ item }, index) => {
               return html`
-                <li id="index_${index}" class="${list.selected ? '' : 'hidden'}"><a @click=${()=> this.goTo(`#${item.id}`)}">${item.name}</a></li>
+                <li id="index_${index}" class="${item.selected ? '' : 'hidden'}"><a @click=${()=> this.goTo(`${item.link}`)}">${item.label}</a></li>
               `;
             })}
           </ul>
@@ -120,29 +119,27 @@ class Shelf extends LitElement {
 
       return listItems;
     };
-    /* eslint-enable */
 
-    return this.shelfList.map((list, index) => {
+    /* eslint-enable */
+    console.log(this.shelfList);
+
+    return this.shelfList.map(({ item, children, selected }, index) => {
       let id = `index_${index}`;
-      let chevron = list.items && list.items.length > 0
-        ? list.selected === true ? chevronDwn : chevronRt
+      let chevron = children && children.length > 0
+        ? selected === true ? chevronDwn : chevronRt
         : '';
 
       return html`
         <li class="list-wrap">
-          <a href="${list.path}" @click="${this.handleClick}"><h2 id="${id}">${list.name} <span>${chevron}</span></h2></a>
+          <a href="${item.link}" @click="${this.handleClick}"><h2 id="${id}">${item.label} <span>${chevron}</span></h2></a>
           <hr>
-          ${renderListItems(list)}
+          ${renderListItems(children)}
         </li>
       `;
     });
   }
 
   render() {
-    const { page } = this;
-
-    this.setupShelf(page);
-
     return html`
       <style>
         ${css}

--- a/www/pages/about/community.md
+++ b/www/pages/about/community.md
@@ -1,3 +1,10 @@
+---
+label: 'community'
+menu: side
+title: 'Community'
+index: 3
+---
+
 ## Community
 
 Greenwood understands the role of community in open source, technology, and learning and we want to embrace that in this project as well.  There are many great tools and projects available in the web ecosystem and we want to highlight those projects here, that have been important in the development of Greenwood (in no particular order).
@@ -6,6 +13,7 @@ Greenwood understands the role of community in open source, technology, and lear
 - [**puppeteer**](https://github.com/GoogleChrome/puppeteer) - Headless Chrome browser used for serializtion.
 - [**WC Markdown Loader**](https://github.com/hutchgrant/wc-markdown-loader/) - A webpack plugin that transforms a markdown file into a Web Component! 🤯
 - [**LitReduxRouter**](https://github.com/fernandopasik/lit-redux-router) - Declarative client side routing library.
+- [**LitApollo**](https://www.npmjs.com/package/@apollo-elements/lit-apollo) - Base component class for connecting to Greenwood's build time GraphQL server.
 
 And of course we can't forget our [Contributors](https://github.com/ProjectEvergreen/greenwood/graphs/contributors)!
 

--- a/www/pages/about/features.md
+++ b/www/pages/about/features.md
@@ -1,19 +1,26 @@
+---
+label: 'features'
+menu: side
+title: 'Features'
+index: 2
+---
+
 ## Features
 
 #### Onboarding
 We built Greenwood in the hopes that getting started would be easy.  By default Greenwood will build an app for you.  Just simply start adding pages and customizing templates as needed and you're good to go!  You pick your workspace, Greenwood makes as few assumptions as needed to deliver an optimal development experience with minimum configuration needed.
 
-We strive to provide good documentation, intuitive developer experiences, and stable workflows.  Even if you don't know anything about webpack or Web Components, if you can learn a little markdown, you can get started making a modern website right away!  
+We strive to provide good documentation, intuitive developer experiences, and stable workflows.  Even if you don't know anything about webpack or Web Components, if you can learn a little markdown, you can get started making a modern website right away!
 
 
 #### Modern Apps, Modern Toolchains
-At the heart of Greenwood is an "evergreen" build, that aims to deliver the most optimized user experience through a combination of tools like webpack, babel, and PostCSS.  
+At the heart of Greenwood is an "evergreen" build, that aims to deliver the most optimized user experience through a combination of tools like webpack, babel, and PostCSS.
 
 Develop like it's a Single Page Application, deploy like it's a static site.  (because it is!)
 
 
 #### Performance
-We believe delivering a great user experience is above all else the most crucial element to a successful web product and part of that means performance out of the box.  Greenwood wants to help your site be one of the fastest out there and so we'll take care of all those optimizations for you, ensuring your site gets a great score in tools like [Lighthouse](https://developers.google.com/web/tools/lighthouse/), one of our primary performance benchmarking tools.  
+We believe delivering a great user experience is above all else the most crucial element to a successful web product and part of that means performance out of the box.  Greenwood wants to help your site be one of the fastest out there and so we'll take care of all those optimizations for you, ensuring your site gets a great score in tools like [Lighthouse](https://developers.google.com/web/tools/lighthouse/), one of our primary performance benchmarking tools.
 
 
 Haven't given Greenwood a try yet?  Check out our [Getting Started](/getting-started) guide and start building your next modern web experience!  💯

--- a/www/pages/about/goals.md
+++ b/www/pages/about/goals.md
@@ -1,3 +1,10 @@
+---
+label: 'goals'
+menu: side
+title: 'Goals'
+index: 0
+---
+
 ## Goals
 
 #### It's Not About Us

--- a/www/pages/about/how-it-works.md
+++ b/www/pages/about/how-it-works.md
@@ -1,5 +1,13 @@
+---
+label: 'how-it-works'
+menu: side
+title: 'How It Works'
+index: 1
+linkheadings: true
+---
+
 ## How It Works
-Following similar motivations and inspirations as other [Project Evergreen](https://github.com/ProjectEvergreen/) projects like [Create Evergreen App](https://github.com/ProjectEvergreen/create-evergreen-app), Greenwood aims to provide a build and development workflow designed for the modern web and leveraging great open source projects in the NodeJS ecosystem.  
+Following similar motivations and inspirations as other [Project Evergreen](https://github.com/ProjectEvergreen/) projects like [Create Evergreen App](https://github.com/ProjectEvergreen/create-evergreen-app), Greenwood aims to provide a build and development workflow designed for the modern web and leveraging great open source projects in the NodeJS ecosystem.
 
 Read on to learn more about how we put them all together for you!
 

--- a/www/pages/about/index.md
+++ b/www/pages/about/index.md
@@ -1,5 +1,7 @@
 ---
 label: 'about'
+menu: navigation
+title: About
 ---
 
 ## About Greenwood

--- a/www/pages/docs/component-model.md
+++ b/www/pages/docs/component-model.md
@@ -1,3 +1,10 @@
+---
+label: 'component-model'
+menu: side
+title: 'Component Model'
+index: 1
+---
+
 ## Component Model
 In this section we'll review a little bit about how you can use Web Components in Greenwood.  Both the native `HTMLElement` and `LitElement` are available by default.
 

--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -1,3 +1,11 @@
+---
+label: 'configuration'
+menu: side
+title: 'Configuration'
+index: 2
+linkheadings: true
+---
+
 ## Configuration
 These are all the supported configuration options in Greenwood, which you can define in a _greenwood.config.js_ file in your project's root directory.
 

--- a/www/pages/docs/css-and-images.md
+++ b/www/pages/docs/css-and-images.md
@@ -1,3 +1,11 @@
+---
+label: 'styles-assets'
+menu: side
+title: 'Styles and Assets'
+index: 5
+linkheadings: true
+---
+
 ## Styles and Assets
 Greenwood provides a couple ways to help style and theme your site.
 

--- a/www/pages/docs/data.md
+++ b/www/pages/docs/data.md
@@ -1,3 +1,12 @@
+---
+label: 'data-sources'
+menu: side
+title: 'Data Sources'
+index: 7
+linkheadings: true
+---
+
+
 ## Data Sources
 Having to repeat things when programming is no fun, and that's why (web) component based development is so useful!  As websites start to grow, there comes a point where being able to have access to the content and structure of your site's layout and configuration as part of the development process becomes essential towards maintainability, performance, and scalability.
 
@@ -41,15 +50,15 @@ This is what the schema looks like:
 graph {
   id, // (string) the unique ID given to the generated component as it's selector e.g. \`<wc-md-id></wc-md-id>\`
 
-  link,  // (string) A URL link, typically derived from the filesystem path, e.g. /blog/2019/first-post/ 
-  
+  link,  // (string) A URL link, typically derived from the filesystem path, e.g. /blog/2019/first-post/
+
   title,  // (string) Useful for a page's <title> tag or the title attribute for an <a> tag, inferred from the filesystem path, e.g. "First Post"
-  
+
   filePath, // (string) path to file
 
   fileName, // (string) file name without extension/path, so that it can be copied to scratch dir with same name
 
-  template // (string) page template used for the page 
+  template // (string) page template used for the page
 }
 ```
 
@@ -267,7 +276,7 @@ import client from '@greenwood/cli/data/client';
 import NavigationQuery from '@greenwood/cli/data/queries/navigation';
 
 class HeaderComponent extends LitElement {
-  
+
   static get properties() {
     return {
       navigation: {
@@ -308,7 +317,7 @@ class HeaderComponent extends LitElement {
             })}
           </ul>
         </nav>
-        
+
       </header>
     \`;
   }

--- a/www/pages/docs/front-matter.md
+++ b/www/pages/docs/front-matter.md
@@ -1,3 +1,11 @@
+---
+label: 'front-matter'
+menu: side
+title: 'Front Matter'
+index: 3
+linkheadings: true
+---
+
 ## Front Matter
 
 "Front matter" is a [YAML](https://yaml.org/) block at the top of any markdown file.  It gives you the ability to define variables that are made available to Greenwood's build process. You can also use it to `import` additional files.

--- a/www/pages/docs/index.md
+++ b/www/pages/docs/index.md
@@ -1,3 +1,9 @@
+---
+label: 'docs'
+menu: navigation
+title: Docs
+---
+
 ## Documentation
 This is the documentation space for Greenwood that we hope will help you get the most out of using it.  If this is your first time with Greenwood, we recommend checking out our [Getting Started](/getting-started/) guide to get more familiar with setting up your first Greenwood project.
 

--- a/www/pages/docs/layouts.md
+++ b/www/pages/docs/layouts.md
@@ -1,3 +1,11 @@
+---
+label: 'templates'
+menu: side
+title: 'Templates and Pages'
+index: 6
+linkheadings: true
+---
+
 ## Templates
 Greenwood has two types of templates:
 - App Template: The [app shell](https://developers.google.com/web/fundamentals/architecture/app-shell) if you will, that wraps all pages.  This is provided for you by Greenwood, but you can override if needed. (though not recommended)

--- a/www/pages/docs/markdown.md
+++ b/www/pages/docs/markdown.md
@@ -1,3 +1,11 @@
+---
+label: 'markdown'
+menu: side
+title: 'Markdown'
+index: 4
+linkheadings: true
+---
+
 ## Markdown
 In this section we'll cover some of the Markdown related feature of Greenwood, which by default supports the [CommonMark](https://commonmark.org/help/) specification.
 

--- a/www/pages/docs/tech-stack.md
+++ b/www/pages/docs/tech-stack.md
@@ -1,3 +1,11 @@
+---
+label: 'stack'
+menu: side
+title: 'Tech Stack'
+index: 8
+linkheadings: true
+---
+
 ## Tech Stack
 
 Greenwood uses a variety of open source JavaScript tools to help faciliate development and production building of Greenwood projects.  By putting all these tools together and configuring them for you, Greenwood helps you focus more on what matters; building your project.  Greenwood takes are of performance and optimizations for you and provides a static build of your project that you can host on any web server or cloud host, be it Netlify, S3 / CloudFront, Express, Apache, etc.  It's entirely up to you and what fits your workflow the best.

--- a/www/pages/getting-started/branding.md
+++ b/www/pages/getting-started/branding.md
@@ -1,13 +1,21 @@
+---
+label: 'css-components'
+menu: side
+title: 'Styles and Web Components'
+index: 5
+linkheadings: true
+---
+
 ## CSS and Web Components
 
-So now that we've made some [content](/getting-started/creating-content/) for your site, I think we can agree it's not quite all "there" yet and could benefit from a little styling and branding.  
+So now that we've made some [content](/getting-started/creating-content/) for your site, I think we can agree it's not quite all "there" yet and could benefit from a little styling and branding.
 
 In this section, we will add the following to your project:
 1. Header / Footer - The elements provide a great case for creating some reusable components and with Custom Elements, we can create self contained reusable components for our site.
 1. Styles - Of course we want things to look nice too!  We'll add some CSS to help hang things in just right the place.
 
 ### Web Components
-Web Components are supported out of the box with Greenwood using `HTMLElement` or **LitElement**.  For this guide, we'll use a "vanilla" custom element for our header, in _src/components/header.js_.  
+Web Components are supported out of the box with Greenwood using `HTMLElement` or **LitElement**.  For this guide, we'll use a "vanilla" custom element for our header, in _src/components/header.js_.
 ```render javascript
 class HeaderComponent extends HTMLElement {
   constructor() {

--- a/www/pages/getting-started/build-and-deploy.md
+++ b/www/pages/getting-started/build-and-deploy.md
@@ -1,3 +1,10 @@
+---
+label: 'deploy'
+menu: side
+title: 'Build and Deploy'
+index: 6
+---
+
 ## Build and Deploy
 
 Congrats!  After all your good work making your first site with Greenwood, it's now time to take it live!
@@ -19,7 +26,7 @@ And from the command line, run `npm run build`.  That's it!
 If you look in your project directory, you will now have a _public/_ directory that will contain all the static assets (HTML / CSS / JS / fonts / images) you will need to deploy your site.  At this point, you can now put these assets on any web server like Apache, S3, Express, or Netlify (which is what this website uses).
 
 ### Deploying and Hosting
-There are many ways to host and deploy a web site, but essentially any static hosting or web server will work for Greenwood, which keeps things simple and easy to setup.  No servers needed if you don't need them!  
+There are many ways to host and deploy a web site, but essentially any static hosting or web server will work for Greenwood, which keeps things simple and easy to setup.  No servers needed if you don't need them!
 
 For the Greenwood website, our code is in [GitHub](https://github.com/ProjectEvergreen/greenwood) and we use [Netlify](https://www.netlify.com) to deploy from our GitHub repo.  With Netlify, Greenwood configuration is straightforward.  Here is what our Netlify configuration looks like.
 

--- a/www/pages/getting-started/creating-content.md
+++ b/www/pages/getting-started/creating-content.md
@@ -1,8 +1,16 @@
+---
+label: 'create-content'
+menu: side
+title: 'Creating Content'
+index: 4
+linkheadings: true
+---
+
 ## Overview
 After setting up our [project workspace](/getting-started/project-setup/) and reviewing some of Greenwood's [key concepts](/getting-started/key-concepts/), it's now time to get to the good stuff: writing some content and building your first site!
 
 ### Objectives
-In this section, we'll walk through developing a site with Greenwood, and making some content.  We'll provide all the code, so you can just follow along.  By the end, you'll have a simple blog starter that you can build and deploy to any web server you like, be it Netlify, Apache, Express, or S3.  What you do from there, is all up to you!  
+In this section, we'll walk through developing a site with Greenwood, and making some content.  We'll provide all the code, so you can just follow along.  By the end, you'll have a simple blog starter that you can build and deploy to any web server you like, be it Netlify, Apache, Express, or S3.  What you do from there, is all up to you!
 
 What we'll cover in this section:
 1. Home Page Template: Single column layout for our home page
@@ -35,7 +43,7 @@ To go along with this guide, check out our [companion repo](https://github.com/P
 Out of the box, Greenwood provides some default content, so even if we use our npm build script, `npm build` right now, we will get a working site in the public directory.  (go ahead and try it out!)
 
 
-Neat!  But naturally you're here to learn how to make your own site, and this is our goal!  The first step towards making your site is to create a home page.  For this site, the home page will be a "full width" page.  
+Neat!  But naturally you're here to learn how to make your own site, and this is our goal!  The first step towards making your site is to create a home page.  For this site, the home page will be a "full width" page.
 
 For this template, create a _page-template.js_ in a directory located at _src/templates/_ (make the _templates/_ directory if it doesn't exist) and include this code in it:
 ```render javascript
@@ -104,7 +112,7 @@ This is the Getting Started home page!
 ```
 
 
-For your blog posts, we can give them their own unique URLs by simply putting them in their own directory and by default Greenwood will "slugify" based on that file path.  
+For your blog posts, we can give them their own unique URLs by simply putting them in their own directory and by default Greenwood will "slugify" based on that file path.
 
 You'll want to create a folder called _blog/_ in _src/pages/_ (make that _pages/_ directory if it doesn't exist) and then create two markdown files called _first-post.md_ and _second-post.md_.
 

--- a/www/pages/getting-started/index.md
+++ b/www/pages/getting-started/index.md
@@ -1,5 +1,7 @@
 ---
 label: 'getting-started'
+menu: navigation
+title: 'Getting Started'
 ---
 
 ## Introduction
@@ -51,7 +53,7 @@ $ npm run develop
 ```
 
 #### Experience
-No advanced JavaScript / CSS experience is needed for using Greenwood.  Just knowing some [markdown](https://daringfireball.net/projects/markdown/) and following some basic steps from the command line will be enough to get you up and running quickly.  
+No advanced JavaScript / CSS experience is needed for using Greenwood.  Just knowing some [markdown](https://daringfireball.net/projects/markdown/) and following some basic steps from the command line will be enough to get you up and running quickly.
 
 We like to think that that as your experience grows, so can the way you build your site.  Greenwood has very few opinions on how you structure your site or what you're trying to build or how and so our hope is to provide you a developer experience that is conducive to modern web development.
 

--- a/www/pages/getting-started/key-concepts.md
+++ b/www/pages/getting-started/key-concepts.md
@@ -1,7 +1,15 @@
+---
+label: 'concepts'
+menu: side
+title: 'Key Concepts'
+index: 2
+linkheadings: true
+---
+
 ## Overview
 In the [previous section](/getting-started/project-setup) we setup our local development environment and installed Greenwood.  We also made a "workspace" for our project files in a directory called _src/_.
 
-Although Greenwood works without any configuration or setup, (go ahead, run `npm run build`, you'll get a default site right out of the box!), you will of course want to create your own site with your own content.  
+Although Greenwood works without any configuration or setup, (go ahead, run `npm run build`, you'll get a default site right out of the box!), you will of course want to create your own site with your own content.
 
 For this reason, the minimum requirements for a site that you will want to be familiar with are:
 1. Workspace

--- a/www/pages/getting-started/next-steps.md
+++ b/www/pages/getting-started/next-steps.md
@@ -1,3 +1,10 @@
+---
+label: 'next'
+menu: side
+title: 'Next Steps'
+index: 7
+---
+
 ## Next Steps
 
 ## About Greenwood
@@ -17,7 +24,7 @@ module.exports = {
 That's it!  You can learn more about configuring Greenwood [here](/docs/configuration).
 
 ## Companion Repo
-You may have noticed that the Getting Started [companion repo](https://github.com/ProjectEvergreen/greenwood-getting-started/) itself is a bit more of a full fledged example then captured in this guide, like with the use use of ["Single File Components"](https://vuejs.org/v2/guide/single-file-components.html) (SFCs).  
+You may have noticed that the Getting Started [companion repo](https://github.com/ProjectEvergreen/greenwood-getting-started/) itself is a bit more of a full fledged example then captured in this guide, like with the use use of ["Single File Components"](https://vuejs.org/v2/guide/single-file-components.html) (SFCs).
 
 This is was intentional for a couple of reasons:
 - _Education_: There is always more than one way to solve a problem, and so we felt that the SFC approach was best for the guide so as to keep the number of steps needed as few and direct as possible.

--- a/www/pages/getting-started/project-setup.md
+++ b/www/pages/getting-started/project-setup.md
@@ -1,5 +1,13 @@
+---
+label: 'project-setup'
+menu: side
+title: 'Project Setup'
+index: 2
+linkheadings: true
+---
+
 ## Overview
-In the [previous section](/getting-started/), we shared a little bit about what Greenwood is and the high level goals of this guide.  Now we are ready to help you start your first project!  
+In the [previous section](/getting-started/), we shared a little bit about what Greenwood is and the high level goals of this guide.  Now we are ready to help you start your first project!
 
 In this section, we will kick off our Greenwood project by:
 1. Initializing our project for development with **npm**

--- a/www/pages/getting-started/quick-start.md
+++ b/www/pages/getting-started/quick-start.md
@@ -1,3 +1,10 @@
+---
+label: 'start'
+menu: side
+title: 'Quick Start'
+index: 1
+---
+
 ## Quick Start
 If you want to code and go then we welcome you to check out the ["companion" repository](https://github.com/ProjectEvergreen/greenwood-getting-started) we made to accompany this guide.
 

--- a/www/pages/plugins/composite-plugins.md
+++ b/www/pages/plugins/composite-plugins.md
@@ -1,5 +1,12 @@
+---
+label: 'composite-plugins'
+menu: side
+title: 'Composite Plugins'
+index: 1
+---
+
 ## Composite Plugins
-Greenwood provides some custom "composite" plugins that are tasked with providing specific functionality to your project, built using the [available plugin types](/plugins/) already provided by Greenwood.  
+Greenwood provides some custom "composite" plugins that are tasked with providing specific functionality to your project, built using the [available plugin types](/plugins/) already provided by Greenwood.
 
 The available plugins built and maintained by Greenwood team and contibutors have been provided in the table below, with links to their README with the appropriate installation and usage steps.
 

--- a/www/pages/plugins/index-hooks.md
+++ b/www/pages/plugins/index-hooks.md
@@ -1,3 +1,10 @@
+---
+label: 'index-hooks'
+menu: side
+title: 'Index Hooks'
+index: 2
+---
+
 ## Index Hooks
 
 It is common when working with certain libraries (3rd party or otherwise) that scripts _must_ be loaded globally and / or unbundled.  Greenwood provides some prefined places in its _index.html_ that can be used to inject custom HTML which can be used to inject scripts for things like polyfills and analytics.
@@ -14,7 +21,7 @@ Below is an example of creating an index hook for loading Google Analytics from 
 module.exports = {
 
   ...
-  
+
   plugins: [{
     type: 'index',
     provider: (compilation) => {
@@ -36,7 +43,7 @@ module.exports = {
 ```
 
 ### Custom Index File
-It should be noted that if these specific hook types are too limiting Greenwood supports providing your own _index.html_ in the root of your workspace directory.  This can either be used to define your own hooks or just hardcode everything you need instead of using plugins.  
+It should be noted that if these specific hook types are too limiting Greenwood supports providing your own _index.html_ in the root of your workspace directory.  This can either be used to define your own hooks or just hardcode everything you need instead of using plugins.
 
 The minimum recommended markup for a custom _index.html_ would be this following:
 ```render html
@@ -55,11 +62,11 @@ The minimum recommended markup for a custom _index.html_ would be this following
   </head>
 
   <body>
-  
+
     <eve-app></eve-app>
 
   </body>
-  
+
 </html>
 ```
 
@@ -68,7 +75,7 @@ To add your own hook, define it in a _greenwood.config.js_
 module.exports = {
 
   ...
-  
+
   plugins: [{
     type: 'index',
     provider: (compilation) => {
@@ -93,7 +100,7 @@ And updated _index.html_
   ...
 
   <body>
-  
+
     <eve-app></eve-app>
 
     <%= htmlWebpackPlugin.options.myCustomHook %>

--- a/www/pages/plugins/index.md
+++ b/www/pages/plugins/index.md
@@ -1,6 +1,12 @@
+---
+label: 'plugins'
+menu: navigation
+title: Plugins
+---
+
 ## Plugins
 
-At its core, Greenwood provides a CLI to drive all the development related workflows for a Greenwood project.  The CLI aims to provide a simple interface for quickly and simply building sites from as little as markdown files.  
+At its core, Greenwood provides a CLI to drive all the development related workflows for a Greenwood project.  The CLI aims to provide a simple interface for quickly and simply building sites from as little as markdown files.
 
 However, for more complex sites and use cases, there will come a need to extend the default functionality of Greenwood for additional capabilities like:
 - Site Analytics (Google, Snowplow)
@@ -14,16 +20,16 @@ Greenwood aims to cater to these use cases through two approaches:
 
 
 ### API
-Each plugin type requires two properties.  
+Each plugin type requires two properties.
 - `type`: A string to specify to Greenwood the type of plugin.  Can be one of the following values: `'index'`, `'webpack'`
-- `provider`: A function that will be invoked by Greenwood during the build, determined by the `type`.  Can accept  a `compilation` param that provides read-only access to parts of Greenwood's state and configuration that can be used by a plugin. 
+- `provider`: A function that will be invoked by Greenwood during the build, determined by the `type`.  Can accept  a `compilation` param that provides read-only access to parts of Greenwood's state and configuration that can be used by a plugin.
 
 Here is an example of creating a plugin in a _greenwood.config.js_.
 ```render javascript
 module.exports = {
 
   ...
-  
+
   plugins: [{
     type: 'webpack',
     provider: (compilation) => {
@@ -43,7 +49,7 @@ This is Greenwood's default configuration options merged with any user provided 
 module.exports = {
 
   title: 'My Blog',
-  
+
   plugins: [{
     type: 'index|webpack',
     provider: (compilation) => {
@@ -71,7 +77,7 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = {
-  
+
   plugins: [{
     type: 'index|webpack',
     provider: (compilation) => {

--- a/www/pages/plugins/webpack.md
+++ b/www/pages/plugins/webpack.md
@@ -1,3 +1,10 @@
+---
+label: 'webpack'
+menu: side
+title: 'Webpack Plugins'
+index: 3
+---
+
 ## Webpack Plugins
 
 > This is an experimental API! [YMMV](http://onlineslangdictionary.com/meaning-definition-of/your-mileage-may-vary)
@@ -15,7 +22,7 @@ const { version } = require('package.json');
 module.exports = {
 
   ...
-  
+
   plugins: [{
     type: 'webpack',
     provider: () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,6 +2157,13 @@ ansi-html@0.0.7:
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
   integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
 
+ansi-red@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-red/-/ansi-red-0.1.1.tgz#8c638f9d1080800a353c9c28c8a81ca4705d946c"
+  integrity sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=
+  dependencies:
+    ansi-wrap "0.1.0"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -2183,6 +2190,11 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-wrap@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-wrap/-/ansi-wrap-0.1.0.tgz#a82250ddb0015e9a27ca82e82ea603bbfa45efaf"
+  integrity sha1-qCJQ3bABXponyoLoLqYDu/pF768=
 
 any-promise@^1.0.0, any-promise@^1.1.0:
   version "1.3.0"
@@ -3462,6 +3474,11 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
+coffee-script@^1.12.4:
+  version "1.12.7"
+  resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
+  integrity sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==
+
 collection-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
@@ -3643,7 +3660,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@1.6.2, concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.0:
+concat-stream@1.6.2, concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.0, concat-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -4523,6 +4540,11 @@ dezalgo@^1.0.0:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
+
+diacritics-map@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/diacritics-map/-/diacritics-map-0.1.0.tgz#6dfc0ff9d01000a2edf2865371cac316e94977af"
+  integrity sha1-bfwP+dAQAKLt8oZTccrDFulJd68=
 
 dicer@0.3.0:
   version "0.3.0"
@@ -5933,6 +5955,17 @@ graphql@^14.5.3, graphql@^14.5.8:
   dependencies:
     iterall "^1.2.2"
 
+gray-matter@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-2.1.1.tgz#3042d9adec2a1ded6a7707a9ed2380f8a17a430e"
+  integrity sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=
+  dependencies:
+    ansi-red "^0.1.1"
+    coffee-script "^1.12.4"
+    extend-shallow "^2.0.1"
+    js-yaml "^3.8.1"
+    toml "^2.3.2"
+
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
@@ -7008,7 +7041,7 @@ js-levenshtein@^1.1.3:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@3.13.1, js-yaml@^3.13.0, js-yaml@^3.13.1:
+js-yaml@3.13.1, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.8.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -7348,6 +7381,13 @@ lazy-cache@^1.0.3:
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
   integrity sha1-odePw6UEdMuAhF07O24dpJpEbo4=
 
+lazy-cache@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264"
+  integrity sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=
+  dependencies:
+    set-getter "^0.1.0"
+
 lcid@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-2.0.0.tgz#6ef5d2df60e52f82eb228a4c373e8d1f397253cf"
@@ -7393,6 +7433,16 @@ levn@~0.2.5:
   dependencies:
     prelude-ls "~1.1.0"
     type-check "~0.3.1"
+
+list-item@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/list-item/-/list-item-1.1.1.tgz#0c65d00e287cb663ccb3cb3849a77e89ec268a56"
+  integrity sha1-DGXQDih8tmPMs8s4Sad+iewmilY=
+  dependencies:
+    expand-range "^1.8.1"
+    extend-shallow "^2.0.1"
+    is-number "^2.1.0"
+    repeat-string "^1.5.2"
 
 lit-element@^2.0.1:
   version "2.2.1"
@@ -7896,6 +7946,29 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-link@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/markdown-link/-/markdown-link-0.1.1.tgz#32c5c65199a6457316322d1e4229d13407c8c7cf"
+  integrity sha1-MsXGUZmmRXMWMi0eQinRNAfIx88=
+
+markdown-toc@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/markdown-toc/-/markdown-toc-1.2.0.tgz#44a15606844490314afc0444483f9e7b1122c339"
+  integrity sha512-eOsq7EGd3asV0oBfmyqngeEIhrbkc7XVP63OwcJBIhH2EpG2PzFcbZdhy1jutXSlRBBVMNXHvMtSr5LAxSUvUg==
+  dependencies:
+    concat-stream "^1.5.2"
+    diacritics-map "^0.1.0"
+    gray-matter "^2.1.0"
+    lazy-cache "^2.0.2"
+    list-item "^1.1.1"
+    markdown-link "^0.1.1"
+    minimist "^1.2.0"
+    mixin-deep "^1.1.3"
+    object.pick "^1.2.0"
+    remarkable "^1.7.1"
+    repeat-string "^1.6.1"
+    strip-color "^0.1.0"
+
 math-random@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"
@@ -8165,7 +8238,7 @@ mississippi@^3.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
-mixin-deep@^1.2.0:
+mixin-deep@^1.1.3, mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
   integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
@@ -8793,7 +8866,7 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
-object.pick@^1.3.0:
+object.pick@^1.2.0, object.pick@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
   integrity sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
@@ -10947,6 +11020,13 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
+set-getter@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.0.tgz#d769c182c9d5a51f409145f2fba82e5e86e80376"
+  integrity sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=
+  dependencies:
+    to-object-path "^0.3.0"
+
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
@@ -11475,6 +11555,11 @@ strip-bom@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
+strip-color@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/strip-color/-/strip-color-0.1.0.tgz#106f65d3d3e6a2d9401cac0eb0ce8b8a702b4f7b"
+  integrity sha1-EG9l09PmotlAHKwOsM6LinArT3s=
+
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
@@ -11835,6 +11920,11 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+toml@^2.3.2:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-2.3.6.tgz#25b0866483a9722474895559088b436fd11f861b"
+  integrity sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==
 
 toposort@^1.0.0:
   version "1.0.7"


### PR DESCRIPTION
## Related Issue
Resolves #275

## Summary of Changes

1. Begins to address (#271) which requires deterministic queries through a single menu based query
2. Removes need for shelfList to use json file
3. Uses [markdown-toc](https://github.com/jonschlinkert/markdown-toc) to generate a table of contents from every page flagged with front-matter variable `linkheadings: true`
4. Added markdown front-matter globals for `menu, index, linkheadings` which are added to our graph via the graph lifecycle
5. if `linkheadings` is flagged true, during graph lifecycle(as markdown file is already being read) we will parse the file for all headings, add it to our graph for that specific page, into an array we will use for our shelf later.
6. the `menu` front-matter is used to specifically define a menu to use with any given markdown file e.g. `navigation` or `side`
7. I've modified our graphql  type defs to add `link` and `menu` 
8. I've added filtering to the query to only display listing for specific menus. e.g. `side` or `navigation`
9. I've modified our resolver to instead look through graph for any pages with the corresponding menu name
10. as per 9, I've also made the resolver check if a file has been flagged `listheadings` if so, it will loop through the `tableOfContents` variable for that page, and create a list of children for that specific link.


## TODO
1. shelf is not rendering the results correctly at the moment, this is important and is the next step, but the data however is being received correctly for all menus
2. fix broken collapse/render that was dependent on previous json file

## Note
At the moment this WIP. Data is received correctly, for all menus, only need to render it.