### PR TITLE
Fix/issue 432 correct shelf and markdown plugins

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -29,8 +29,8 @@ module.exports = {
   markdown: {
     plugins: [
       '@mapbox/rehype-prism',
-      'rehype-autolink-headings',
       'rehype-slug',
+      'rehype-autolink-headings',
       'remark-github'
     ]
   }

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -77,6 +77,12 @@ module.exports = generateGraph = async (compilation) => {
               // parse markdown for table of contents and output to json
               customData.tableOfContents = toc(fileContents).json;
               customData.tableOfContents.shift();
+
+              // parse table of contents for only the pages user wants linked
+              if (customData.tableOfContents.length > 0 && customData.linkheadings > 0) {
+                customData.tableOfContents = customData.tableOfContents
+                  .filter((item) => item.lvl === customData.linkheadings);
+              }
             }
             /* ---------End Menu Query-------------------- */
 

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -202,14 +202,15 @@ class StandardHtmlResource extends ResourceInterface {
           });
 
           // TODO extract front matter contents from remark-frontmatter instead of frontmatter lib
+          const settings = config.markdown.settings || {};
           const fm = frontmatter(markdownContents);
           processedMarkdown = await unified()
-            .use(remarkParse) // parse markdown into AST
+            .use(remarkParse, settings) // parse markdown into AST
             .use(remarkFrontmatter) // extract frontmatter from AST
-            .use(...remarkPlugins) // apply userland remark plugins
+            .use(remarkPlugins) // apply userland remark plugins
             .use(remarkRehype, { allowDangerousHtml: true }) // convert from markdown to HTML AST
             .use(rehypeRaw) // support mixed HTML in markdown
-            .use(...rehypePlugins) // apply userland rehype plugins
+            .use(rehypePlugins) // apply userland rehype plugins
             .use(rehypeStringify) // convert AST to HTML string
             .process(markdownContents);
 

--- a/packages/cli/test/cases/build.config.markdown-custom.plugins/build.config.markdown-custom.spec.js
+++ b/packages/cli/test/cases/build.config.markdown-custom.plugins/build.config.markdown-custom.spec.js
@@ -62,18 +62,16 @@ describe('Build Greenwood With: ', function() {
         expect(code[0].getAttribute('class')).to.equal('language-js');
       });
 
-      // TODO?
-      xit('should use our custom markdown preset rehype-autolink-headings and rehype-slug plugins', function() {
-        let heading = dom.window.document.querySelector('h3 > a');
+      it('should use our custom markdown preset rehype-autolink-headings and rehype-slug plugins', function() {
+        let heading = dom.window.document.querySelector('h1 > a');
         
-        expect(heading.getAttribute('href')).to.equal('#greenwood');
+        expect(heading.getAttribute('href')).to.equal('#greenwood-markdown-syntax-highlighting-test');
       });
 
-      // TODO?
-      xit('should use our custom markdown preset rremark-TBD plugins', function() {
+      it('should use our custom markdown preset rremark-TBD plugins', function() {
         let heading = dom.window.document.querySelector('h3 > a');
         
-        expect(heading.getAttribute('href')).to.equal('#greenwood');
+        expect(heading.getAttribute('href')).to.equal('#lower-heading-test');
       });
     });
 

--- a/packages/cli/test/cases/build.config.markdown-custom.settings/build.config.markdown-custom.settings.spec.js
+++ b/packages/cli/test/cases/build.config.markdown-custom.settings/build.config.markdown-custom.settings.spec.js
@@ -58,7 +58,7 @@ describe('Build Greenwood With: ', function() {
   });
 
   after(function() {
-    // setup.teardownTestBed();
+    setup.teardownTestBed();
   });
 
 });

--- a/packages/cli/test/cases/build.config.markdown-custom.settings/build.config.markdown-custom.settings.spec.js
+++ b/packages/cli/test/cases/build.config.markdown-custom.settings/build.config.markdown-custom.settings.spec.js
@@ -18,12 +18,12 @@
  *   pages/
  *     index.md
  */
