### PR TITLE
add github action for release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Installing project dependencies
       run: |
-        yarn install  --frozen-lockfile && yarn lerna bootstrap
+        yarn install --frozen-lockfile && yarn lerna bootstrap
     - name: Lint
       run: |
         yarn lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release Branch Integration
+
+on:
+  push:
+    branches:
+      - release/**
+
+jobs:
+
+  build:
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Chromium Library Dependencies
+      run: |
+        sh ./.github/workflows/chromium-lib-install.sh
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Installing project dependencies
+      run: |
+        yarn install  --frozen-lockfile && yarn lerna bootstrap
+    - name: Lint
+      run: |
+        yarn lint
+    - name: Test
+      run: |
+        yarn test
+    - name: Build
+      run: |
+        yarn clean && yarn build
+      env:
+        CI: true


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
I think this should solve the issue with `release/xxx` branches not building in GitHub Actions.  🤞 
https://github.com/ProjectEvergreen/greenwood/pull/436
<img width="1292" alt="Screen Shot 2020-12-20 at 1 03 34 PM" src="https://user-images.githubusercontent.com/895923/102720694-d1bfdc80-42c3-11eb-9378-2db2d1989e9f.png">