### PR TITLE
style headers and link icon to be consistent throughout pages and sizes

### DIFF
--- a/www/styles/page.css
+++ b/www/styles/page.css
@@ -6,11 +6,12 @@
   & h3 {
     color: #2D3D3A;
     padding-top: 4rem;
+    font-size: 1.8rem !important;
   }
 
   & h2 {
     color: #2D3D3A;
-    font-size: 2.2rem;
+    font-size: 2rem;
   }
 
   & h4, h5, h6 {

--- a/www/styles/page.css
+++ b/www/styles/page.css
@@ -8,7 +8,18 @@
     padding-top: 4rem;
   }
 
+  & h2 {
+    color: #2D3D3A;
+    font-size: 2.2rem;
+  }
+
+  & h4, h5, h6 {
+    font-size: 1.2rem;
+  }
+
   & h1, h2, h3, h4, h5 {
+    line-height: 1rem;
+
     & a > span.icon {
       width:28px;
       height:24px;
@@ -17,7 +28,6 @@
       background-image: url(/assets/link.png);
       background-size: 20px 20px;
       background-repeat: no-repeat;
-      margin-top: 10px;
 
       &:hover {
         filter: invert(.4);


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
was discussed during 7/7/2020, not sure if there is an issue yet.
<!-- Include a link to the issue (e.g. Resolves #12) -->

## Summary of Changes
updated the styling of h2 through h5 elements to align with link icon and consistent sizing of h2 to h6 elements 

[ex.](https://www.greenwoodjs.io/docs/data)
<img width="1620" alt="Screen Shot 2020-07-07 at 9 10 43 PM" src="https://user-images.githubusercontent.com/895923/86862040-6a57fc80-c096-11ea-8c26-adac9740b930.png">
<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->