### PR TITLE
handle no bundling of remote URLs and add error handling for sync rollup hooks

### DIFF
--- a/packages/cli/test/cases/build.default.workspace-javascript-css-remote/build.default.workspace-javascript-css-remote.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css-remote/build.default.workspace-javascript-css-remote.spec.js
@@ -1,0 +1,107 @@
+/*
+ * Use Case
+ * Run Greenwood with various usages of JavaScript (<script>) and CSS (<style> / <link>) tags with remove links.
+ * 
+ * Uaer Result
+ * Should generate a bare bones Greenwood build without erroring.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * None
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     index.html
+ *     
+ */
+const expect = require('chai').expect;
+const glob = require('glob-promise');
+const { JSDOM } = require('jsdom');
+const path = require('path');
+const TestBed = require('../../../../../test/test-bed');
+
+describe('Build Greenwood With: ', function() {
+  const LABEL = 'Loading remote JavaScript and CSS using <script> and <link> tags';
+
+  let setup;
+
+  before(async function() {
+    setup = new TestBed();
+
+    this.context = await setup.setupTestBed(__dirname);
+  });
+
+  describe(LABEL, function() {
+    let dom;
+
+    before(async function() {
+      await setup.runGreenwoodCommand('build');
+
+      dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, 'index.html'));
+    });
+
+    describe('it should have the expected files in the output directory', function() {
+      it('should output no javascript files', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, '*.js'))).to.have.lengthOf(0);
+      });
+
+      it('should output no css files', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, '*.css'))).to.have.lengthOf(0);
+      });
+    });
+
+    describe('two <script></script> tags with remote URLs in the <head>', function() {
+      it('should have two <script src="..."> tags in the <head>', function() {
+        const scriptTags = dom.window.document.querySelectorAll('head > script');
+        const mainScriptTags = Array.prototype.slice.call(scriptTags).filter(script => {
+          return (/http/).test(script.src);
+        });
+        
+        expect(mainScriptTags.length).to.be.equal(2);
+      });
+
+      it('should have one CDN <script src="..."> tag for jquery in the <head> using http', function() {
+        const scriptTags = dom.window.document.querySelectorAll('head > script');
+        const jqueryScriptTag = Array.prototype.slice.call(scriptTags).filter(script => {
+          return (/http:\/\/code.jquery.com\//).test(script.src);
+        });
+        
+        expect(jqueryScriptTag.length).to.be.equal(1);
+      });
+
+      it('should have one UNPKG <script src="..." type="module"> tag for LitElements in the <head> using https', function() {
+        const scriptTags = dom.window.document.querySelectorAll('head > script');
+        const unpkgScriptTag = Array.prototype.slice.call(scriptTags).filter(script => {
+          return (/https:\/\/unpkg.com\//).test(script.src);
+        });
+        
+        expect(unpkgScriptTag.length).to.be.equal(1);
+      });
+    });
+
+    describe('<link rel="stylesheet" href="..."/> tag in the <head>', function() {
+      it('should have one <link> tag in the <head> with no protocol specified', function() {
+        const linkTags = dom.window.document.querySelectorAll('head > link');
+        
+        expect(linkTags.length).to.be.equal(1);
+      });
+
+      it('should have one <link> tag for google fonts in the <head> with no protocol specified', async function() {
+        const linkTags = dom.window.document.querySelectorAll('head > link');
+        const fontsLinkTag = Array.prototype.slice.call(linkTags).filter(link => {
+          return (/\/\/fonts.googleapis.com\//).test(link.href);
+        });
+        
+        expect(fontsLinkTag.length).to.be.equal(1);
+      });
+    });
+  });
+
+  after(function() {
+    setup.teardownTestBed();
+  });
+
+});

--- a/packages/cli/test/cases/build.default.workspace-javascript-css-remote/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css-remote/src/pages/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en" prefix="og:http://ogp.me/ns#">
+
+  <head>
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto&display=swap"></link>
+    <script src="http://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script type="module" src="https://unpkg.com/lit-element@2.4.0/lit-element.js"></script>
+  </head>
+
+  <body>
+    <h1>Hello!</h1>
+  </body>
+
+</html>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #491 

## Summary of Changes
1. Add error handing (`try / catch`) for synchronous rollup build hooks to address unhandled Promise reject error
1. For rollup, avoid bundling remote URLs for `<script>` and `<link>` tags
1. Added new test case