### PR TITLE
bug/issue 350 Fix website shelf collapse/expand event

### DIFF
--- a/www/components/shelf/shelf.css
+++ b/www/components/shelf/shelf.css
@@ -16,6 +16,7 @@
   }
 
   & h2 {
+    pointer-events: none;
     display: block;
     font-size: 1.5em;
     margin-block-start: 0.83em;
@@ -65,11 +66,14 @@
     }
   }
 
-  & span > svg {
-    margin-top:5px;
-    float:right;
-    margin-left: auto;
-    height:20px;
+  & span {
+    pointer-events: none;
+    > svg {
+      margin-top:5px;
+      float:right;
+      margin-left: auto;
+      height:20px;
+    }
   }
 
   & .hidden {

--- a/www/components/shelf/shelf.css
+++ b/www/components/shelf/shelf.css
@@ -15,14 +15,24 @@
     }
   }
 
-  & .list-wrap a {
+  & .list-wrap > a {
     display: grid;
     grid-template-columns: auto 20px;
     align-items: center;
+    font-size: 1.5em;
+    margin-block-start: 0.83em;
+    margin-block-end: 0.83em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+    font-weight: bold;
+    @media (max-width: 768px) {
+      padding-left:10px;
+      padding-right:10px;
+    }
+    
   }
 
   & h2 {
-    pointer-events: none;
     display: block;
     font-size: 1.5em;
     margin-block-start: 0.83em;
@@ -75,7 +85,7 @@
   & span {
     pointer-events: none;
     > svg {
-      margin-top:5px;
+      margin-top:10px;
       margin-left: auto;
       height:20px;
     }

--- a/www/components/shelf/shelf.css
+++ b/www/components/shelf/shelf.css
@@ -15,6 +15,12 @@
     }
   }
 
+  & .list-wrap a {
+    display: grid;
+    grid-template-columns: auto 20px;
+    align-items: center;
+  }
+
   & h2 {
     pointer-events: none;
     display: block;
@@ -70,7 +76,6 @@
     pointer-events: none;
     > svg {
       margin-top:5px;
-      float:right;
       margin-left: auto;
       height:20px;
     }

--- a/www/components/shelf/shelf.js
+++ b/www/components/shelf/shelf.js
@@ -128,7 +128,7 @@ class Shelf extends LitElement {
 
       return html`
         <li class="list-wrap">
-        <a id="${id}" href="${item.link}" @click="${this.handleClick}"><h2>${item.label}</h2><span>${chevron}</span></a>
+          <a id="${id}" href="${item.link}" @click="${this.handleClick}"><span>${item.label}</span><span>${chevron}</span></a>
           <hr>
           ${renderListItems(children, selected)}
         </li>

--- a/www/components/shelf/shelf.js
+++ b/www/components/shelf/shelf.js
@@ -128,7 +128,7 @@ class Shelf extends LitElement {
 
       return html`
         <li class="list-wrap">
-          <a href="${item.link}" @click="${this.handleClick}"><h2 id="${id}">${item.label} <span>${chevron}</span></h2></a>
+        <a id="${id}" href="${item.link}" @click="${this.handleClick}"><h2>${item.label}</h2><span>${chevron}</span></a>
           <hr>
           ${renderListItems(children, selected)}
         </li>


### PR DESCRIPTION
## Related Issue
Resolves #350  / #352 

## Summary of Changes

Adds `pointer-events:none` for elements within the anchor element.