### PR TITLE
filter only JS packages for importMap and add tests

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,6 +58,7 @@
     "pwa-helpers": "^0.9.1",
     "redux": "^4.0.5",
     "rehype-autolink-headings": "^4.0.0",
-    "rehype-slug": "^3.0.0"
+    "rehype-slug": "^3.0.0",
+    "simpledotcss": "^1.0.0"
   }
 }

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -80,12 +80,15 @@ const walkPackageJson = (packageJson = {}) => {
     const entry = getPackageEntryPath(dependencyPackageJson);
     const packageEntryPointPath = path.join(process.cwd(), './node_modules', dependency, entry);
     const packageEntryModule = fs.readFileSync(packageEntryPointPath, 'utf-8');
+    const isJavascriptPackage = packageEntryPointPath.endsWith('.js') || packageEntryPointPath.endsWith('.mjs');
 
-    walkModule(packageEntryModule, dependency);
+    if (isJavascriptPackage) {
+      walkModule(packageEntryModule, dependency);
 
-    importMap[dependency] = `/node_modules/${dependency}/${entry}`;
+      importMap[dependency] = `/node_modules/${dependency}/${entry}`;
 
-    walkPackageJson(dependencyPackageJson);
+      walkPackageJson(dependencyPackageJson);
+    }
   });
 };
 

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -130,9 +130,18 @@ describe('Build Greenwood With: ', function() {
       // prism.css
       dir: 'node_modules/prismjs/themes/',
       name: 'prism-tomorrow.css'
-    }
+    },
 
-    ]);
+    {
+      // simple.css - included as a non-JavaScript package
+      // https://github.com/ProjectEvergreen/greenwood/issues/484
+      dir: 'node_modules/simpledotcss/',
+      name: 'package.json'
+    },
+    {
+      dir: 'node_modules/simpledotcss/',
+      name: 'simple.css'
+    }]);
   });
 
   describe(LABEL, function() {

--- a/packages/cli/test/cases/build.default.import-node-modules/package.json
+++ b/packages/cli/test/cases/build.default.import-node-modules/package.json
@@ -4,6 +4,7 @@
     "lit-element": "^2.4.0",
     "lodash-es": "^4.17.20",
     "pwa-helpers": "^0.9.1",
-    "redux": "^4.0.5"
+    "redux": "^4.0.5",
+    "simpledotcss": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7655,6 +7655,11 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
+simpledotcss@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/simpledotcss/-/simpledotcss-1.0.0.tgz#b5ac8fcd73d111938def9c0f43f1839d6eae96be"
+  integrity sha512-inneK6Wqh5rUdASxJMAKJORbDeKRySZPlY6H1Jqc6o6t5QbXhd5UZUi5snkKnB0ror0H72in0zlNeeA4Vw+Fiw==
+
 slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #484 

## Summary of Changes
1. Filter for only JS packages in `importMap`
2. Updated tests using [**simpledotcss**](https://www.npmjs.com/package/simpledotcss) as an example