### PR TITLE
Chore/pin netlify node version v12.13.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,6 @@
 
 [build.processing]
   skip_processing = true
+
+[build.environment]
+  NODE_VERSION = "12.13.0"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Per [observations upgrading the Getting Started repo](https://github.com/ProjectEvergreen/greenwood-getting-started/pull/22#issuecomment-770310483), pinning Netlify to build on NodeJS v12.  Also updates #428 

## Summary of Changes
1. Updated _netlify.toml_ to NodeJS `v12.13.0`