### PR TITLE
co-locate rollup plugins near their greenwood resource plugin match

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -53,7 +53,8 @@ async function getOptimizedSource(url, plugins, compilation) {
       .map((filename) => {
         return require(`${standardPluginsPath}/${filename}`);
       }).map((plugin) => {
-        return plugin.length 
+        // assume that if it is an array, second item is a rollup plugin
+        return plugin.length
           ? plugin[0].provider(compilation)
           : plugin.provider(compilation);
       });

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -20,13 +20,13 @@ function getDevServer(compilation) {
   const resources = [
     // Greenwood default standard resource and import plugins
     pluginUserWorkspace.provider(compilation),
-    pluginNodeModules.provider(compilation),
+    pluginNodeModules[0].provider(compilation),
     pluginResourceStandardCss.provider(compilationCopy),
     pluginResourceStandardFont.provider(compilationCopy),
     pluginResourceStandardHtml.provider(compilationCopy),
     pluginResourceStandardImage.provider(compilationCopy),
-    pluginResourceStandardJavaScript.provider(compilationCopy),
-    pluginResourceStandardJson.provider(compilationCopy),
+    pluginResourceStandardJavaScript[0].provider(compilationCopy),
+    pluginResourceStandardJson[0].provider(compilationCopy),
     pluginResourceOptimizationMpa().provider(compilationCopy),
 
     // custom user resource plugins

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -6,6 +6,8 @@
 const acorn = require('acorn');
 const fs = require('fs');
 const path = require('path');
+const { nodeResolve } = require('@rollup/plugin-node-resolve');
+const replace = require('@rollup/plugin-replace');
 const { ResourceInterface } = require('../../lib/resource-interface');
 const walk = require('acorn-walk');
 
@@ -243,8 +245,19 @@ class NodeModulesResource extends ResourceInterface {
   }
 }
 
-module.exports = {
+module.exports = [{
   type: 'resource',
-  name: 'plugin-node-modules',
+  name: 'plugin-node-modules:resource',
   provider: (compilation, options) => new NodeModulesResource(compilation, options)
-};
+}, {
+  type: 'rollup',
+  name: 'plugin-node-modules:rollup',
+  provider: () => {
+    return [
+      replace({ // https://github.com/rollup/rollup/issues/487#issuecomment-177596512
+        'process.env.NODE_ENV': JSON.stringify('production')
+      }),
+      nodeResolve()
+    ];
+  }
+}];

--- a/packages/cli/src/plugins/resource/plugin-standard-javascript.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-javascript.js
@@ -6,6 +6,7 @@
  */
 const fs = require('fs');
 const { ResourceInterface } = require('../../lib/resource-interface');
+const { terser } = require('rollup-plugin-terser');
 
 class StandardJavaScriptResource extends ResourceInterface {
   constructor(compilation, options) {
@@ -30,8 +31,16 @@ class StandardJavaScriptResource extends ResourceInterface {
   }
 }
 
-module.exports = {
+module.exports = [{
   type: 'resource',
-  name: 'plugin-standard-javascript',
+  name: 'plugin-standard-javascript:resource',
   provider: (compilation, options) => new StandardJavaScriptResource(compilation, options)
-};
+}, {
+  type: 'rollup',
+  name: 'plugin-standard-javascript:rollup',
+  provider: (compilation) => {
+    return compilation.config.optimization !== 'none'
+      ? [terser()]
+      : [];
+  }
+}];

--- a/packages/cli/src/plugins/resource/plugin-standard-json.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-json.js
@@ -5,6 +5,7 @@
  *
  */
 const fs = require('fs');
+const json = require('@rollup/plugin-json');
 const path = require('path');
 const { ResourceInterface } = require('../../lib/resource-interface');
 
@@ -45,8 +46,16 @@ class StandardJsonResource extends ResourceInterface {
   }
 }
 
-module.exports = {
+module.exports = [{
   type: 'resource',
-  name: 'plugin-standard-json',
+  name: 'plugin-standard-json:resource',
   provider: (compilation, options) => new StandardJsonResource(compilation, options)
-};
+}, {
+  type: 'resource',
+  name: 'plugin-standard-json:rollup',
+  provider: () => {
+    return [
+      json()
+    ];
+  }
+}];


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Co-locating rollup plugins with the greenwood resource plugin match
    - terser
    - nodeResolve / replace
    - json

> _Note: I plan on making an issue to refactor and move default greenwood plugins into the actual compilation.plugins array since I don't think them being ad-hoc spread around the codebase the way they are._. - see #551 and #520