### PR TITLE
Enhancement/issue 434 expand script style link tag production bundling

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,7 +33,6 @@
     "cssnano": "^4.1.10",
     "es-module-shims": "^0.5.2",
     "front-matter": "^4.0.2",
-    "htmlparser2": "^4.1.0",
     "koa": "^2.13.0",
     "livereload": "^0.9.1",
     "markdown-toc": "^1.2.0",

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -298,9 +298,7 @@ function greenwoodHtmlPlugin(compilation) {
 
     // crawl through all entry HTML files and map bundled JavaScript and CSS filenames 
     // back to original <script> / <link> tags and update to their bundled filename in the HTML
-    generateBundle(outputOptions, bundles) {
-      const mappedBundles = new Map();
-      
+    generateBundle(outputOptions, bundles) {      
       for (const bundleId of Object.keys(bundles)) {
         const bundle = bundles[bundleId];
 
@@ -327,16 +325,6 @@ function greenwoodHtmlPlugin(compilation) {
 
                 if (facadeModuleId && facadeModuleId.indexOf(pathToMatch) > 0) {
                   newHtml = newHtml.replace(src, `/${innerBundleId}`);
-                } else {
-                  // TODO better testing
-                  // TODO no magic strings
-                  if (innerBundleId.indexOf('.greenwood/') < 0 && !mappedBundles.get(innerBundleId)) {
-                    // console.debug('NEW BUNDLE TO INJECT!');
-                    newHtml = newHtml.replace(/<script type="module" src="(.*)"><\/script>/, `
-                      <script type="module" src="/${innerBundleId}"></script>
-                    `);
-                    mappedBundles.set(innerBundleId, true);
-                  }
                 }
               }
             }

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -216,7 +216,7 @@ function greenwoodHtmlPlugin(compilation) {
             }
 
             // TODO handle auto expanding deeper paths
-            const filePath = path.join(userWorkspace, href);
+            const filePath = path.join(userWorkspace, href.replace('../', './'));
             const source = fs.readFileSync(filePath, 'utf-8');
             const to = `${outputDir}/${href}`;
             const hash = crypto.createHash('md5').update(source, 'utf8').digest('hex');

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -390,7 +390,7 @@ function greenwoodHtmlPlugin(compilation) {
               for (const innerBundleId of Object.keys(bundles)) {
                 if (innerBundleId.indexOf(`-${tokenSuffix}`) > 0 && path.extname(innerBundleId) === '.js') {           
                   const bundledSource = fs.readFileSync(path.join(outputDir, innerBundleId), 'utf-8')
-                    .replace(/.\//g, '/'); // force absolute paths
+                    .replace(/\.\//g, '/'); // force absolute paths
                   html = html.replace(scriptTag.rawText, bundledSource);
                 }
               }

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -149,7 +149,6 @@ function greenwoodHtmlPlugin(compilation) {
         });
         const headScripts = root.querySelectorAll('script');
         const headLinks = root.querySelectorAll('link');
-        // const headStyles = root.querySelectorAll('style');
     
         // TODO handle deeper paths. e.g. ../../../
         headScripts.forEach((scriptTag) => {
@@ -159,8 +158,9 @@ function greenwoodHtmlPlugin(compilation) {
           if (parsedAttributes.type === 'module' && parsedAttributes.src && !mappedScripts.get(parsedAttributes.src)) {
             const { src } = parsedAttributes;
 
-            // TODO avoid using src and set it to the value of rollup fileName
-            // since user paths can still be the same file, e.g.  ../theme.css and ./theme.css are still the same file
+            // TODO avoid using href and set it to the value of rollup fileName instead
+            // since user paths can still be the same file, 
+            // e.g.  ../theme.css and ./theme.css are still the same file
             mappedScripts.set(src, true);
 
             const srcPath = src.replace('../', './');
@@ -191,8 +191,9 @@ function greenwoodHtmlPlugin(compilation) {
               // have to write a file for rollup?
               fs.writeFileSync(path.join(scratchDir, filename), source);
 
-              // TODO avoid using src and set it to the value of rollup fileName
-              // since user paths can still be the same file, e.g.  ../theme.css and ./theme.css are still the same file
+              // TODO avoid using href and set it to the value of rollup fileName instead
+              // since user paths can still be the same file, 
+              // e.g.  ../theme.css and ./theme.css are still the same file
               mappedScripts.set(id, true);
 
               this.emitFile({
@@ -203,8 +204,6 @@ function greenwoodHtmlPlugin(compilation) {
               });
             }
           }
-
-          // TODO handle <script type="module" src="@bare-path/specifier"></script>
         });
     
         headLinks.forEach((linkTag) => {
@@ -231,7 +230,7 @@ function greenwoodHtmlPlugin(compilation) {
               .replace('../', '')
               .replace('./', '');
 
-            if (!fs.existsSync(path.dirname(to))) {
+            if (!fs.existsSync(path.dirname(to)) && href.indexOf(tokenNodeModules) < 0) {
               fs.mkdirSync(path.dirname(to), {
                 recursive: true
               });
@@ -249,34 +248,7 @@ function greenwoodHtmlPlugin(compilation) {
               source
             };
           }
-    
-          // TODO handle <style>/* some inline CSS */</style> - as part of generateBundle?
         });
-
-        // TODO handle <style>/* some inline CSS code */</style>
-        // how to avoid Puppeteer styles?
-        // headStyles.map((styleTag) => {
-        //   const cssSource = styleTag.childNodes.map(node => node.rawText).join();
-        //   const id = Buffer.from(cssSource).toString('base64').slice(0, 8).toLowerCase();
-        //   const filename = `${id}-${tokenSuffix}.css`;
-          
-        //   if (cssSource !== '' && !mappedStyles[filename]) {
-        //     const fileName = `${id}-${tokenSuffix}.css`;
-        //     const source = `
-        //       /*! ${filename} */
-        //       ${cssSource}
-        //     `; // .trim();
-
-        //     // TODO avoid using src and set it to the value of rollup fileName
-        //     // since user paths can still be the same file, e.g.  ../theme.css and ./theme.css are still the same file
-        //     mappedStyles[filename] = {
-        //       type: 'asset',
-        //       fileName,
-        //       name: id,
-        //       source
-        //     };
-        //   }
-        // });
       }
 
       // this is a giant work around because PostCSS and some plugins can only be run async
@@ -381,7 +353,6 @@ function greenwoodHtmlPlugin(compilation) {
             style: true
           });
           const headScripts = root.querySelectorAll('script');
-          const headStyles = root.querySelectorAll('style');
 
           headScripts.forEach((scriptTag) => {
             const parsedAttributes = parseTagForAttributes(scriptTag);
@@ -395,27 +366,6 @@ function greenwoodHtmlPlugin(compilation) {
                   html = html.replace(scriptTag.rawText, bundledSource);
 
                   scratchFiles[innerBundleId] = true;
-                }
-              }
-            }
-          });
-
-          // TODO - support optimizzing <style> /* some code */ </style> and not confuse with puppeteer styles
-          headStyles.forEach((styleTag) => {
-            const cssSource = styleTag.childNodes.map(node => node.rawText).join();
-            
-            if (cssSource !== '') {
-              for (const innerBundleId of Object.keys(bundles)) {
-                if (innerBundleId.indexOf(`-${tokenSuffix}`) > 0 && path.extname(innerBundleId) === '.css') {             
-                  // console.debug('!!!!!!!! found an inline style tag, swap out with optimized from disk');
-                  // const bundledSource = fs.readFileSync(path.join(outputDir, innerBundleId), 'utf-8');
-                  // html = html.replace(cssSource, bundledSource);
-                  // console.debug('****************');
-                  // console.debug('bundledSource', bundledSource);
-                  // console.debug('css source', cssSource);
-                  // if()
-                  // console.debug('newHtml', newHtml);
-                  // console.debug('****************');
                 }
               }
             }

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -79,7 +79,7 @@ function greenwoodWorkspaceResolver (compilation) {
 
   return {
     name: 'greenwood-workspace-resolver',
-    resolveId(source) {      
+    resolveId(source) {
       // TODO better way to handle relative paths?  happens in generateBundle too
       if ((source.indexOf('./') === 0 || source.indexOf('/') === 0) && path.extname(source) !== '.html' && fs.existsSync(path.join(userWorkspace, source))) {        
         return source.replace(source, path.join(userWorkspace, source));
@@ -149,6 +149,7 @@ function greenwoodHtmlPlugin(compilation) {
         });
         const headScripts = root.querySelectorAll('script');
         const headLinks = root.querySelectorAll('link');
+        const headStyles = root.querySelectorAll('style');
     
         // TODO handle deeper paths. e.g. ../../../
         headScripts.forEach((scriptTag) => {
@@ -243,6 +244,30 @@ function greenwoodHtmlPlugin(compilation) {
     
           // TODO handle <style>/* some inline CSS */</style> - as part of generateBundle?
         });
+
+        // handle <style>/* some inline CSS code */</style>
+        Promise.all(headStyles.map(async (styleTag) => {
+          const cssSource = styleTag.childNodes.map(node => node.rawText).join();
+          const id = Buffer.from(cssSource).toString('base64').slice(0, 8).toLowerCase();
+          const filename = `${id}-${tokenSuffix}.css`;
+          
+          if (cssSource !== '' && !mappedStyles[filename]) {
+            const fileName = `${id}-${tokenSuffix}.css`;
+            const source = `
+              /*! ${filename} */
+              ${cssSource}
+            `; // .trim();
+
+            // TODO avoid using src and set it to the value of rollup fileName
+            // since user paths can still be the same file, e.g.  ../theme.css and ./theme.css are still the same file
+            mappedStyles[filename] = {
+              type: 'asset',
+              fileName,
+              name: id,
+              source
+            };
+          }
+        }));
       }
 
       // this is a giant work around because PostCSS and some plugins can only be run async
@@ -321,7 +346,7 @@ function greenwoodHtmlPlugin(compilation) {
             const parsedAttributes = parseTagForAttributes(linkTag);
             const { href } = parsedAttributes;
   
-            // handle <link rel="stylesheet" src="some/path.css"></link>
+            // handle <link rel="stylesheet" src="/some/path.css"></link>
             if (parsedAttributes.rel === 'stylesheet') {
               for (const bundleId2 of Object.keys(bundles)) {
                 if (bundleId2.indexOf('.css') > 0) {
@@ -345,6 +370,7 @@ function greenwoodHtmlPlugin(compilation) {
       // TODO looping over bundles twice is wildly inneficient, should refactor and safe references once
       for (const bundleId of Object.keys(bundles)) {
         const bundle = bundles[bundleId];
+        console.debug('bundleId@@@@@@', bundleId);
 
         // TODO handle (!) Generated empty chunks .greenwood/about, .greenwood/index
         if (bundle.isEntry && path.extname(bundle.facadeModuleId) === '.html') {
@@ -352,9 +378,11 @@ function greenwoodHtmlPlugin(compilation) {
           const htmlPath = bundle.facadeModuleId.replace('.greenwood', 'public');
           const html = fs.readFileSync(htmlPath, 'utf-8');
           const root = htmlparser.parse(html, {
-            script: true
+            script: true,
+            style: true
           });
           const headScripts = root.querySelectorAll('script');
+          const headStyles = root.querySelectorAll('style');
 
           headScripts.forEach((scriptTag) => {
             const parsedAttributes = parseTagForAttributes(scriptTag);
@@ -362,7 +390,7 @@ function greenwoodHtmlPlugin(compilation) {
             // handle <script type="module"> /* inline code */ </script>
             if (parsedAttributes.type === 'module' && scriptTag.rawText !== '') {
               for (const innerBundleId of Object.keys(bundles)) {
-                if (innerBundleId.indexOf(`-${tokenSuffix}`) > 0) {             
+                if (innerBundleId.indexOf(`-${tokenSuffix}`) > 0 && path.extname(innerBundleId) === '.js') {             
                   const bundledSource = fs.readFileSync(path.join(outputDir, innerBundleId), 'utf-8');
                   const newHtml = html.replace(scriptTag.rawText, bundledSource);                  
 
@@ -371,7 +399,28 @@ function greenwoodHtmlPlugin(compilation) {
               }
             }
           });
->>>>>>> handling bundling of inline script tags
+
+          headStyles.forEach((styleTag) => {
+            const cssSource = styleTag.childNodes.map(node => node.rawText).join();
+            
+            if (cssSource !== '') {
+              for (const innerBundleId of Object.keys(bundles)) {
+                if (innerBundleId.indexOf(`-${tokenSuffix}`) > 0 && path.extname(innerBundleId) === '.css') {             
+                  console.debug('!!!!!!!! found an inline style tag, swap out with optimized from disk');
+                  const bundledSource = fs.readFileSync(path.join(outputDir, innerBundleId), 'utf-8');
+                  const newHtml = html.replace(cssSource, bundledSource);
+                  // console.debug('****************');
+                  // console.debug('bundledSource', bundledSource);
+                  // console.debug('css source', cssSource);
+                  // if()
+                  // console.debug('newHtml', newHtml);
+                  console.debug('****************');
+
+                  fs.writeFileSync(htmlPath, newHtml);
+                }
+              }
+            }
+          });
         }
       }
     }

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -1,5 +1,4 @@
 const Buffer = require('buffer').Buffer;
-const crypto = require('crypto');
 const fs = require('fs');
 const htmlparser = require('node-html-parser');
 const json = require('@rollup/plugin-json');
@@ -219,7 +218,7 @@ function greenwoodHtmlPlugin(compilation) {
             const filePath = path.join(userWorkspace, href.replace('../', './'));
             const source = fs.readFileSync(filePath, 'utf-8');
             const to = `${outputDir}/${href}`;
-            const hash = crypto.createHash('md5').update(source, 'utf8').digest('hex');
+            const hash = Buffer.from(source).toString('base64').toLowerCase();
             const fileName = href
               .replace('.css', `.${hash.slice(0, 8)}.css`)
               .replace('../', '')

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -11,7 +11,7 @@ const replace = require('@rollup/plugin-replace');
 const { terser } = require('rollup-plugin-terser');
 
 const tokenSuffix = 'scratch';
-// const tokenNodeModules = 'node_modules/';
+const tokenNodeModules = 'node_modules/';
 
 const parseTagForAttributes = (tag) => {
   return tag.rawAttrs.split(' ').map((attribute) => {
@@ -164,14 +164,14 @@ function greenwoodHtmlPlugin(compilation) {
             mappedScripts.set(src, true);
 
             const srcPath = src.replace('../', './');
-            const basePath = srcPath.indexOf('node_modules/') >= 0
+            const basePath = srcPath.indexOf(tokenNodeModules) >= 0
               ? projectDirectory
               : userWorkspace;
             const source = fs.readFileSync(path.join(basePath, srcPath), 'utf-8');
 
             this.emitFile({
               type: 'chunk',
-              id: srcPath.replace('/node_modules', path.join(projectDirectory, 'node_modules')),
+              id: srcPath.replace('/node_modules', path.join(projectDirectory, tokenNodeModules)),
               name: srcPath.split('/')[srcPath.split('/').length - 1].replace('.js', ''),
               source
             });
@@ -219,7 +219,7 @@ function greenwoodHtmlPlugin(compilation) {
             }
 
             // TODO handle auto expanding deeper paths
-            const basePath = href.indexOf('node_modules/') >= 0
+            const basePath = href.indexOf(tokenNodeModules) >= 0
               ? projectDirectory
               : userWorkspace;
             const filePath = path.join(basePath, href.replace('../', './'));
@@ -242,7 +242,7 @@ function greenwoodHtmlPlugin(compilation) {
             // e.g.  ../theme.css and ./theme.css are still the same file
             mappedStyles[parsedAttributes.href] = {
               type: 'asset',
-              fileName: fileName.indexOf('node_modules/') >= 0
+              fileName: fileName.indexOf(tokenNodeModules) >= 0
                 ? path.basename(fileName)
                 : fileName,
               name: href,
@@ -286,7 +286,7 @@ function greenwoodHtmlPlugin(compilation) {
       Promise.all(Object.keys(mappedStyles).map(async (assetKey) => {
         const asset = mappedStyles[assetKey];
         const source = mappedStyles[assetKey].source;
-        const basePath = asset.name.indexOf('node_modules/') >= 0
+        const basePath = asset.name.indexOf(tokenNodeModules) >= 0
           ? projectDirectory
           : userWorkspace;
         const result = await postcss()

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -97,7 +97,7 @@ function greenwoodWorkspaceResolver (compilation) {
 
 // https://github.com/rollup/rollup/issues/2873
 function greenwoodHtmlPlugin(compilation) {
-  const { userWorkspace, outputDir, scratchDir  } = compilation.context;
+  const { userWorkspace, outputDir, scratchDir } = compilation.context;
   const customResources = compilation.config.plugins.filter((plugin) => {
     return plugin.type === 'resource';
   }).map((plugin) => {
@@ -367,12 +367,10 @@ function greenwoodHtmlPlugin(compilation) {
       }
     },
 
-    writeBundle(outputOptions, bundles) {      
-      // TODO looping over bundles twice is wildly inneficient, should refactor and safe references once
+    async writeBundle(outputOptions, bundles) {
       for (const bundleId of Object.keys(bundles)) {
         const bundle = bundles[bundleId];
 
-        // TODO handle (!) Generated empty chunks .greenwood/about, .greenwood/index
         if (bundle.isEntry && path.extname(bundle.facadeModuleId) === '.html') {
           // TODO this seems hacky; hardcoded dirs :D
           const htmlPath = bundle.facadeModuleId.replace('.greenwood', 'public');
@@ -421,6 +419,11 @@ function greenwoodHtmlPlugin(compilation) {
           });
 
           fs.writeFileSync(htmlPath, html);
+        } else {
+          const sourcePath = `${outputDir}/${bundleId}`;
+          const optimizedSource = await getOptimizedSource(sourcePath, customResources, compilation);
+  
+          await fs.promises.writeFile(sourcePath, optimizedSource);
         }
       }
     }

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -188,7 +188,6 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected inline node_modules content in the inline script', async function() {
         const inlineScriptTag = dom.window.document.querySelector('head > script:not([src])');
         
-        console.debug('inlineScriptTag', inlineScriptTag);
         expect(inlineScriptTag.textContent).to.contain('import"/lit-element.397ae7ce.js"');
       });
 

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -1,6 +1,6 @@
 /*
  * Use Case
- * Run Greenwood with and loading different module types to ensure support for ESM and MJS node modules resolution.
+ * Run Greenwood with and loading different references to node_module types to ensure proper support.
  *
  * Uaer Result
  * Should generate a bare bones Greenwood build without erroring.
@@ -124,7 +124,13 @@ describe('Build Greenwood With: ', function() {
       name: 'package.json'
     },
 
-    ...pwaHelpersLibs
+    ...pwaHelpersLibs,
+
+    {
+      // prism.css
+      dir: 'node_modules/prismjs/themes/',
+      name: 'prism-tomorrow.css'
+    }
 
     ]);
   });
@@ -148,16 +154,12 @@ describe('Build Greenwood With: ', function() {
         expect(mainScriptTags.length).to.be.equal(1);
       });
 
-      it('should have the expected number of bundled .js files in the output directory', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, '*.js'))).to.have.lengthOf(2);
+      it('should have the total expected number of .js file in the output directory', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, '*.js'))).to.have.lengthOf(4);
       });
 
       it('should have the expected main.js file in the output directory', async function() {
         expect(await glob.promise(path.join(this.context.publicDir, 'main.*.js'))).to.have.lengthOf(1);
-      });
-
-      it('should have the expected lit-element.js file in the output directory', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, 'lit-element.*.js'))).to.have.lengthOf(1);
       });
 
       it('should have the expected output from main.js for lit-element (ESM) in the page output', async function() {
@@ -189,17 +191,26 @@ describe('Build Greenwood With: ', function() {
       });
     });
 
-    describe('<script> tag within inline code in the <head> tag', function() {
-      it('should have one <script src="..."> tag for main.js loaded in the <head> tag', function() {
+    describe('<script> tag with inline code in the <head> tag', function() {
+      it('should have one <script> tag with inline code loaded in the <head> tag', function() {
         const scriptTagsInline = dom.window.document.querySelectorAll('head > script:not([src])');
         
         expect(scriptTagsInline.length).to.be.equal(1);
       });
 
+      it('should have the expected lit-element.js file in the output directory', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, 'lit-element.*.js'))).to.have.lengthOf(1);
+      });
+
+      it('should have the expected lit-html.js files in the output directory', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, 'lit-html.cdc8faae.js'))).to.have.lengthOf(1);
+      });
+
       it('should have the expected inline node_modules content in the inline script', async function() {
         const inlineScriptTag = dom.window.document.querySelector('head > script:not([src])');
         
-        expect(inlineScriptTag.textContent).to.contain('import"/lit-element.397ae7ce.js"');
+        expect(inlineScriptTag.textContent).to
+          .contain('import"/lit-html.d69ea26f.js";import"/lit-element.ea26fec7.js";document.getElementsByClassName("output-script-inline")[0].innerHTML="script tag module inline"');
       });
 
       it('should have the expected output from inline <script> tag in the page output', async function() {
@@ -207,6 +218,36 @@ describe('Build Greenwood With: ', function() {
         
         expect(inlineScriptOutput.length).to.be.equal(1);
         expect(inlineScriptOutput[0].textContent).to.be.equal('script tag module inline');
+      });
+    });
+
+    describe('<script src="..."> with reference to node_modules/ path in the <head> tag', function() {
+      it('should have one <script src="..."> tag for lit-html loaded in the <head> tag', function() {
+        const scriptTagsInline = dom.window.document.querySelectorAll('head > script[src]');
+        const litScriptTags = Array.prototype.slice.call(scriptTagsInline).filter(script => {
+          return (/lit.*.js/).test(script.src);
+        });
+
+        expect(litScriptTags.length).to.be.equal(1);
+      });
+
+      it('should have the expected lit-html.js files in the output directory', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, 'lit-html.d69ea26f.js'))).to.have.lengthOf(1);
+      });
+    });
+
+    describe('<link rel="stylesheet" href="..."> with reference to node_modules/ path in the <head> tag', function() {
+      it('should have one <link href="..."> tag in the <head> tag', function() {
+        const linkTags = dom.window.document.querySelectorAll('head > link[href]');
+        const prismLinkTag = Array.prototype.slice.call(linkTags).filter(link => {
+          return (/prism-tomorrow.*.css/).test(link.href);
+        });
+
+        expect(prismLinkTag.length).to.be.equal(1);
+      });
+
+      it('should have the expected prism.css file in the output directory', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, 'prism-tomorrow.*.css'))).to.have.lengthOf(1);
       });
     });
   });

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -138,22 +138,17 @@ describe('Build Greenwood With: ', function() {
       dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, 'index.html'));
     });
 
-    describe('Script tag in the <head> tag', function() {
-      it('should have one <script> tag for main.js loaded in the <head> tag', function() {
-        const scriptTags = dom.window.document.querySelectorAll('head > script');
-        const mainScriptTag = Array.prototype.slice.call(scriptTags).filter(script => {
-          return (/main.*.js/).test(script.src);
-        });
+    describe('<script src="..."> tag in the <head> tag', function() {
+      it('should have one <script src="..."> tag for main.js loaded in the <head> tag', function() {
+        const scriptTags = dom.window.document.querySelectorAll('head > script[src]');
         
-        expect(mainScriptTag.length).to.be.equal(1);
+        expect(scriptTags.length).to.be.equal(1);
       });
 
       it('should have the expected main.js file in the output directory', async function() {
         expect(await glob.promise(path.join(this.context.publicDir, 'main.*.js'))).to.have.lengthOf(1);
       });
-    });
 
-    describe('exported node_module content in the body of the page', function() {
       it('should have the expected output from main.js for lit-element (ESM) in the page output', async function() {
         const litOutput = dom.window.document.querySelectorAll('body > .output-lit');
         
@@ -180,6 +175,28 @@ describe('Build Greenwood With: ', function() {
         
         expect(reduxOutput.length).to.be.equal(1);
         expect(reduxOutput[0].textContent).to.be.equal('import from redux ZnVuY3Rpb24gbyh0');
+      });
+    });
+
+    describe('<script> tag within inline code in the <head> tag', function() {
+      it('should have one <script src="..."> tag for main.js loaded in the <head> tag', function() {
+        const scriptTagsInline = dom.window.document.querySelectorAll('head > script:not([src])');
+        
+        expect(scriptTagsInline.length).to.be.equal(1);
+      });
+
+      it('should have the expected inline node_modules content in the inline script', async function() {
+        const inlineScriptTag = dom.window.document.querySelector('head > script:not([src])');
+        
+        console.debug('inlineScriptTag', inlineScriptTag);
+        expect(inlineScriptTag.textContent).to.contain('import"/lit-element.397ae7ce.js"');
+      });
+
+      it('should have the expected output from inline <script> tag in the page output', async function() {
+        const inlineScriptOutput = dom.window.document.querySelectorAll('body > .output-script-inline');
+        
+        expect(inlineScriptOutput.length).to.be.equal(1);
+        expect(inlineScriptOutput[0].textContent).to.be.equal('script tag module inline');
       });
     });
   });

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -148,8 +148,16 @@ describe('Build Greenwood With: ', function() {
         expect(mainScriptTags.length).to.be.equal(1);
       });
 
+      it('should have the expected number of bundled .js files in the output directory', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, '*.js'))).to.have.lengthOf(2);
+      });
+
       it('should have the expected main.js file in the output directory', async function() {
         expect(await glob.promise(path.join(this.context.publicDir, 'main.*.js'))).to.have.lengthOf(1);
+      });
+
+      it('should have the expected lit-element.js file in the output directory', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, 'lit-element.*.js'))).to.have.lengthOf(1);
       });
 
       it('should have the expected output from main.js for lit-element (ESM) in the page output', async function() {

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -141,8 +141,11 @@ describe('Build Greenwood With: ', function() {
     describe('<script src="..."> tag in the <head> tag', function() {
       it('should have one <script src="..."> tag for main.js loaded in the <head> tag', function() {
         const scriptTags = dom.window.document.querySelectorAll('head > script[src]');
+        const mainScriptTags = Array.prototype.slice.call(scriptTags).filter(script => {
+          return (/main.*.js/).test(script.src);
+        });
         
-        expect(scriptTags.length).to.be.equal(1);
+        expect(mainScriptTags.length).to.be.equal(1);
       });
 
       it('should have the expected main.js file in the output directory', async function() {

--- a/packages/cli/test/cases/build.default.import-node-modules/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.import-node-modules/src/pages/index.html
@@ -4,12 +4,13 @@
   <head>
     <!-- TODO have to use forward slash / for path references?  translate on the fly in serve.js? -->
     <script type="module" src="../scripts/main.js"></script>
-
     <script type="module">
       import { html } from 'lit-element';
 
       document.getElementsByClassName('output-script-inline')[0].innerHTML = 'script tag module inline';
     </script>
+    <script type="module" src="/node_modules/lit-html/lit-html.js"></script>
+    <link rel="stylesheet" href="/node_modules/prismjs/themes/prism-tomorrow.css"></link>
 
   </head>
 

--- a/packages/cli/test/cases/build.default.import-node-modules/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.import-node-modules/src/pages/index.html
@@ -4,6 +4,13 @@
   <head>
     <!-- TODO have to use forward slash / for path references?  translate on the fly in serve.js? -->
     <script type="module" src="../scripts/main.js"></script>
+
+    <script type="module">
+      import { html } from 'lit-element';
+
+      document.getElementsByClassName('output-script-inline')[0].innerHTML = 'script tag module inline';
+    </script>
+
   </head>
 
   <body>
@@ -11,6 +18,7 @@
     <span class="output-lodash"></span>
     <span class="output-pwa"></span>
     <span class="output-redux"></span>
+    <span class="output-script-inline"></span>
   </body>
 
 </html>

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -18,6 +18,7 @@
  *   scripts/
  *     main.js
  *   styles/
+ *     main.css
  *     
  */
 const expect = require('chai').expect;
@@ -32,7 +33,7 @@ describe('Build Greenwood With: ', function() {
   let setup;
 
   before(async function() {
-    setup = new TestBed(true);
+    setup = new TestBed();
 
     this.context = await setup.setupTestBed(__dirname);
   });
@@ -49,11 +50,12 @@ describe('Build Greenwood With: ', function() {
     describe('<script type="module" src="..."></script> tag in the <head>', function() {
       it('should have one <script> tag for main.js loaded in the <head>', function() {
         const scriptTags = dom.window.document.querySelectorAll('head > script[src]');
-        const mainScriptTag = Array.prototype.slice.call(scriptTags).filter(script => {
-          return (/.*.js/).test(script.src);
-        });
+        // TODO
+        // const mainScriptTag = Array.prototype.slice.call(scriptTags).filter(script => {
+        //   return (/main.*.js/).test(script.src);
+        // });
         
-        expect(mainScriptTag.length).to.be.equal(1);
+        expect(scriptTags.length).to.be.equal(1);
       });
 
       it('should have the expected main.js file in the output directory', async function() {

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -50,16 +50,28 @@ describe('Build Greenwood With: ', function() {
     describe('<script type="module" src="..."></script> tag in the <head>', function() {
       it('should have one <script> tag for main.js loaded in the <head>', function() {
         const scriptTags = dom.window.document.querySelectorAll('head > script[src]');
-        // TODO
-        // const mainScriptTag = Array.prototype.slice.call(scriptTags).filter(script => {
-        //   return (/main.*.js/).test(script.src);
-        // });
+        const mainScriptTags = Array.prototype.slice.call(scriptTags).filter(script => {
+          return (/main.*.js/).test(script.src);
+        });
         
-        expect(scriptTags.length).to.be.equal(1);
+        expect(mainScriptTags.length).to.be.equal(1);
+      });
+
+      it('should have one <script> tag for other.js loaded in the <head>', function() {
+        const scriptTags = dom.window.document.querySelectorAll('head > script[src]');
+        const mainScriptTags = Array.prototype.slice.call(scriptTags).filter(script => {
+          return (/other.*.js/).test(script.src);
+        });
+        
+        expect(mainScriptTags.length).to.be.equal(1);
       });
 
       it('should have the expected main.js file in the output directory', async function() {
         expect(await glob.promise(path.join(this.context.publicDir, 'main.*.js'))).to.have.lengthOf(1);
+      });
+
+      it('should have the expected main.js file in the output directory', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, 'other.*.js'))).to.have.lengthOf(1);
       });
 
       it('should have the expected output from main.js file in index.html', async function() {

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -1,0 +1,133 @@
+/*
+ * Use Case
+ * Run Greenwood with various usages of JavaScript (<script>) and CSS (<style> / <link>) tags, with inlined or file based content.
+ *
+ * Uaer Result
+ * Should generate a bare bones Greenwood build without erroring.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * None
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     index.html
+ *   scripts/
+ *     main.js
+ *   styles/
+ *     
+ */
+const expect = require('chai').expect;
+const glob = require('glob-promise');
+const { JSDOM } = require('jsdom');
+const path = require('path');
+const TestBed = require('../../../../../test/test-bed');
+
+describe('Build Greenwood With: ', function() {
+  const LABEL = 'Importing JavaScript and CSS using <script>, <style>, and <link> tags';
+
+  let setup;
+
+  before(async function() {
+    setup = new TestBed(true);
+
+    this.context = await setup.setupTestBed(__dirname);
+  });
+
+  describe(LABEL, function() {
+    let dom;
+
+    before(async function() {
+      await setup.runGreenwoodCommand('build');
+
+      dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, 'index.html'));
+    });
+
+    describe('<script type="module" src="..."></script> tag in the <head>', function() {
+      it('should have one <script> tag for main.js loaded in the <head>', function() {
+        const scriptTags = dom.window.document.querySelectorAll('head > script[src]');
+        const mainScriptTag = Array.prototype.slice.call(scriptTags).filter(script => {
+          return (/.*.js/).test(script.src);
+        });
+        
+        expect(mainScriptTag.length).to.be.equal(1);
+      });
+
+      it('should have the expected main.js file in the output directory', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, 'main.*.js'))).to.have.lengthOf(1);
+      });
+
+      it('should have the expected output from main.js file in index.html', async function() {
+        const scriptTagSrc = dom.window.document.querySelector('body > .output-script-src');
+
+        expect(scriptTagSrc.textContent).to.be.equal('script tag module with src');
+      });
+    });
+
+    describe('<script>...</script> tag in the <head>', function() {
+      it('should have one <script> tag with inline script in the <head>', function() {
+        const scriptTagInline = dom.window.document.querySelectorAll('head > script:not([src])');
+        
+        expect(scriptTagInline.length).to.be.equal(1);
+      });
+
+      it('should have the expected output from inline <script> tag in index.html', async function() {
+        const scriptTagSrc = dom.window.document.querySelector('body > .output-script-inline');
+
+        expect(scriptTagSrc.textContent).to.be.equal('script tag module inline');
+      });
+    });
+
+    describe('<style>...</style> tag in the <head>', function() {
+      it('should have one <style> tag in the <head>', function() {
+        const styleTags = dom.window.document.querySelectorAll('head > style');
+        
+        // first <style> tag comes from puppeteer output
+        expect(styleTags.length).to.be.equal(2);
+      });
+
+      it('should have the expected output from main.js file in index.html', async function() {
+        const styleTags = dom.window.document.querySelectorAll('head > style');
+
+        // first <style> tag comes from puppeteer output
+        expect(styleTags[1].textContent.replace(/\n/g, '').trim().replace(' ', '')).to.be.contain('p.output-style{        color: green;      }');
+      });
+
+      it('should have the color style for the output element', function() {
+        const output = dom.window.document.querySelector('body > p.output-style');
+        const computedStyle = dom.window.getComputedStyle(output);
+
+        expect(computedStyle.color).to.equal('green');
+      });
+    });
+
+    describe('<link rel="stylesheet" href="..."/> tag in the <head>', function() {
+      it('should have one <link> tag in the <head>', function() {
+        const linkTags = dom.window.document.querySelectorAll('head > link');
+        
+        expect(linkTags.length).to.be.equal(1);
+      });
+
+      it('should have the expected main.css file in the output directory', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, 'styles', 'main.*.css'))).to.have.lengthOf(1);
+      });
+
+      // JSDOM may not support this case of computing styles when using a <link> tag?
+      // https://github.com/jsdom/jsdom/issues/2986
+      xit('should have the color style for the output element', function() {
+        const output = dom.window.document.querySelector('body > p.output-link');
+        const computedStyle = dom.window.getComputedStyle(output);
+
+        expect(computedStyle.color).to.equal('blue');
+      });
+    });
+  });
+
+  after(function() {
+    setup.teardownTestBed();
+  });
+
+});

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -66,11 +66,15 @@ describe('Build Greenwood With: ', function() {
         expect(mainScriptTags.length).to.be.equal(1);
       });
 
+      it('should have the expected number of bundled .js files in the output directory', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, '*.js'))).to.have.lengthOf(2);
+      });
+
       it('should have the expected main.js file in the output directory', async function() {
         expect(await glob.promise(path.join(this.context.publicDir, 'main.*.js'))).to.have.lengthOf(1);
       });
 
-      it('should have the expected main.js file in the output directory', async function() {
+      it('should have the expected other.js file in the output directory', async function() {
         expect(await glob.promise(path.join(this.context.publicDir, 'other.*.js'))).to.have.lengthOf(1);
       });
 

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -142,6 +142,9 @@ describe('Build Greenwood With: ', function() {
         expect(computedStyle.color).to.equal('blue');
       });
     });
+
+    // TODO <script type="module" src="/node_modules/@evergreen-wc/eve-container/src/eve-container.js"></script>
+    // TODO <link rel="stylesheet" href="/node_modules/prismjs/themes/prism-tomorrow.css"></link>
   });
 
   after(function() {

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -142,9 +142,6 @@ describe('Build Greenwood With: ', function() {
         expect(computedStyle.color).to.equal('blue');
       });
     });
-
-    // TODO <script type="module" src="/node_modules/@evergreen-wc/eve-container/src/eve-container.js"></script>
-    // TODO <link rel="stylesheet" href="/node_modules/prismjs/themes/prism-tomorrow.css"></link>
   });
 
   after(function() {

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/src/pages/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en" prefix="og:http://ogp.me/ns#">
+
+  <head>
+    <!-- TODO have to use forward slash / for path references?  translate on the fly in serve.js? -->
+    <script type="module" src="../scripts/main.js"></script>
+    
+    <script type="module">
+      document.getElementsByClassName('output-script-inline')[0].innerHTML = 'script tag module inline';
+    </script>
+
+    <style>
+      p.output-style {
+        color: green;
+      }
+    </style>
+
+    <link rel="stylesheet" href="../styles/main.css"></link>
+  </head>
+
+  <body>
+    <p class="output-script-src"></p>
+    <p class="output-script-inline"></p>
+    <p class="output-style"></p>
+    <p class="output-link">Hi</p>
+  </body>
+
+</html>

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/src/pages/index.html
@@ -4,6 +4,7 @@
   <head>
     <!-- TODO have to use forward slash / for path references?  translate on the fly in serve.js? -->
     <script type="module" src="../scripts/main.js"></script>
+    <script type="module" src="../scripts/other.js"></script>
     
     <script type="module">
       document.getElementsByClassName('output-script-inline')[0].innerHTML = 'script tag module inline';

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/src/pages/index.html
@@ -22,7 +22,7 @@
     <p class="output-script-src"></p>
     <p class="output-script-inline"></p>
     <p class="output-style"></p>
-    <p class="output-link">Hi</p>
+    <p class="output-link"></p>
   </body>
 
 </html>

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/src/scripts/main.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/src/scripts/main.js
@@ -1,0 +1,1 @@
+document.getElementsByClassName('output-script-src')[0].innerHTML = 'script tag module with src';

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/src/scripts/other.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/src/scripts/other.js
@@ -1,0 +1,1 @@
+console.debug('hello world');

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/src/styles/main.css
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/src/styles/main.css
@@ -1,0 +1,3 @@
+.output-link {
+  color: blue;
+}

--- a/www/pages/docs/layouts.md
+++ b/www/pages/docs/layouts.md
@@ -135,3 +135,47 @@ And the following file output in the _public/_ directory
 ```
 
 > _See our [Front Matter Docs](/docs/front-matter#define-template) for more information on how you can extend fontmatter in **Greenwood**._
+
+## Scripts and Styles
+
+Since all pages and templates are just HTML with Greenwood, you can use `<script>`, `<style>`, and `<link>` tags as normal, referencing paths from your template to the location of the files in your project's workspace.
+
+For example, here is what a standard app template might look like:
+```html
+<!DOCTYPE html>
+<html lang="en" prefix="og:http://ogp.me/ns#">
+
+  <head>
+    <meta-outlet></meta-outlet>
+    <link rel="stylesheet" href="/styles/theme.css"/>
+    <script type="module" src="/components/app-header.js"></script>
+    <script type="module" src="/components/app-footer.js"></script>
+  </head>
+  
+  <body>
+    <app-header></app-header>
+      
+    <page-outlet></page-outlet>
+
+    <app-footer></app-footer>
+  </body>
+  
+</html>
+```
+
+And the directory structure for it:
+```shell
+.
+└── src
+      ├── components
+      │   ├── app-header.js
+      │   └── app-footer.js
+      ├── pages
+      │   ├── index.md
+      ├── styles
+      │   └── theme.css
+      ├── templates/
+          └── app.html
+```
+
+> _It is recommended to use the "file" based approaches for loading JavaScript and CSS; `<script src="...">` and `<link rel="stylesheet" href="...">` respectively.  This will allow Greenwood to optimize these assets during both development and build workflows.  However, inline `<script>` and `<style>` can both be super helpful for one-off cases, so in those cases we recommend only relying on "vanilla" JS / CSS syntax. For more context, examples, and background information, you can [review this PR](https://github.com/ProjectEvergreen/greenwood/pull/472)._

--- a/www/styles/page.css
+++ b/www/styles/page.css
@@ -1,5 +1,3 @@
-@import url('../../node_modules/prismjs/themes/prism-tomorrow.css');
-
 h3 {
   color: #2D3D3A;
   padding-top: 4rem;

--- a/www/templates/app.html
+++ b/www/templates/app.html
@@ -6,15 +6,7 @@
     <meta name='viewport' content='width=device-width, initial-scale=1'/>
     <meta-outlet></meta-outlet>
 
-    <!-- TODO how to import / register a component like below? -->
-    <script type="module">
-      import '@evergreen-wc/eve-container';
-    </script>
-    
-    <!-- TODO have to use / for path references?  translate on the fly in serve.js? -->
-    <script type="module" src="/components/footer/footer.js"></script>
-    <script type="module" src="/components/header/header.js"></script>
-
+    <link rel="stylesheet" href="/assets/fonts/source-sans-pro.css"></link>
     <link rel="stylesheet" href="/styles/theme.css"></link>
 
     <style>
@@ -22,6 +14,14 @@
         min-height: 100vh
       };
     </style>
+
+    <script type="module">
+      import '@evergreen-wc/eve-container';
+    </script>
+    
+    <!-- TODO have to use / for path references?  translate on the fly in serve.js? -->
+    <script type="module" src="/components/footer/footer.js"></script>
+    <script type="module" src="/components/header/header.js"></script>
     
   </head>
 

--- a/www/templates/page.html
+++ b/www/templates/page.html
@@ -3,9 +3,11 @@
 
   <head>
     <!-- TODO have to use forward slash / for path references?  translate on the fly in serve.js? -->
+    <link rel="stylesheet" href="/node_modules/prismjs/themes/prism-tomorrow.css"></link>
+    <link rel="stylesheet" href="/styles/page.css"></link>
+
     <script type="module" src="/components/shelf/shelf.js"></script>
     <script type="module" src="/components/scroll/scroll.js"></script>
-
     <script>
       window.onload = () => {
         const route = window.location.pathname.split('/')[1];
@@ -13,8 +15,6 @@
         document.getElementsByTagName('app-shelf')[0].setAttribute('page', route);
       }
     </script>
-
-    <link rel="stylesheet" href="/styles/page.css"></link>    
   </head>
 
   <body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2761,15 +2761,6 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
-dom-serializer@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.1.0.tgz#5f7c828f1bfc44887dc2a315ab5c45691d544b58"
-  integrity sha512-ox7bvGXt2n+uLWtCRLybYx60IrOlWL/aCebWJk1T0d4m3y2tzf4U3ij9wBMUb6YJZpz06HCCYuyCDveE2xXmzQ==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^3.0.0"
-    entities "^2.0.0"
-
 domelementtype@1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
@@ -2787,13 +2778,6 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
-domhandler@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
-  integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
-  dependencies:
-    domelementtype "^2.0.1"
-
 domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
@@ -2801,15 +2785,6 @@ domutils@^1.7.0:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
-
-domutils@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.3.0.tgz#6469c63a3da2de0c3016f3a59e6a969e10705bce"
-  integrity sha512-xWC75PM3QF6MjE5e58OzwTX0B/rPQnlqH0YyXB/c056RtVJA+eu60da2I/bdnEHzEYC00g8QaZUlAbqOZVbOsw==
-  dependencies:
-    dom-serializer "^1.0.1"
-    domelementtype "^2.0.1"
-    domhandler "^3.0.0"
 
 dot-prop@^4.2.0:
   version "4.2.1"
@@ -4057,16 +4032,6 @@ html-void-elements@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"
   integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
-
-htmlparser2@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
-  integrity sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^3.0.0"
-    domutils "^2.0.0"
-    entities "^2.0.0"
 
 http-assert@^1.3.0:
   version "1.4.1"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #434 

I gotchu fam

<img width="1680" alt="Screen Shot 2021-02-03 at 8 45 32 PM" src="https://user-images.githubusercontent.com/895923/106833668-f0a2e400-6661-11eb-8224-0db8e81bf96c.png">
<img width="1090" alt="Screen Shot 2021-02-03 at 8 45 55 PM" src="https://user-images.githubusercontent.com/895923/106833669-f13b7a80-6661-11eb-9653-0b5e345f42b1.png">


## Summary of Changes
1. Refactored _rollup.config.js_ to align on a single html parsing library
1. Now the below type of inline `<script>` tag usage will get properly bundled by Rollup and inlined back into the HTML
    ```js
    <script type="module">
      import '@bare/specifier';
    <script>
    ```
1. Added test cases and fixed a rollup `<script>` tag matching bug - (also seen in https://github.com/ProjectEvergreen/greenwood/pull/475/files#diff)
1. Updated docs with notes on a recommendation to use file based style and script tag usage

## TODO
1. [x] I think JavaScript handling breaks on multiple usages of `<script src="...">` in the same document... (looks like this is due to a bug I saw happening inhttps://github.com/ProjectEvergreen/greenwood/pull/475/files#diff-57634df7e2b1ba3ea0031d8adc1e73230ca3c93bbecfdea7b44d00c7e100ec8b as well)
1. [x] Tests (think I will add this the _import_ case added in #465 once it gets merged )
1. [ ] ~~Would like handle similar case for inline CSS, e.g.~~ - can't do this easily, just yet.  how to avoid Puppeteer added inline styles?
    ```css
    <style>
      @import '../some.css'
      .my {
         .nested-styles {
          }
      }
    </style>
    ```
1. [x] Documentation
1. [x] Clean up intermediate emitted (scratch) files
1. [x] pick `Buffer` or `crypto`

_Nice To Have_
1.  [x] Would like to _also_ support / verify this, but will likely just push this off to another issue for the 1.0 release
    ```html
      <script type="module" src="@bare/specifier"></script>
      <link rel="stylesheeet" href="@bare/specifier"/>
     ```
1. [x] avoid commented out code - this seems to happen already?

## Summary / Thoughts / Takeaways
So for where this stands as of now, the general (to be) documented recommendation will be to use a file based entry point for all your scripts and styles, for anything anything doing any "heavy lifting" as this will afford the most opportunity for full and consistent bundling and optimization (at this time).  

The mean reason is that since inline `<script>` and `<style>` don't initiate any fetch / network requests, the ability for the Greenwood server to intercept these and run tranforms and optimizatoin's is limited and so may lead to different outcomes between `build` and `develop` commands.  This is something we could try and support, but I think can come at a later time.  For now, we can at least do node_modules directly, which is pretty great.  

Here are some examples of what is / isn't supported.
```html
<!-- this will work -->
<script type="module" src="/your/scripts/main.js"></script>
<script type="module" src="/node_modules/some-package/index.js"></script>
<script type="module">
  import 'some-lib'; // bare import from node_modules

  // inline JavaScript works just fine!
  window.onload = () => {
     const route = window.location.pathname.split('/')[1];
        
     document.getElementsByTagName('app-shelf')[0].setAttribute('page', route);
  }
</script>

<style>
  p {
    color: red;
  }
</style>

<link rel="stylesheet" href="/your/styles/main.css"></link>
<link rel="stylesheet" href="/node_modules/some-package/styles.css"></link>


<!-- this will NOT work -->
<style>
  /* @import only works in a stylesheet? */
  @import url('./some.css')
  
  /* cant transpiling, like when using PostCSS for nested styles */
  p {
    & span {
      color: red;
    }
 }
</style>
```