### PR TITLE
strip query params from URLs

### DIFF
--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -141,7 +141,7 @@ function getProdServer(compilation) {
 
   app.use(async ctx => {
     const { outputDir } = compilation.context;
-    const { url } = ctx.request;
+    const url = ctx.request.url.replace(/\?(.*)/, ''); // get rid of things like query string parameters
 
     if (url.endsWith('/') || url.endsWith('.html')) {
       const barePath = url.endsWith('/') ? path.join(url, 'index.html') : url;

--- a/packages/cli/src/plugins/resource/plugin-user-workspace.js
+++ b/packages/cli/src/plugins/resource/plugin-user-workspace.js
@@ -14,14 +14,19 @@ class UserWorkspaceResource extends ResourceInterface {
     this.extensions = ['*'];
   }
 
+  getBareUrlPath(url) {
+    // get rid of things like query string parameters
+    return url.replace(/\?(.*)/, '');
+  }
+
   async shouldResolve(url = '/') {
-    return Promise.resolve(fs.existsSync(this.compilation.context.userWorkspace, url) || url === '/');
+    return Promise.resolve(fs.existsSync(this.compilation.context.userWorkspace, this.getBareUrlPath(url)) || url === '/');
   }
 
   async resolve(url = '/') {
     return new Promise(async (resolve, reject) => {
       try {
-        const workspaceUrl = path.join(this.compilation.context.userWorkspace, url);
+        const workspaceUrl = path.join(this.compilation.context.userWorkspace, this.getBareUrlPath(url));
         
         resolve(workspaceUrl);
       } catch (e) {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #578 

## Summary of Changes
1. Strip query strings when mapping URLs to filesystem
<img width="1672" alt="Screen Shot 2021-04-26 at 11 24 00 AM" src="https://user-images.githubusercontent.com/895923/116168174-d52efe80-a6cf-11eb-924c-0668732ef0ec.png">