### PR TITLE
drop google analytics plugin

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const pluginGoogleAnalytics = require('@greenwood/plugin-google-analytics');
 const pluginGraphQL = require('@greenwood/plugin-graphql');
 const pluginImportCss = require('@greenwood/plugin-import-css');
 const pluginImportJson = require('@greenwood/plugin-import-json');
@@ -27,9 +26,6 @@ module.exports = {
     { name: 'google-site-verification', content: '4rYd8k5aFD0jDnN0CCFgUXNe4eakLP4NnA18mNnK5P0' }
   ],
   plugins: [
-    pluginGoogleAnalytics({
-      analyticsId: 'UA-147204327-1'
-    }),
     ...pluginGraphQL(),
     pluginPolyfills(),
     pluginPostCss(),


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->


## Related Issue
related to #447, this is an example with Google Analytics, just to see what perf is like.  Click [here for the simple diff](https://github.com/ProjectEvergreen/greenwood/compare/enhancement/issue-354-restore-optimization-for-no-bundle...enhancement/issue-354-restore-optimization-for-no-bundle-drop-google-analytics).

> _Deploy Preview permalink [is here](https://60ce302294fbc6000747f14b--elastic-blackwell-3aef44.netlify.app/)_

_GA is 58.2KB gzipped, 146KB non-gzipped!_  😱 😮 
<img width="1680" alt="default-google-analytics-payload" src="https://user-images.githubusercontent.com/895923/112738592-8c522180-8f3a-11eb-9291-f427d910e4d9.png">

_Network Requests_
<img width="1677" alt="optimization-default-drop-ga-network" src="https://user-images.githubusercontent.com/895923/112738597-9aa03d80-8f3a-11eb-956a-cc3a85f32547.png">

_Lighthouse_
<img width="1680" alt="optimization-default-drop-ga-lighthouse" src="https://user-images.githubusercontent.com/895923/112738601-a12eb500-8f3a-11eb-92bd-1dd884120dc2.png">

## Summary of Changes
1. dropped **plugin-google-anlaytics** from _greenwood.config.js_

> _After #566 is merged and plan is accepted, will merge this_