### PR TITLE
better handling for pages with index in their name

### DIFF
--- a/packages/cli/src/transforms/transform.md.js
+++ b/packages/cli/src/transforms/transform.md.js
@@ -26,7 +26,7 @@ class MDTransform extends TransformInterface {
       ? `${workspace}/pages${url}index`
       : `${workspace}/pages${url.replace('.html', '')}`;
 
-    return fs.existsSync(`${barePath}.md`) || fs.existsSync(`${barePath.replace('/index', '.md')}`);
+    return fs.existsSync(`${barePath}.md`) || fs.existsSync(`${barePath.substring(0, barePath.lastIndexOf('/index'))}.md`);
   }
 
   async applyTransform() {
@@ -43,11 +43,10 @@ class MDTransform extends TransformInterface {
           : `${workspace}/pages${url.replace('.html', '')}`;
           
         // TODO all this lookup could probably be handled a bit more gracefully perhaps?
-        // console.debug('this route exists as markdown');
         const markdownPath = fs.existsSync(`${barePath}.md`)
           ? `${barePath}.md`
-          : fs.existsSync(`${barePath.replace('/index', '.md')}`)
-            ? `${barePath.replace('/index', '.md')}`
+          : fs.existsSync(`${barePath.substring(0, barePath.lastIndexOf('/index'))}.md`)
+            ? `${barePath.substring(0, barePath.lastIndexOf('/index'))}.md`
             : `${workspace}/pages${url.replace('/index.html', '.md')}`;
         const markdownContents = await fsp.readFile(markdownPath, 'utf-8');
         const rehypePlugins = [];

--- a/packages/cli/test/cases/build.default.workspace-user-directory-mapping/build.default.workspace-user-directory-mapping.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-user-directory-mapping/build.default.workspace-user-directory-mapping.spec.js
@@ -18,12 +18,15 @@
  *     header/
  *       header.js
  *   pages/
- *     about.md
+ *     plugins/
+ *       index-hooks.md
+ *       index.md
  *     index.md
+ *     pages.md
  *   services/
- *     components.js
  *     pages/
  *       pages.js
+ *     components.js
  *   templates/
  *     page.html
  */
@@ -158,8 +161,7 @@ describe('Build Greenwood With: ', function() {
         expect(p.textContent).to.be.equal('Lorum Ipsum');
       });
 
-      // TODO - https://github.com/ProjectEvergreen/greenwood/issues/456
-      xit('should have the expected content in the <body> of the plugins hook index.html with index in the route name', function() {
+      it('should have the expected content in the <body> of the plugins hook index.html with index in the route name', function() {
         const h2 = pluginHooksIndexPageDom.window.document.querySelector('body h2');
         const p = pluginHooksIndexPageDom.window.document.querySelector('body p');
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #455 

> _Will track in Trello for post 1.0 release some ways to refactor / clean up a lot of this repeated page look up logic, like we have in the markdown / HTML transforms, as well as in the [graph lifecycle](https://github.com/ProjectEvergreen/greenwood/blob/release/0.10.0/packages/cli/src/lifecycles/graph.js#L38).  Maybe some sort of shared utility so we can avoid duplications, or at the very least, maybe this is a case to merge markdown and HTML transforms?_

## Summary of Changes
1. Better checking for pages that may include **index** as part of the page name (non "destructive" approach)
1. Enabled tests to verify the same
1. Although will be deprecated, _Plugins -> Index Hooks_ docs are now working again
<img width="1680" alt="Screen Shot 2020-12-31 at 1 43 09 PM" src="https://user-images.githubusercontent.com/895923/103422256-85e81f80-4b6e-11eb-8c0f-ff11d09e94dd.png">