-const fs = require('fs');
+const { JSDOM } = require('jsdom');
 const path = require('path');
 const expect = require('chai').expect;
 const TestBed = require('../../../../../test/test-bed');
 
-xdescribe('Build Greenwood With: ', function() {
+describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Markdown Configuration and Custom Workspace';
   let setup;
 
@@ -34,15 +34,23 @@ xdescribe('Build Greenwood With: ', function() {
   });
 
   describe(LABEL, function() {
+
+    before(async function() {
+      await setup.runGreenwoodCommand('build');
+    });
+
     describe('Custom Markdown Presets', function() {
+      let dom;
+
+      before(async function() {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, 'index.html'));
+      });
 
       // gfm: false disables things like fenced code blocks https://www.npmjs.com/package/remark-parse#optionsgfm
-      it('should intentionally fail to compile using our custom markdown preset settings', async function() {
-        try {
-          await setup.runGreenwoodCommand('build');
-        } catch (err) {
-          expect(fs.existsSync(path.join(this.context.publicDir, './index.html'))).to.be.false;
-        }
+      it('should intentionally fail to compile code fencing using our custom markdown preset settings', async function() {
+        let pre = dom.window.document.querySelector('pre > code'); 
+
+        expect(pre).to.equal(null);
       });
 
     });
@@ -50,7 +58,7 @@ xdescribe('Build Greenwood With: ', function() {
   });
 
   after(function() {
-    setup.teardownTestBed();
+    // setup.teardownTestBed();
   });
 
 });

--- a/www/components/scroll/scroll.js
+++ b/www/components/scroll/scroll.js
@@ -25,7 +25,7 @@ class scroll extends LitElement {
       return Array.from(elements).filter((element) => {
         let el = RegExp(text, 'gmi').test(element.href);
         let href = element.href;
-        if (el && href.substr(href.length - text.length, href.length) === text) {
+        if (el && href.substr(href.length - text.length, href.length) === text && (el.tagName && el.tagName.toLowerCase() === 'h3')) {
           return el;
         }
       });
@@ -36,7 +36,7 @@ class scroll extends LitElement {
     // query hash text
     const heading = contains('a', hash)[0];
 
-    if (heading !== undefined) {
+    if (heading) {
       heading.scrollIntoView(true);
     }
   }

--- a/www/components/shelf/shelf.js
+++ b/www/components/shelf/shelf.js
@@ -88,7 +88,6 @@ class Shelf extends LitElement {
   }
 
   async fetchShelfData() {
-    console.log('fetchShelfData!!!', this.page);
     return fetch('/graph.json')
       .then(res => res.json())
       .then(data => {

--- a/www/components/shelf/shelf.js
+++ b/www/components/shelf/shelf.js
@@ -41,7 +41,7 @@ class Shelf extends LitElement {
   expandRoute(path) {
     let routeShelfListIndex = this.shelfList.findIndex(item => {
       let expRoute = new RegExp(`^${path}$`);
-      return expRoute.test(item.link);
+      return expRoute.test(item.route);
     });
 
     if (routeShelfListIndex > -1) {
@@ -96,7 +96,7 @@ class Shelf extends LitElement {
           if (page.data.menu && page.data.menu === 'side' && page.route.indexOf(`/${this.page}`) === 0) {
             page.label = `${page.label.charAt(0).toUpperCase()}${page.label.slice(1)}`.replace('-', ' ');
             page.children = [];
-            
+
             page.data.tableOfContents.forEach(({ content, slug }) => {
               page.children.push({
                 label: content,

--- a/www/components/shelf/shelf.js
+++ b/www/components/shelf/shelf.js
@@ -88,7 +88,7 @@ class Shelf extends LitElement {
   }
 
   async fetchShelfData() {
-    // console.debug('fetchShelfData!!!', this.page);
+    console.log('fetchShelfData!!!', this.page);
     return fetch('/graph.json')
       .then(res => res.json())
       .then(data => {
@@ -132,9 +132,18 @@ class Shelf extends LitElement {
     }
   }
 
+  handleSubItemSelect(mainRoute, itemRoute) {
+    // check if we're on the same page as subitem anchor
+    if (window.location.pathname.substr(0, window.location.pathname.length - 1) !== mainRoute) {
+      window.location.href = mainRoute + itemRoute;
+    } else {
+      this.goTo(`${item.route}`);
+    }
+  }
+
   renderList() {
     /* eslint-disable indent */
-    const renderListItems = (list, selected) => {
+    const renderListItems = (mainRoute, list, selected) => {
       let listItems = '';
 
       if (list && list.length > 0) {
@@ -143,7 +152,7 @@ class Shelf extends LitElement {
             ${list.map((item) => {
               return html`
                 <li class="${selected ? '' : 'hidden'}">
-                  <a @click=${() => { this.goTo(`${item.route}`); }}>${item.label}</a>
+                  <a @click=${() => this.handleSubItemSelect(mainRoute, item.route)}>${item.label}</a>
                 </li>
               `;
             })}
@@ -170,7 +179,7 @@ class Shelf extends LitElement {
 
           <hr/>
           
-          ${renderListItems(item.children, item.selected)}
+          ${renderListItems(item.route, item.children, item.selected)}
         </li>
       `;
     });

--- a/www/styles/page.css
+++ b/www/styles/page.css
@@ -7,7 +7,6 @@ h3 {
 }
 
 h2 {
-  color: #2D3D3A;
   font-size: 2rem;
 }
 
@@ -17,7 +16,7 @@ h4, h5, h6 {
 
 h1, h2, h3, h4, h5 {
   line-height: 1.8rem;
-
+  color: #2D3D3A;
   & a > span.icon {
     width:28px;
     height:24px;

--- a/www/styles/page.css
+++ b/www/styles/page.css
@@ -17,19 +17,20 @@ h4, h5, h6 {
 h1, h2, h3, h4, h5 {
   line-height: 1.8rem;
   color: #2D3D3A;
-  & a > span.icon {
-    width:28px;
-    height:24px;
-    float:left;
-    padding:2px;
-    background-image: url(/assets/link.png);
-    background-size: 20px 20px;
-    background-repeat: no-repeat;
-    background-position-y: center;
-    
-    &:hover {
-      filter: invert(.4);
-    }
+}
+
+h3 > a > span.icon {
+  width:28px;
+  height:24px;
+  float:left;
+  padding:2px;
+  background-image: url(/assets/link.png);
+  background-size: 20px 20px;
+  background-repeat: no-repeat;
+  background-position-y: center;
+  
+  &:hover {
+    filter: invert(.4);
   }
 }
 

--- a/www/styles/theme.css
+++ b/www/styles/theme.css
@@ -39,7 +39,7 @@ h2, h3, h4, h5 {
   color: #1d337a;
 }
 
-ul {
+ul, ol {
   padding-left: 20px;
 }
 
@@ -59,6 +59,11 @@ a {
   & .step {
     margin: 2px;
   }
+}
+
+p > code {
+  color: #2D3D3A;
+  font-weight: 800;
 }
 
 .gwd-content-wrapper {


### PR DESCRIPTION
## Related Issue
#432

## Summary of Changes

* Fix shelf not expanding properly
* Fix page headers not being linked (markdown plugins not being executed in unified.js)
* Fixed `<ol>`
* Fixed missing link icons on headers (order of markdown plugins + merged postcss from release/0.10.0 branch)
* Fixed inline code block highlighting
* brought back our markdown config tests from master
* Fixed linkHeadings not being respected because not using our previous graphql query
* Fixed expanded subitems not linking to the menus page + anchor, rather than page it was initially clicked on