### PR TITLE
fix typo in layouts docs

### DIFF
--- a/www/pages/docs/layouts.md
+++ b/www/pages/docs/layouts.md
@@ -35,7 +35,7 @@ class PageTemplate extends LitElement {
 customElements.define('page-template', PageTemplate);
 ```
 
-> **Note**: the filename must be in the format `<label>-templates.js` and the `customElements` name must be `page-template`.
+> **Note**: the filename must be in the format `<label>-template.js` and the `customElements` name must be `page-template`.
 
 With a completed page-template.js present in your `src/templates/` folder you can define which page uses it via front-matter at the top of any markdown file.  See [Front Matter Docs](/docs/front-matter#define-template) for more information.  Simply including a file named `page-template.js` will overwrite the greenwood default template for all markdown files, without needing to declare the template at the top of markdown file.
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
none

## Summary of Changes
1. Fix typo observed by @hutchgrant in the [layouts docs](https://www.greenwoodjs.io/docs/layouts)

<img width="1108" alt="Screen Shot 2020-07-28 at 8 11 29 PM" src="https://user-images.githubusercontent.com/895923/88741839-ab2fb800-d10e-11ea-8562-276f514333ae.png">

Should be (no **s**)
> Note: the filename must be in the format < label >-template**~~s~~**.js and the customElements name must be page-template.