### PR TITLE
fix duplicate head tags and harden smoke tests

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -211,11 +211,7 @@ class NodeModulesResource extends ResourceInterface {
           const contents = hasHead[0]
             .replace(/type="module"/g, 'type="module-shim"');
 
-          newContents = newContents.replace(/\<head>(.*)<\/head>/s, `
-            <head>
-              ${contents}
-            </head>
-          `);
+          newContents = newContents.replace(/\<head>(.*)<\/head>/s, contents);
         }
 
         const userPackageJson = fs.existsSync(`${userWorkspace}/package.json`)

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -316,11 +316,7 @@ class StandardHtmlResource extends ResourceInterface {
           contents = contents.replace(/<script defer="" src="(.*es-module-shims.js)"><\/script>/, '');
           contents = contents.replace(/type="module-shim"/g, 'type="module"');
 
-          body = body.replace(/\<head>(.*)<\/head>/s, `
-            <head>
-              ${contents}
-            </head>
-          `);
+          body = body.replace(/\<head>(.*)<\/head>/s, contents);
         }
     
         resolve(body);

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -57,8 +57,8 @@ function defaultIndex(label) {
           expect(htmlTag[0].getAttribute('prefix')).to.be.equal('og:http://ogp.me/ns#');
         });
 
-        it('should have matching opening and closing <head> tags', function() {
-          expect(tagsMatch('<html>', html)).to.be.equal(true);
+        it('should have matching opening and closing <html> tags', function() {
+          expect(tagsMatch('html', html, 1)).to.be.equal(true);
         });
       });
 
@@ -72,7 +72,7 @@ function defaultIndex(label) {
         it('should have matching opening and closing <head> tags in the <head>', function() {
           // add an expclit > here to avoid conflicting with <header>
           // which is used in a lot of test case scaffolding
-          expect(tagsMatch('head>', html)).to.be.equal(true);
+          expect(tagsMatch('head>', html, 1)).to.be.equal(true);
         });
   
         it('should have a <title> tag in the <head>', function() {
@@ -109,6 +109,10 @@ function defaultIndex(label) {
       });
 
       describe('document <body>', function() {
+        it('should have matching opening and closing <body> tags', function() {
+          expect(tagsMatch('body', html, 1)).to.be.equal(true);
+        });
+
         it('should have no <script> tags in the <body>', function() {
           const bodyScripts = dom.window.document.querySelectorAll('body script');
   

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,10 +1,11 @@
-function tagsMatch(tagName, html) {
+function tagsMatch(tagName, html, expected = null) {
   const openTagRegex = new RegExp(`<${tagName}`, 'g');
   const closeTagRegex = new RegExp(`<\/${tagName.replace('>', '')}>`, 'g');
   const openingCount = (html.match(openTagRegex) || []).length;
   const closingCount = (html.match(closeTagRegex) || []).length;
+  const expectedMatches = parseInt(expected, 10) ? expected : openingCount;
   
-  return openingCount === closingCount;
+  return openingCount === closingCount && openingCount === expectedMatches;
 }
 
 module.exports = {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #564 

## Summary of Changes
1. Found instances where `<head>` tags were being duplicated back into templates
1. Hardened tests to better ensure proper tag matching