### PR TITLE
set node v12 as minimum version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [10, 12]
+        node: [12, 14]
 
     steps:
     - uses: actions/checkout@v1

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
     "Web Components"
   ],
   "engines": {
-    "node": ">=10.x"
+    "node": ">=12.x"
   },
   "bin": {
     "greenwood": "./src/index.js"

--- a/www/pages/guides/cloudflare-workers-deployment.md
+++ b/www/pages/guides/cloudflare-workers-deployment.md
@@ -87,7 +87,7 @@ jobs:
          sh ./.github/workflows/chromium-lib-install.sh
       - uses: actions/setup-node@v1
         with:
-           node-version: "10.x"
+           node-version: "12.x"
       - name: Install deps
         run: npm install
       - name: Build docs

--- a/www/pages/guides/s3-cloudfront.md
+++ b/www/pages/guides/s3-cloudfront.md
@@ -71,7 +71,7 @@ jobs:
          sh ./.github/workflows/chromium-lib-install.sh
       - uses: actions/setup-node@v1
         with:
-          node-version: "10.x"
+          node-version: "12.x"
       - name: Install deps
         run: npm install
       - name: Build docs


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #448 

## Summary of Changes
1. Sets minimum Node.js version to v12, and added v14 as canary for CI
1. Updated CI / docs

> _As part of #418, would like to get the minimum version fo v14 (for better ESM and native `Promises` support) for the eventual 1.0.0 release_