### PR TITLE
add additional handling for chrome headers

### DIFF
--- a/packages/plugin-import-css/src/index.js
+++ b/packages/plugin-import-css/src/index.js
@@ -16,7 +16,10 @@ class ImportCssResource extends ResourceInterface {
   }
 
   async shouldIntercept(url, body, headers) {
-    const isCssInJs = path.extname(url) === this.extensions[0] && headers.request.accept.indexOf('text/css') < 0;
+    // https://github.com/ProjectEvergreen/greenwood/issues/492
+    const isCssInJs = path.extname(url) === this.extensions[0]
+      && headers.request.accept.indexOf('text/css') < 0
+      && headers.request.accept.indexOf('application/signed-exchange') < 0;
 
     return Promise.resolve(isCssInJs);
   }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #492 

## Summary of Changes
1. Added support for new Chrome header sometime causing incorrect detection of CSS files loaded via `import`

> _I'll plan to do a little more research into this to see if there are other options for addressing the problem that could be enabled in a future PR._