### PR TITLE
Bug/issue 371 similar query calls invariant error

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,12 +44,10 @@
     "css-loader": "^2.1.1",
     "css-to-string-loader": "^0.1.3",
     "cssnano": "^4.1.10",
-    "deepmerge": "^4.2.2",
     "file-loader": "^3.0.1",
     "filewatcher-webpack-plugin": "^1.2.0",
     "front-matter": "^3.0.1",
     "fs-extra": "^8.1.0",
-    "glob-promise": "^3.4.0",
     "graphql": "^14.5.8",
     "graphql-tag": "^2.10.1",
     "html-webpack-plugin": "^3.2.0",
@@ -74,6 +72,7 @@
     "webpack-merge": "^4.2.1"
   },
   "devDependencies": {
+    "glob-promise": "^3.4.0",
     "rehype-autolink-headings": "^4.0.0",
     "rehype-slug": "^3.0.0"
   }

--- a/packages/cli/src/data/cache.js
+++ b/packages/cli/src/data/cache.js
@@ -24,8 +24,6 @@ module.exports = async (req, context) => {
       const { query, variables } = req.body;
       const queryObj = gql`${query}`;
 
-      console.log('cache query', query);
-
       const { data } = await client.query({
         query: queryObj,
         variables

--- a/packages/cli/src/data/cache.js
+++ b/packages/cli/src/data/cache.js
@@ -34,16 +34,15 @@ module.exports = async (req, context) => {
       if (data) {
         const cache = JSON.stringify(client.extract());
         const queryHash = getQueryHash(queryObj, variables);
-        /* Get the requests entire (full) route and rootRoute to use as reference for designated cache directory */
-        const { origin, referer } = req.headers;
-        const fullRoute = referer.substring(origin.length, referer.length);
-        const rootRoute = fullRoute.substring(0, fullRoute.substring(1, fullRoute.length).indexOf('/') + 1);
-        const targetDir = path.join(context.publicDir, rootRoute);
-        const targetFile = path.join(targetDir, `${queryHash}-cache.json`);
+        const hashFilename = `${queryHash}-cache.json`;
+        const cachePath = `${context.publicDir}/${queryHash}-cache.json`;
+        
+        if (!fs.existsSync(context.publicDir)) {
+          fs.mkdirSync(context.publicDir);
+        }
 
-        if (!fs.existsSync(targetFile)) {
-          fs.mkdirsSync(targetDir, { recursive: true });
-          fs.writeFileSync(path.join(targetFile), cache, 'utf8');
+        if (!fs.existsSync(cachePath)) {
+          fs.writeFileSync(path.join(context.publicDir, hashFilename), cache, 'utf8');
         }
       }
       resolve();

--- a/packages/cli/src/data/cache.js
+++ b/packages/cli/src/data/cache.js
@@ -5,7 +5,7 @@ const fs = require('fs-extra');
 const { gql } = require('apollo-server');
 const InMemoryCache = require('apollo-cache-inmemory').InMemoryCache;
 const path = require('path');
-const { getQueryKeysHash } = require('./common');
+const { getQueryHash } = require('./common');
 
 /* Extract cache server-side */
 module.exports = async (req, context) => {
@@ -33,14 +33,13 @@ module.exports = async (req, context) => {
 
       if (data) {
         const cache = JSON.stringify(client.extract());
-        const md5 = getQueryKeysHash(queryObj);
-
+        const queryHash = getQueryHash(queryObj, variables);
         /* Get the requests entire (full) route and rootRoute to use as reference for designated cache directory */
         const { origin, referer } = req.headers;
         const fullRoute = referer.substring(origin.length, referer.length);
         const rootRoute = fullRoute.substring(0, fullRoute.substring(1, fullRoute.length).indexOf('/') + 1);
         const targetDir = path.join(context.publicDir, rootRoute);
-        const targetFile = path.join(targetDir, `${md5}-cache.json`);
+        const targetFile = path.join(targetDir, `${queryHash}-cache.json`);
 
         if (!fs.existsSync(targetFile)) {
           fs.mkdirsSync(targetDir, { recursive: true });

--- a/packages/cli/src/data/client.js
+++ b/packages/cli/src/data/client.js
@@ -18,7 +18,6 @@ client.query = (params) => {
     const queryHash = getQueryHash(params.query, params.variables);
     const cachePath = `/${queryHash}-cache.json`;
     
-    console.log('cachePath', cachePath);
     return fetch(cachePath)
       .then(response => response.json())
       .then((response) => {

--- a/packages/cli/src/data/client.js
+++ b/packages/cli/src/data/client.js
@@ -5,7 +5,7 @@ import { getQueryHash } from '@greenwood/cli/data/common';
 
 const APOLLO_STATE = window.__APOLLO_STATE__; // eslint-disable-line no-underscore-dangle
 const client = new ApolloClient({
-  cache: new InMemoryCache().restore(APOLLO_STATE),
+  cache: new InMemoryCache(),
   link: new HttpLink({
     uri: 'http://localhost:4000'
   })
@@ -13,16 +13,10 @@ const client = new ApolloClient({
 const backupQuery = client.query;
 
 client.query = (params) => {
-
   if (APOLLO_STATE) {
     // __APOLLO_STATE__ defined, in "SSG" mode...
-    const root = window.location.pathname.split('/')[1];
-    const rootSuffix = root === ''
-      ? ''
-      : '/';
-
     const queryHash = getQueryHash(params.query, params.variables);
-    const cachePath = `/${root}${rootSuffix}${queryHash}-cache.json`;
+    const cachePath = `/${queryHash}-cache.json`;
     
     console.log('cachePath', cachePath);
     return fetch(cachePath)

--- a/packages/cli/src/data/client.js
+++ b/packages/cli/src/data/client.js
@@ -1,6 +1,7 @@
 import { ApolloClient } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { HttpLink } from 'apollo-link-http';
+import { getQueryKeysHash } from '@greenwood/cli/data/common';
 
 const APOLLO_STATE = window.__APOLLO_STATE__; // eslint-disable-line no-underscore-dangle
 const client = new ApolloClient({
@@ -20,7 +21,11 @@ client.query = (params) => {
       ? ''
       : '/';
 
-    return fetch(`/${root}${rootSuffix}cache.json`)
+    const hash = getQueryKeysHash(params.query);
+    const cachePath = `/${root}${rootSuffix}${hash}-cache.json`;
+    
+    console.log('cachePath', cachePath);
+    return fetch(cachePath)
       .then(response => response.json())
       .then((response) => {
         // mock client.query response

--- a/packages/cli/src/data/client.js
+++ b/packages/cli/src/data/client.js
@@ -1,7 +1,7 @@
 import { ApolloClient } from 'apollo-client';
 import { InMemoryCache } from 'apollo-cache-inmemory';
 import { HttpLink } from 'apollo-link-http';
-import { getQueryKeysHash } from '@greenwood/cli/data/common';
+import { getQueryHash } from '@greenwood/cli/data/common';
 
 const APOLLO_STATE = window.__APOLLO_STATE__; // eslint-disable-line no-underscore-dangle
 const client = new ApolloClient({
@@ -21,8 +21,8 @@ client.query = (params) => {
       ? ''
       : '/';
 
-    const hash = getQueryKeysHash(params.query);
-    const cachePath = `/${root}${rootSuffix}${hash}-cache.json`;
+    const queryHash = getQueryHash(params.query, params.variables);
+    const cachePath = `/${root}${rootSuffix}${queryHash}-cache.json`;
     
     console.log('cachePath', cachePath);
     return fetch(cachePath)

--- a/packages/cli/src/data/common.js
+++ b/packages/cli/src/data/common.js
@@ -30,13 +30,18 @@ function getQueryKeysFromSelectionSet(selectionSet) {
   return queryKeys;
 }
 
-function getQueryKeysHash(query) {
+function getQueryHash(query, variables = {}) {
   const queryKeys = getQueryKeysFromSelectionSet(query.definitions[0].selectionSet);
-  
+  const variableValues = Object.keys(variables).length > 0
+    ? `_${Object.values(variables).join('').replace(/\//g, '')}` // handle / which will translate to filepaths
+    : '';
+
+  console.log('variableValues', variableValues);
+
   // return crypto.createHash('md5').update(hash).digest('hex');  
-  return queryKeys;
+  return `${queryKeys}${variableValues}`;
 }
 
 module.exports = {
-  getQueryKeysHash
+  getQueryHash
 };

--- a/packages/cli/src/data/common.js
+++ b/packages/cli/src/data/common.js
@@ -1,4 +1,13 @@
-const crypto = require('crypto');
+// https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0#gistcomment-2775538
+function hashString(queryKeysString) {
+  let h = 0;
+    
+  for (let i = 0; i < queryKeysString.length; i += 1) {
+    h = Math.imul(31, h) + queryKeysString.charCodeAt(i) | 0; // eslint-disable-line no-bitwise
+  }
+
+  return Math.abs(h).toString();
+}
 
 function getQueryKeysFromSelectionSet(selectionSet) {
   let queryKeys = '';
@@ -38,7 +47,7 @@ function getQueryHash(query, variables = {}) {
 
   console.log('variableValues', variableValues);
 
-  return crypto.createHash('md5').update(`${queryKeys}${variableValues}`).digest('hex');
+  return hashString(`${queryKeys}${variableValues}`);
 }
 
 module.exports = {

--- a/packages/cli/src/data/common.js
+++ b/packages/cli/src/data/common.js
@@ -1,0 +1,40 @@
+// const crypto = require('crypto');
+
+function getQueryKeysFromSelectionSet(selectionSet) {
+  let queryKeys = '';
+
+  for (let key in selectionSet) {
+    console.log('key is', key);
+    
+    if (key === 'selections') {
+      console.log('key is a selection');
+      console.log('unique items before', queryKeys);
+      queryKeys += selectionSet[key].map(selection => selection.name.value).join('');
+      console.log('unique items after', queryKeys);
+      console.log('**************');
+    }
+  }
+  
+  if (selectionSet.kind === 'SelectionSet') {
+    console.log('has a selectionSet, recurse!');
+    selectionSet.selections.forEach(selection => {
+      if (selection.selectionSet) {
+        queryKeys += getQueryKeysFromSelectionSet(selection.selectionSet);
+      }
+    });
+  }
+
+  console.log('return queryKeys.....', queryKeys);
+  return queryKeys;
+}
+
+function getQueryKeysHash(query) {
+  const queryKeys = getQueryKeysFromSelectionSet(query.definitions[0].selectionSet);
+  
+  // return crypto.createHash('md5').update(hash).digest('hex');  
+  return queryKeys;
+}
+
+module.exports = {
+  getQueryKeysHash
+};

--- a/packages/cli/src/data/common.js
+++ b/packages/cli/src/data/common.js
@@ -9,7 +9,9 @@ function getQueryKeysFromSelectionSet(selectionSet) {
     if (key === 'selections') {
       console.log('key is a selection');
       console.log('unique items before', queryKeys);
-      queryKeys += selectionSet[key].map(selection => selection.name.value).join('');
+      queryKeys += selectionSet[key]
+        .filter(selection => selection.name.value !== '__typename') // __typename is added by server.js
+        .map(selection => selection.name.value).join('');
       console.log('unique items after', queryKeys);
       console.log('**************');
     }

--- a/packages/cli/src/data/common.js
+++ b/packages/cli/src/data/common.js
@@ -1,4 +1,4 @@
-// const crypto = require('crypto');
+const crypto = require('crypto');
 
 function getQueryKeysFromSelectionSet(selectionSet) {
   let queryKeys = '';
@@ -38,8 +38,7 @@ function getQueryHash(query, variables = {}) {
 
   console.log('variableValues', variableValues);
 
-  // return crypto.createHash('md5').update(hash).digest('hex');  
-  return `${queryKeys}${variableValues}`;
+  return crypto.createHash('md5').update(`${queryKeys}${variableValues}`).digest('hex');
 }
 
 module.exports = {

--- a/packages/cli/src/data/common.js
+++ b/packages/cli/src/data/common.js
@@ -1,7 +1,7 @@
 // https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0#gistcomment-2775538
 function hashString(queryKeysString) {
   let h = 0;
-    
+
   for (let i = 0; i < queryKeysString.length; i += 1) {
     h = Math.imul(31, h) + queryKeysString.charCodeAt(i) | 0; // eslint-disable-line no-bitwise
   }
@@ -13,21 +13,15 @@ function getQueryKeysFromSelectionSet(selectionSet) {
   let queryKeys = '';
 
   for (let key in selectionSet) {
-    console.log('key is', key);
     
     if (key === 'selections') {
-      console.log('key is a selection');
-      console.log('unique items before', queryKeys);
       queryKeys += selectionSet[key]
         .filter(selection => selection.name.value !== '__typename') // __typename is added by server.js
         .map(selection => selection.name.value).join('');
-      console.log('unique items after', queryKeys);
-      console.log('**************');
     }
   }
   
   if (selectionSet.kind === 'SelectionSet') {
-    console.log('has a selectionSet, recurse!');
     selectionSet.selections.forEach(selection => {
       if (selection.selectionSet) {
         queryKeys += getQueryKeysFromSelectionSet(selection.selectionSet);
@@ -35,7 +29,6 @@ function getQueryKeysFromSelectionSet(selectionSet) {
     });
   }
 
-  console.log('return queryKeys.....', queryKeys);
   return queryKeys;
 }
 
@@ -44,8 +37,6 @@ function getQueryHash(query, variables = {}) {
   const variableValues = Object.keys(variables).length > 0
     ? `_${Object.values(variables).join('').replace(/\//g, '')}` // handle / which will translate to filepaths
     : '';
-
-  console.log('variableValues', variableValues);
 
   return hashString(`${queryKeys}${variableValues}`);
 }

--- a/packages/cli/test/cases/build.data.graph-custom-frontmatter/build.data.graph-custom-frontmatter.spec.js
+++ b/packages/cli/test/cases/build.data.graph-custom-frontmatter/build.data.graph-custom-frontmatter.spec.js
@@ -29,7 +29,7 @@ const TestBed = require('../../../../../test/test-bed');
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Data from GraphQL and using Custom Frontmatter Data';
-  const apolloStateRegex = /window.__APOLLO_STATE__=({.*?});/;
+  const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
   let setup;
 
   before(async function() {
@@ -54,14 +54,18 @@ describe('Build Greenwood With: ', function() {
         expect(fs.existsSync(path.join(this.context.publicDir, 'blog', 'first-post', 'index.html'))).to.be.true;
       });
 
-      it('should output one cache.json file', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, 'blog', 'cache.json'))).to.have.lengthOf(1);
+      it('should output a (partial) *-cache.json file, one per each query made', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, './*-cache.json'))).to.have.lengthOf(3);
       });
 
-      it('should output one cache.json file to be defined', function() {
-        const cacheContents = require(path.join(this.context.publicDir, 'blog', 'cache.json'));
+      it('should output a (partial) *-cache.json files, one per each query made, that are all defined', async function() {
+        const cacheFiles = await glob.promise(path.join(this.context.publicDir, './*-cache.json'));
 
-        expect(cacheContents).to.not.be.undefined;
+        cacheFiles.forEach(file => {
+          const cache = require(file);
+
+          expect(cache).to.not.be.undefined;
+        });
       });
 
       it('should have one window.__APOLLO_STATE__ <script> with (approximated) expected state', () => {

--- a/packages/cli/test/cases/build.data.graph/build.data.graph.spec.js
+++ b/packages/cli/test/cases/build.data.graph/build.data.graph.spec.js
@@ -36,7 +36,7 @@ const TestBed = require('../../../../../test/test-bed');
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Data from GraphQL';
-  const apolloStateRegex = /window.__APOLLO_STATE__=({.*?});/;
+  const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
   let setup;
 
   before(async function() {
@@ -73,21 +73,11 @@ describe('Build Greenwood With: ', function() {
         expect(await glob.promise(path.join(this.context.publicDir, './index.*.bundle.js'))).to.have.lengthOf(1);
       });
 
-      it('should output one (unified) cache.json file', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, './cache.json'))).to.have.lengthOf(1);
+      it('should output a (partial) *-cache.json file, one per each query made', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, './*-cache.json'))).to.have.lengthOf(5);
       });
 
-      it('should output one (unified) cache.json file that is defined', function() {
-        const cacheContents = require(path.join(this.context.publicDir, 'cache.json'));
-
-        expect(cacheContents).to.not.be.undefined;
-      });
-
-      it('should output three (partial) *-cache.json files, one per query made', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, './*-cache.json'))).to.have.lengthOf(3);
-      });
-
-      it('should output three (partial) *-cache.json files that are all defined', async function() {
+      it('should output a (partial) *-cache.json files, one per each query made, that are all defined', async function() {
         const cacheFiles = await glob.promise(path.join(this.context.publicDir, './*-cache.json'));
 
         cacheFiles.forEach(file => {
@@ -138,30 +128,6 @@ describe('Build Greenwood With: ', function() {
 
       it('should output an index.html file (first post page)', function() {
         expect(fs.existsSync(path.join(this.context.publicDir, 'blog', 'index.html'))).to.be.true;
-      });
-
-      it('should output one (unified) cache.json file', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, 'blog', 'cache.json'))).to.have.lengthOf(1);
-      });
-
-      it('should output one (unified) cache.json file that is defined', function() {
-        const cacheContents = require(path.join(this.context.publicDir, 'blog', 'cache.json'));
-
-        expect(cacheContents).to.not.be.undefined;
-      });
-
-      it('should output four ("partial") *-cache.json files, one per query made', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, 'blog', './*-cache.json'))).to.have.lengthOf(5);
-      });
-
-      it('should output four (partial) *-cache.json files that are defined', async function() {
-        const cacheFiles = await glob.promise(path.join(this.context.publicDir, 'blog', './*-cache.json'));
-
-        cacheFiles.forEach(file => {
-          const cache = require(file);
-
-          expect(cache).to.not.be.undefined;
-        });
       });
 
       it('should have one window.__APOLLO_STATE__ <script> with (approximated) expected state', () => {
@@ -227,34 +193,6 @@ describe('Build Greenwood With: ', function() {
 
       it('should output an index.html file for first blog post page', function() {
         expect(fs.existsSync(path.join(this.context.publicDir, 'blog', 'first-post', 'index.html'))).to.be.true;
-      });
-
-      it('should output an index.html file for second blog post page)', function() {
-        expect(fs.existsSync(path.join(this.context.publicDir, 'blog', 'second-post', 'index.html'))).to.be.true;
-      });
-
-      it('should output one (unified) cache.json file', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, 'blog', 'cache.json'))).to.have.lengthOf(1);
-      });
-
-      it('should output one (unified) cache.json file that is defined', function() {
-        const cacheContents = require(path.join(this.context.publicDir, 'blog', 'cache.json'));
-
-        expect(cacheContents).to.not.be.undefined;
-      });
-
-      it('should output four ("partial") *-cache.json files, one per query made', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, 'blog', './*-cache.json'))).to.have.lengthOf(5);
-      });
-
-      it('should output four (partial) *-cache.json files that are defined', async function() {
-        const cacheFiles = await glob.promise(path.join(this.context.publicDir, 'blog', './*-cache.json'));
-
-        cacheFiles.forEach(file => {
-          const cache = require(file);
-
-          expect(cache).to.not.be.undefined;
-        });
       });
 
       it('should have one window.__APOLLO_STATE__ <script> with (approximated) expected state', () => {

--- a/packages/cli/test/cases/build.data.graph/src/pages/blog/first-post/index.md
+++ b/packages/cli/test/cases/build.data.graph/src/pages/blog/first-post/index.md
@@ -1,7 +1,8 @@
 ---
-template: 'blog'
+template: 'post'
 title: 'First'
 menu: navigation
+date: '07.08.2020'
 ---
 
 ## My First Blog Post

--- a/packages/cli/test/cases/build.data.graph/src/pages/blog/index.md
+++ b/packages/cli/test/cases/build.data.graph/src/pages/blog/index.md
@@ -1,0 +1,5 @@
+---
+template: 'blog'
+---
+
+## My Posts

--- a/packages/cli/test/cases/build.data.graph/src/pages/blog/second-post/index.md
+++ b/packages/cli/test/cases/build.data.graph/src/pages/blog/second-post/index.md
@@ -1,7 +1,8 @@
 ---
-template: 'blog'
+template: 'post'
 title: 'Second'
 menu: navigation
+date: '07.09.2020'
 ---
 
 ## My Second Blog Post

--- a/packages/cli/test/cases/build.data.graph/src/templates/blog-template.js
+++ b/packages/cli/test/cases/build.data.graph/src/templates/blog-template.js
@@ -29,7 +29,9 @@ class BlogTemplate extends LitElement {
       }
     });
 
-    this.posts = response.data.children;
+    this.posts = response.data.children.filter(post => {
+      return post.filePath.indexOf('/blog/index') < 0;
+    });
   }
 
   /* eslint-disable indent */
@@ -41,16 +43,14 @@ class BlogTemplate extends LitElement {
       <div class='container'>
         <app-header></app-header>
 
-        <entry></entry>
-
         <div class="posts">
-          <h1>More Posts</h1>
-
+          <entry></entry>
+          
           <ul>
-            ${posts.map((item) => {
+            ${posts.map((post) => {
               return html`
                 <li>
-                  <a href="${item.link}/" title="Click to read my ${item.title} blog post">${item.title}</a>
+                  <a href="${post.link}" title="Click to read my ${post.title} blog post">${post.title}</a>
                 </li>
               `;
             })}

--- a/packages/cli/test/cases/build.data.graph/src/templates/post-template.js
+++ b/packages/cli/test/cases/build.data.graph/src/templates/post-template.js
@@ -1,0 +1,69 @@
+import client from '@greenwood/cli/data/client';
+import gql from 'graphql-tag';
+import { html, LitElement } from 'lit-element';
+import '../components/header';
+
+MDIMPORT;
+
+class PostTemplate extends LitElement {
+
+  static get properties() {
+    return {
+      post: {
+        type: Object
+      }
+    };
+  }
+
+  constructor() {
+    super();
+
+    this.post = {
+      title: '',
+      link: '',
+      data: {
+        date: ''
+      }
+    };
+  }
+
+  async connectedCallback() {
+    super.connectedCallback();
+    let route = window.location.pathname;
+    const response = await client.query({
+      query: gql`query {
+        graph {
+          title,
+          link,
+          data {
+            date
+          }
+        }
+      }`
+    });
+
+    if (route.lastIndexOf('/') !== route.length - 1) {
+      route = `${route}/`;
+    }
+
+    this.post = response.data.graph.filter((page) => {
+      return page.link.lastIndexOf(route) >= 0;
+    })[0];
+  }
+
+  render() {
+    const { date } = this.post.data;
+
+    return html`
+      <div>
+        <app-header></app-header>
+        
+        <entry></entry>
+
+        <p class="date">Posted on ${date}</p>
+      </div>
+    `;
+  }
+}
+
+customElements.define('page-template', PostTemplate);

--- a/packages/cli/test/unit/data/common.spec.js
+++ b/packages/cli/test/unit/data/common.spec.js
@@ -25,7 +25,7 @@ describe('Unit Test: Data', function() {
         `;
         const hash = getQueryHash(query);
 
-        expect(hash).to.be.equal('8b36e0d34b7a39b5795e516474dc864b');
+        expect(hash).to.be.equal('876029931');
       });
 
       it('should return the expected hash for a custom graph query with custom data', function () {
@@ -43,7 +43,7 @@ describe('Unit Test: Data', function() {
         `;
         const hash = getQueryHash(query);
 
-        expect(hash).to.be.equal('3d8d29dc5119e352cf8bf3f46681cf2f');
+        expect(hash).to.be.equal('1656784831');
       });
 
       it('should return the expected hash for a children query with a variable', function () {
@@ -63,7 +63,7 @@ describe('Unit Test: Data', function() {
           parent: '/docs/'
         });
 
-        expect(hash).to.be.equal('754338ce25f3b0c6bedf5a845c287618');
+        expect(hash).to.be.equal('1366211136');
       });
     });
 

--- a/packages/cli/test/unit/data/common.spec.js
+++ b/packages/cli/test/unit/data/common.spec.js
@@ -1,12 +1,12 @@
 const expect = require('chai').expect;
 const { gql } = require('apollo-server');
-const { getQueryKeysHash } = require('../../../src/data/common');
+const { getQueryHash } = require('../../../src/data/common');
 
 describe('Unit Test: Data', function() {
 
   describe('Common', function() {
 
-    describe('getQueryKeysHash', function() {
+    describe('getQueryHash', function() {
       
       describe('standard graph query', function () {
         // __typename is added by server.js
@@ -23,7 +23,7 @@ describe('Unit Test: Data', function() {
             }
           }
         `;
-        const hash = getQueryKeysHash(query);
+        const hash = getQueryHash(query);
 
         expect(hash).to.be.equal('graphidtitlelinkfilePathfileNametemplate');
       });
@@ -41,29 +41,30 @@ describe('Unit Test: Data', function() {
             }
           }
         `;
-        const hash = getQueryKeysHash(query);
+        const hash = getQueryHash(query);
 
         expect(hash).to.be.equal('graphtitlelinkdatadateimage');
       });
 
-      // TODO variables
-      // describe('menu query (multiple nesting) with variables', async function () {
-      //   const query = gql`
-      //     query {
-      //       graph {
-      //         title,
-      //         link,
-      //         data {
-      //           date,
-      //           image
-      //         }
-      //       }
-      //     }
-      //   `;
-      //   const hash = getQueryKeysHash(query);
-      //   console.log('hash', hash);
-      //   expect(hash).to.be.equal('graphtitlelinkdatadateimage');
-      // });
+      describe('query with variables', function () {
+        const query = gql`
+          query($parent: String!) {
+            children(parent: $parent) {
+              id,
+              title,
+              link,
+              filePath,
+              fileName,
+              template
+            }
+          }
+        `;
+        const hash = getQueryHash(query, {
+          parent: '/docs/'
+        });
+
+        expect(hash).to.be.equal('childrenidtitlelinkfilePathfileNametemplate_docs');
+      });
     });
 
   });

--- a/packages/cli/test/unit/data/common.spec.js
+++ b/packages/cli/test/unit/data/common.spec.js
@@ -8,7 +8,7 @@ describe('Unit Test: Data', function() {
 
     describe('getQueryHash', function() {
       
-      describe('standard graph query', function () {
+      it('should return the expected hash for a standard graph query', function () {
         // __typename is added by server.js
         const query = gql`
           query {
@@ -25,10 +25,10 @@ describe('Unit Test: Data', function() {
         `;
         const hash = getQueryHash(query);
 
-        expect(hash).to.be.equal('graphidtitlelinkfilePathfileNametemplate');
+        expect(hash).to.be.equal('8b36e0d34b7a39b5795e516474dc864b');
       });
 
-      describe('custom graph query and custom data', function () {
+      it('should return the expected hash for a custom graph query with custom data', function () {
         const query = gql`
           query {
             graph {
@@ -43,10 +43,10 @@ describe('Unit Test: Data', function() {
         `;
         const hash = getQueryHash(query);
 
-        expect(hash).to.be.equal('graphtitlelinkdatadateimage');
+        expect(hash).to.be.equal('3d8d29dc5119e352cf8bf3f46681cf2f');
       });
 
-      describe('query with variables', function () {
+      it('should return the expected hash for a children query with a variable', function () {
         const query = gql`
           query($parent: String!) {
             children(parent: $parent) {
@@ -63,7 +63,7 @@ describe('Unit Test: Data', function() {
           parent: '/docs/'
         });
 
-        expect(hash).to.be.equal('childrenidtitlelinkfilePathfileNametemplate_docs');
+        expect(hash).to.be.equal('754338ce25f3b0c6bedf5a845c287618');
       });
     });
 

--- a/packages/cli/test/unit/data/common.spec.js
+++ b/packages/cli/test/unit/data/common.spec.js
@@ -6,9 +6,10 @@ describe('Unit Test: Data', function() {
 
   describe('Common', function() {
 
-    describe('generateQueryHash', function() {
+    describe('getQueryKeysHash', function() {
       
       describe('standard graph query', function () {
+        // __typename is added by server.js
         const query = gql`
           query {
             graph {
@@ -17,7 +18,8 @@ describe('Unit Test: Data', function() {
               link,
               filePath,
               fileName,
-              template
+              template,
+              __typename
             }
           }
         `;

--- a/packages/cli/test/unit/data/common.spec.js
+++ b/packages/cli/test/unit/data/common.spec.js
@@ -1,0 +1,68 @@
+const expect = require('chai').expect;
+const { gql } = require('apollo-server');
+const { getQueryKeysHash } = require('../../../src/data/common');
+
+describe('Unit Test: Data', function() {
+
+  describe('Common', function() {
+
+    describe('generateQueryHash', function() {
+      
+      describe('standard graph query', function () {
+        const query = gql`
+          query {
+            graph {
+              id,
+              title,
+              link,
+              filePath,
+              fileName,
+              template
+            }
+          }
+        `;
+        const hash = getQueryKeysHash(query);
+
+        expect(hash).to.be.equal('graphidtitlelinkfilePathfileNametemplate');
+      });
+
+      describe('custom graph query and custom data', function () {
+        const query = gql`
+          query {
+            graph {
+              title,
+              link,
+              data {
+                date,
+                image
+              }
+            }
+          }
+        `;
+        const hash = getQueryKeysHash(query);
+
+        expect(hash).to.be.equal('graphtitlelinkdatadateimage');
+      });
+
+      // TODO variables
+      // describe('menu query (multiple nesting) with variables', async function () {
+      //   const query = gql`
+      //     query {
+      //       graph {
+      //         title,
+      //         link,
+      //         data {
+      //           date,
+      //           image
+      //         }
+      //       }
+      //     }
+      //   `;
+      //   const hash = getQueryKeysHash(query);
+      //   console.log('hash', hash);
+      //   expect(hash).to.be.equal('graphtitlelinkdatadateimage');
+      // });
+    });
+
+  });
+});

--- a/www/templates/home-template.js
+++ b/www/templates/home-template.js
@@ -1,5 +1,3 @@
-import client from '@greenwood/cli/data/client';
-import gql from 'graphql-tag';
 import { html, LitElement } from 'lit-element';
 
 import '../components/banner/banner';
@@ -15,23 +13,6 @@ MDIMPORT;
 
 class HomeTemplate extends LitElement {
 
-  async connectedCallback() {
-    super.connectedCallback();
-    const response = await client.query({
-      query: gql`query {
-        graph {
-          title,
-          link,
-          data {
-            noop
-          }
-        }
-      }`
-    });
-
-    console.log('response', response);
-  }
-  
   render() {
     return html`
       <style>

--- a/www/templates/home-template.js
+++ b/www/templates/home-template.js
@@ -1,4 +1,7 @@
+import client from '@greenwood/cli/data/client';
+import gql from 'graphql-tag';
 import { html, LitElement } from 'lit-element';
+
 import '../components/banner/banner';
 import '../components/card/card';
 import '../components/header/header';
@@ -12,6 +15,23 @@ MDIMPORT;
 
 class HomeTemplate extends LitElement {
 
+  async connectedCallback() {
+    super.connectedCallback();
+    const response = await client.query({
+      query: gql`query {
+        graph {
+          title,
+          link,
+          data {
+            noop
+          }
+        }
+      }`
+    });
+
+    console.log('response', response);
+  }
+  
   render() {
     return html`
       <style>

--- a/www/templates/home-template.js
+++ b/www/templates/home-template.js
@@ -1,5 +1,4 @@
 import { html, LitElement } from 'lit-element';
-
 import '../components/banner/banner';
 import '../components/card/card';
 import '../components/header/header';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4632,11 +4632,6 @@ deepmerge@4.0.0:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.0.0.tgz#3e3110ca29205f120d7cb064960a39c3d2087c09"
   integrity sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww==
 
-deepmerge@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
-  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
-
 default-gateway@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-4.2.0.tgz#167104c7500c2115f6dd69b0a536bb8ed720552b"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #371 

## Summary of Changes
> _For context, my thoughts on root cause analysis can be found [here](https://github.com/ProjectEvergreen/greenwood/issues/371#issuecomment-654492993)_
1. Created a common utility that will generate a unique hash per query, that can in turn be used to write / read cache file paths in _cache.js_ and _client.js_, respectively
1. Added unit tests and test cases, observed #386 that may result in intermittent test failures on this PR perhaps
1. Removed _cache.json_, left `window.__APOLLO_STATE__`, cleaned up deps.  
    - This effectively invalidates #349 at this point, IMO
    - Would also take care of #317 too then?

~~**Note**: You can test on the home page now and see multiple `query` calls now returning.   However, do keep in mind that pages with a menu will break right now until I add support for variables.  (right now both `menu` queries are using the same keys and so filenames are not unique)~~
<img width="1652" alt="Screen Shot 2020-07-08 at 10 21 37 PM" src="https://user-images.githubusercontent.com/895923/86989906-6cd75680-c169-11ea-9d9b-1eed04eb3dcf.png">

## TODOs
1. [x] Add support for variables (to fix pages with `menu` queries)
1. [x] Add a test case
1. [x] remove `deepmerge` dependency / unified _cache.json_ in **serialize** lifecycle.  All _-cache.json_ files can now stay at the root as well
1. [x] return an actual hash
1. [x] Perf comparison - need to swap out with something other than `crypto`, much too large!
1. [x] remove `console` logs / example in _home-template.js_