### PR TITLE
hoist cssnano to cli package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
     "acorn": "^8.0.1",
     "acorn-walk": "^8.0.0",
     "commander": "^2.20.0",
+    "cssnano": "^4.1.10",
     "es-module-shims": "^0.5.2",
     "front-matter": "^4.0.2",
     "htmlparser2": "^4.1.0",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #479 

## Summary of Changes
1. Added / hoisted **cssnano** to `@greenwood/cli` package where it is getting used for default optimization
```js
% yarn why cssnano
yarn why v1.12.3
[1/4] 🤔  Why do we have the module "cssnano"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "cssnano@4.1.10"
info Reasons this module exists
   - "_project_#@greenwood#cli" depends on it
   - Hoisted from "_project_#@greenwood#cli#cssnano"
   - Hoisted from "_project_#@greenwood#plugin-import-css#rollup-plugin-postcss#cssnano"
info Disk size without dependencies: "48KB"
info Disk size with unique dependencies: "1.36MB"
info Disk size with transitive dependencies: "25.89MB"
info Number of shared dependencies: 52
✨  Done in 0.85s.
```