### PR TITLE
task/issue 384 add support for custom loading component

### DIFF
--- a/packages/cli/src/config/webpack.config.common.js
+++ b/packages/cli/src/config/webpack.config.common.js
@@ -84,7 +84,8 @@ module.exports = ({ config, context }) => {
     resolve: {
       extensions: ['.js', '.json', '.gql', '.graphql'],
       alias: {
-        '@greenwood/cli/data': context.dataDir
+        '@greenwood/cli/data': context.dataDir,
+        '@greenwood/cli/templates/loading': context.loadingTemplatePath
       }
     },
 

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -24,7 +24,7 @@ module.exports = initContexts = async({ config }) => {
       const userWorkspace = path.join(config.workspace);
       const userPagesDir = path.join(userWorkspace, 'pages/');
       const userTemplatesDir = path.join(userWorkspace, 'templates/');
-      const userAppTemplate = path.join(userTemplatesDir,  appTemplate);
+      const userAppTemplate = path.join(userTemplatesDir, appTemplate);
       const userPageTemplate = path.join(userTemplatesDir, pageTemplate);
       const userLoadingTemplate = path.join(userTemplatesDir, loadingTemplate);
 

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -9,32 +9,38 @@ const dataDir = path.join(__dirname, '../data');
 module.exports = initContexts = async({ config }) => {
 
   return new Promise(async (resolve, reject) => {
-
+    
     try {
-      const userWorkspace = path.join(config.workspace);
-      const userPagesDir = path.join(userWorkspace, 'pages/');
-      const userTemplatesDir = path.join(userWorkspace, 'templates/');
-      const userAppTemplate = path.join(userTemplatesDir, 'app-template.js');
-      const userPageTemplate = path.join(userTemplatesDir, 'page-template.js');
+      const appTemplate = 'app-template.js';
+      const pageTemplate = 'page-template.js';
       const indexPageTemplate = 'index.html';
       const notFoundPageTemplate = '404.html';
+      const loadingTemplate = 'loading.js';
       const webpackProd = 'webpack.config.prod.js';
       const webpackDev = 'webpack.config.develop.js';
       const babelConfig = 'babel.config.js';
       const postcssConfig = 'postcss.config.js';
+
+      const userWorkspace = path.join(config.workspace);
+      const userPagesDir = path.join(userWorkspace, 'pages/');
+      const userTemplatesDir = path.join(userWorkspace, 'templates/');
+      const userAppTemplate = path.join(userTemplatesDir,  appTemplate);
+      const userPageTemplate = path.join(userTemplatesDir, pageTemplate);
+      const userLoadingTemplate = path.join(userTemplatesDir, loadingTemplate);
 
       const userHasWorkspace = await fs.exists(userWorkspace);
       const userHasWorkspacePages = await fs.exists(userPagesDir);
       const userHasWorkspaceTemplates = await fs.exists(userTemplatesDir);
       const userHasWorkspacePageTemplate = await fs.exists(userPageTemplate);
       const userHasWorkspaceAppTemplate = await fs.exists(userAppTemplate);
-      const userHasWorkspaceIndexTemplate = await fs.exists(path.join(userTemplatesDir, 'index.html'));
-      const userHasWorkspaceNotFoundTemplate = await fs.exists(path.join(userTemplatesDir, '404.html'));
+      const userHasWorkspaceLoadingTemplate = await fs.exists(userLoadingTemplate);
+      const userHasWorkspaceIndexTemplate = await fs.exists(path.join(userTemplatesDir, indexPageTemplate));
+      const userHasWorkspaceNotFoundTemplate = await fs.exists(path.join(userTemplatesDir, notFoundPageTemplate));
       const userHasWorkspaceWebpackProd = await fs.exists(path.join(process.cwd(), webpackProd));
       const userHasWorkspaceWebpackDevelop = await fs.exists(path.join(process.cwd(), webpackDev));
       const userHasWorkspaceBabel = await fs.exists(path.join(process.cwd(), babelConfig));
       const userHasWorkspacePostCSS = await fs.exists(path.join(process.cwd(), postcssConfig));
-      
+
       let context = {
         dataDir,
         scratchDir,
@@ -44,18 +50,22 @@ module.exports = initContexts = async({ config }) => {
         userWorkspace: userHasWorkspace ? userWorkspace : defaultTemplatesDir,
         pageTemplatePath: userHasWorkspacePageTemplate
           ? userPageTemplate
-          : path.join(defaultTemplatesDir, 'page-template.js'),
+          : path.join(defaultTemplatesDir, pageTemplate),
         appTemplatePath: userHasWorkspaceAppTemplate
           ? userAppTemplate
-          : path.join(defaultTemplatesDir, 'app-template.js'),
+          : path.join(defaultTemplatesDir, appTemplate),
         indexPageTemplatePath: userHasWorkspaceIndexTemplate
           ? path.join(userTemplatesDir, indexPageTemplate)
           : path.join(defaultTemplatesDir, indexPageTemplate),
         notFoundPageTemplatePath: userHasWorkspaceNotFoundTemplate
           ? path.join(userTemplatesDir, notFoundPageTemplate)
           : path.join(defaultTemplatesDir, notFoundPageTemplate),
+        loadingTemplatePath: userHasWorkspaceLoadingTemplate
+          ? path.join(userTemplatesDir, loadingTemplate)
+          : path.join(defaultTemplatesDir, loadingTemplate),
         indexPageTemplate,
         notFoundPageTemplate,
+        loadingTemplate,
         assetDir: path.join(userHasWorkspace ? userWorkspace : defaultTemplatesDir, 'assets'),
         webpackProd: userHasWorkspaceWebpackProd
           ? path.join(process.cwd(), './', webpackProd)

--- a/packages/cli/src/lifecycles/scaffold.js
+++ b/packages/cli/src/lifecycles/scaffold.js
@@ -86,7 +86,6 @@ const writeRoutes = async(compilation) => {
       });
 
       let result = data.toString().replace(/MYROUTES/g, routes.join(''));
-      result = result.replace(/LDIMPORT/g, `import '${compilation.context.loadingTemplatePath}';`);
 
       // Create app directory so that app-template relative imports are correct
       const appDir = path.join(compilation.context.scratchDir, 'app');

--- a/packages/cli/src/lifecycles/scaffold.js
+++ b/packages/cli/src/lifecycles/scaffold.js
@@ -81,10 +81,13 @@ const writeRoutes = async(compilation) => {
           path="${file.route}"
           component="eve-${file.label}"
           .resolve="\${() => import(/* webpackChunkName: "${file.chunkName}" */ ${file.relativeExpectedPath})}"
+          loading="eve-loading"
           ></lit-route>`;
       });
 
-      const result = data.toString().replace(/MYROUTES/g, routes.join(''));
+      let result = data.toString().replace(/MYROUTES/g, routes.join(''));
+      result = result.replace(/LDIMPORT/g, `import '${compilation.context.loadingTemplatePath}';`);
+
       // Create app directory so that app-template relative imports are correct
       const appDir = path.join(compilation.context.scratchDir, 'app');
 

--- a/packages/cli/src/templates/app-template.js
+++ b/packages/cli/src/templates/app-template.js
@@ -6,7 +6,7 @@ import thunk from 'redux-thunk';
 import client from '@greenwood/cli/data/client';
 import ConfigQuery from '@greenwood/cli/data/queries/config';
 import GraphQuery from '@greenwood/cli/data/queries/graph';
-LDIMPORT;
+import '@greenwood/cli/templates/loading';
 
 // eslint-disable-next-line no-underscore-dangle
 const compose = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || origCompose;

--- a/packages/cli/src/templates/app-template.js
+++ b/packages/cli/src/templates/app-template.js
@@ -6,7 +6,7 @@ import thunk from 'redux-thunk';
 import client from '@greenwood/cli/data/client';
 import ConfigQuery from '@greenwood/cli/data/queries/config';
 import GraphQuery from '@greenwood/cli/data/queries/graph';
-LDIMPORT
+LDIMPORT;
 
 // eslint-disable-next-line no-underscore-dangle
 const compose = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || origCompose;

--- a/packages/cli/src/templates/app-template.js
+++ b/packages/cli/src/templates/app-template.js
@@ -6,6 +6,7 @@ import thunk from 'redux-thunk';
 import client from '@greenwood/cli/data/client';
 import ConfigQuery from '@greenwood/cli/data/queries/config';
 import GraphQuery from '@greenwood/cli/data/queries/graph';
+LDIMPORT
 
 // eslint-disable-next-line no-underscore-dangle
 const compose = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || origCompose;

--- a/packages/cli/src/templates/loading.js
+++ b/packages/cli/src/templates/loading.js
@@ -1,0 +1,19 @@
+import { html, css, LitElement } from 'lit-element';
+
+class Loading extends LitElement {
+    static get styles() {
+        return css`
+            div {
+                height: 100vh;
+                width: 100vw;
+            }
+        `
+    }
+    render() {
+        return html`
+            <div></div>
+        `;
+    }
+}
+
+customElements.define('eve-loading', Loading);

--- a/packages/cli/src/templates/loading.js
+++ b/packages/cli/src/templates/loading.js
@@ -1,19 +1,19 @@
 import { html, css, LitElement } from 'lit-element';
 
 class Loading extends LitElement {
-    static get styles() {
-        return css`
-            div {
-                height: 100vh;
-                width: 100vw;
-            }
-        `
-    }
-    render() {
-        return html`
-            <div></div>
-        `;
-    }
+  static get styles() {
+    return css`
+      div {
+        height: 100vh;
+        width: 100vw;
+      }
+    `;
+  }
+  render() {
+    return html`
+      <div></div>
+    `;
+  }
 }
 
 customElements.define('eve-loading', Loading);

--- a/packages/cli/test/cases/build.default.webpack/webpack.config.common.js
+++ b/packages/cli/test/cases/build.default.webpack/webpack.config.common.js
@@ -85,7 +85,8 @@ module.exports = ({ config, context }) => {
     resolve: {
       extensions: ['.js', '.json', '.gql', '.graphql'],
       alias: {
-        '@greenwood/cli/data': path.join(__dirname, '../../..', './src', './data')
+        '@greenwood/cli/data': context.dataDir,
+        '@greenwood/cli/templates/loading': context.loadingTemplatePath
       }
     },
 

--- a/packages/cli/test/cases/build.default.workspace-template-app/src/templates/app-template.js
+++ b/packages/cli/test/cases/build.default.workspace-template-app/src/templates/app-template.js
@@ -5,6 +5,7 @@ import { lazyReducerEnhancer } from 'pwa-helpers/lazy-reducer-enhancer.js';
 import thunk from 'redux-thunk';
 import client from '@greenwood/cli/data/client';
 import ConfigQuery from '@greenwood/cli/data/queries/config';
+import '@greenwood/cli/templates/loading';
 
 // eslint-disable-next-line no-underscore-dangle
 const compose = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || origCompose;

--- a/www/templates/app-template.js
+++ b/www/templates/app-template.js
@@ -8,6 +8,7 @@ import ConfigQuery from '@greenwood/cli/data/queries/config';
 import GraphQuery from '@greenwood/cli/data/queries/graph';
 import '../components/header/header';
 import '../components/footer/footer';
+LDIMPORT
 
 // eslint-disable-next-line no-underscore-dangle
 const compose = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || origCompose;

--- a/www/templates/app-template.js
+++ b/www/templates/app-template.js
@@ -8,7 +8,7 @@ import ConfigQuery from '@greenwood/cli/data/queries/config';
 import GraphQuery from '@greenwood/cli/data/queries/graph';
 import '../components/header/header';
 import '../components/footer/footer';
-LDIMPORT
+LDIMPORT;
 
 // eslint-disable-next-line no-underscore-dangle
 const compose = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || origCompose;

--- a/www/templates/app-template.js
+++ b/www/templates/app-template.js
@@ -8,7 +8,7 @@ import ConfigQuery from '@greenwood/cli/data/queries/config';
 import GraphQuery from '@greenwood/cli/data/queries/graph';
 import '../components/header/header';
 import '../components/footer/footer';
-LDIMPORT;
+import '@greenwood/cli/templates/loading';
 
 // eslint-disable-next-line no-underscore-dangle
 const compose = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || origCompose;

--- a/www/templates/loading.js
+++ b/www/templates/loading.js
@@ -1,19 +1,19 @@
 import { html, css, LitElement } from 'lit-element';
 
-class LoadingComponent extends LitElement {
-    static get styles() {
-        return css`
-            div {
-                height: calc(100vh - 70px - 40px);
-                width: 100vw;
-            }
-        `
-    }
-    render() {
-        return html`
-            <div></div>
-        `;
-    }
+class Loading extends LitElement {
+  static get styles() {
+    return css`
+      div {
+        height: 100vh;
+        width: 100vw;
+      }
+    `;
+  }
+  render() {
+    return html`
+      <div></div>
+    `;
+  }
 }
 
-customElements.define('eve-loading', LoadingComponent);
+customElements.define('eve-loading', Loading);

--- a/www/templates/loading.js
+++ b/www/templates/loading.js
@@ -1,0 +1,19 @@
+import { html, css, LitElement } from 'lit-element';
+
+class LoadingComponent extends LitElement {
+    static get styles() {
+        return css`
+            div {
+                height: calc(100vh - 70px - 40px);
+                width: 100vw;
+            }
+        `
+    }
+    render() {
+        return html`
+            <div></div>
+        `;
+    }
+}
+
+customElements.define('eve-loading', LoadingComponent);


### PR DESCRIPTION
## Related Issue
Resolves #384

## Summary of Changes

* Create default loading component used as a placeholder between lazy loaded routes 
* Modify scaffold to enable loading component in lazy loaded routes
* Modify scaffold to replace instances of predefined `LDIMPORT` with path to loading component
* Modify context to detect if custom loading component is present

## Notes

* custom loading component must be in `<workspace>/templates/loading.js`
* custom loading component element must be defined as `eve-loading`
* custom app-template must import the component using predefined hook `LDIMPORT`

## TODO

* Documentation
* Test custom/default loading component does indeed render

## Future

* remove need for LDIMPORT hook