### PR TITLE
add support for resolving sourcemaps in development

### DIFF
--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -4,6 +4,7 @@ const Koa = require('koa');
 
 const pluginNodeModules = require('../plugins/resource/plugin-node-modules');
 const pluginResourceOptimizationMpa = require('../plugins/resource/plugin-optimization-mpa');
+const pluginSourceMaps = require('../plugins/resource/plugin-source-maps');
 const pluginResourceStandardCss = require('../plugins/resource/plugin-standard-css');
 const pluginResourceStandardFont = require('../plugins/resource/plugin-standard-font');
 const pluginResourceStandardHtml = require('../plugins/resource/plugin-standard-html');
@@ -27,6 +28,7 @@ function getDevServer(compilation) {
     pluginResourceStandardImage.provider(compilationCopy),
     pluginResourceStandardJavaScript[0].provider(compilationCopy),
     pluginResourceStandardJson[0].provider(compilationCopy),
+    pluginSourceMaps.provider(compilationCopy),
     pluginResourceOptimizationMpa().provider(compilationCopy),
 
     // custom user resource plugins

--- a/packages/cli/src/plugins/resource/plugin-source-maps.js
+++ b/packages/cli/src/plugins/resource/plugin-source-maps.js
@@ -1,0 +1,40 @@
+/*
+ * 
+ * Detects and fully resolve requests to source map (.map) files.
+ *
+ */
+const fs = require('fs');
+const path = require('path');
+const { ResourceInterface } = require('../../lib/resource-interface');
+
+class SourceMapsResource extends ResourceInterface {
+  constructor(compilation, options) {
+    super(compilation, options);
+    this.extensions = ['.map'];
+  }
+
+  async shouldServe(url) {
+    return Promise.resolve(path.extname(url) === this.extensions[0]);
+  }
+
+  async serve(url) {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const sourceMap = fs.readFileSync(url, 'utf-8');
+        
+        resolve({
+          body: sourceMap,
+          contentType: 'application/json'
+        });
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+}
+
+module.exports = {
+  type: 'resource',
+  name: 'plugin-source-maps',
+  provider: (compilation, options) => new SourceMapsResource(compilation, options)
+};


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #437 

## Summary of Changes
1. Correctly resolve source maps (now there are no more warnings in the developer console when developing)


_Before_
![image](https://user-images.githubusercontent.com/895923/116633282-179e4880-a927-11eb-8b55-2cfbbe9e870f.png)

_After_
<img width="1663" alt="Screen Shot 2021-04-29 at 11 21 34 AM" src="https://user-images.githubusercontent.com/895923/116633292-1d942980-a927-11eb-88c3-cbc8c5aedc06.png">