### PR TITLE
[demo / bug] inline optimization is broken on subsequent page load

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -11,6 +11,7 @@ const FAVICON_HREF = '/assets/favicon.ico';
 module.exports = {
   workspace: path.join(__dirname, 'www'),
   mode: 'mpa',
+  optimization: 'inline',
   title: 'Greenwood',
   meta: [
     { name: 'description', content: META_DESCRIPTION },

--- a/www/templates/app.html
+++ b/www/templates/app.html
@@ -2,6 +2,7 @@
 <html lang="en" prefix="og:http://ogp.me/ns#">
 
   <head>
+    <base href="/">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="mobile-web-app-capable" content="yes"/>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #447, this is an example of the `inline` **optimization** setting.  Click [here for the simpler diff](https://github.com/ProjectEvergreen/greenwood/compare/enhancement/issue-354-restore-optimization-for-no-bundle...enhancement/issue-354-restore-optimization-for-no-bundle-inline).  _**This is a known broken issue since it works in the specs, but not with the Greenwood**_

Score seems about the same?

_Network requests (not entirely everything is inlined, but most)_
<img width="1680" alt="optimization-inline-network" src="https://user-images.githubusercontent.com/895923/112738499-d4bd0f80-8f39-11eb-90d0-264fa1085ba6.png">

_Lighthouse_
<img width="1680" alt="optimization-inline-lighthouse" src="https://user-images.githubusercontent.com/895923/112738497-cd960180-8f39-11eb-925d-b2190db4f1f2.png">

_On Navigation_ 😬 
<img width="1680" alt="optimization-inline-route-change" src="https://user-images.githubusercontent.com/895923/112738522-f1f1de00-8f39-11eb-8f9e-d37cfee705ca.png">

## Summary of Changes
1. Sets `optimization` setting to **inline** in _greenwood.config.js_
1. Set `<base href="/">` to set consistent reference point for all JS / CSS file requests