### PR TITLE
fix duplicate path seperator

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -224,7 +224,7 @@ module.exports = getRollupConfig = async (compilation) => {
 
   return [{
     // TODO Avoid .greenwood/ directory, do everything in public/?
-    input: `${scratchDir}/**/*.html`,
+    input: `${scratchDir}**/*.html`,
     // preserveEntrySignatures: false,
     output: { 
       dir: outputDir,


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #460 

## Summary of Changes
1. Fixed bug with duplicate `//` path separator breaking **npm** clients when using **npm** scripts