### PR TITLE
ignore nested node_modules from linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+**/node_modules/**


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
Coming out of #286 , it looks like nested _node_modules_ need to be ignored explicitly for ESLint.  Now for that PR, it only shows these (legit) errors
```bash
$ yarn lint
yarn run v1.12.3
$ eslint "./packages/**/**/*.js" "./test/*.js" "./www/**/**/*.js"

/Users/owenbuckley/Desktop/greenwood/packages/cli/src/config/webpack.config.common.js
  132:22  error  Unexpected trailing comma  comma-dangle
  164:4   error  Missing semicolon          semi
  165:2   error  Missing semicolon          semi

/Users/owenbuckley/Desktop/greenwood/www/templates/page-template.js
  29:20  error  Parsing error: Unexpected token import

✖ 4 problems (4 errors, 0 warnings)
  3 errors and 0 warnings potentially fixable with the `--fix` option.

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```