### PR TITLE
remove node_modules exclude from graphql loader

### DIFF
--- a/packages/cli/src/config/webpack.config.common.js
+++ b/packages/cli/src/config/webpack.config.common.js
@@ -135,7 +135,6 @@ module.exports = ({ config, context }) => {
         loader: 'file-loader'
       }, {
         test: /\.(graphql|gql)$/,
-        exclude: /node_modules/,
         loader: 'graphql-tag/loader'
       }]
     },


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #311 

## Summary of Changes
1. Removed `exclude` rule from **graphql-loader** configuration