### PR TITLE
Bug/issue 586 fix rollup dropping markers

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -423,7 +423,7 @@ function greenwoodHtmlPlugin(compilation) {
                     .replace(/\.\//g, '/'); // force absolute paths
                   
                   if (markerRegex.test(bundledSource)) {
-                    const marker = bundledSource.match(/[0-9]+-scratch/)[0].split('-')[0];
+                    const marker = bundledSource.match(new RegExp(`[0-9]+-${tokenSuffix}`))[0].split('-')[0];
                     
                     if (id === marker) {
                       const cleaned = bundledSource

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -195,10 +195,10 @@ function greenwoodHtmlPlugin(compilation) {
               const id = hashString(scriptTag.rawText);
 
               if (!mappedScripts.get(id)) {
-                // using alert avoids having rollup strip out our internal marker if we used a commnent
+                // using console.log avoids having rollup strip out our internal marker if we used a commnent
                 const marker = `${id}-${tokenSuffix}`;
                 const filename = `${marker}.js`;
-                const source = `${scriptTag.rawText}alert("${marker}");`.trim();
+                const source = `${scriptTag.rawText}console.log("${marker}");`.trim();
 
                 fs.writeFileSync(path.join(scratchDir, filename), source);
                 mappedScripts.set(id, true);
@@ -414,7 +414,7 @@ function greenwoodHtmlPlugin(compilation) {
             // handle <script type="module"> /* inline code */ </script>
             if (parsedAttributes.type === 'module' && !parsedAttributes.src) {
               const id = hashString(scriptTag.rawText);
-              const markerExp = `alert\\("[0-9]+-${tokenSuffix}"\\)`;
+              const markerExp = `console.log\\("[0-9]+-${tokenSuffix}"\\)`;
               const markerRegex = new RegExp(markerExp);
 
               for (const innerBundleId of Object.keys(bundles)) {

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -207,7 +207,7 @@ describe('Build Greenwood With: ', function() {
       it('should have one <script> tag with inline code loaded in the <head> tag', function() {
         const scriptTagsInline = dom.window.document.querySelectorAll('head > script:not([src])');
         
-        expect(scriptTagsInline.length).to.be.equal(1);
+        expect(scriptTagsInline.length).to.be.equal(2);
       });
 
       it('should have the expected lit-element.js file in the output directory', async function() {
@@ -218,14 +218,20 @@ describe('Build Greenwood With: ', function() {
         expect(await glob.promise(path.join(this.context.publicDir, 'lit-html.cdc8faae.js'))).to.have.lengthOf(1);
       });
 
-      it('should have the expected inline node_modules content in the inline script', async function() {
-        const inlineScriptTag = dom.window.document.querySelector('head > script:not([src])');
+      it('should have the expected inline node_modules content in the first inline script', async function() {
+        const inlineScriptTag = dom.window.document.querySelectorAll('head > script:not([src])')[0];
         
         expect(inlineScriptTag.textContent.replace('\n', '')).to
-          .contain('import"/lit-html.d69ea26f.js";import"/lit-element.ea26fec7.js";document.getElementsByClassName("output-script-inline")[0].innerHTML="script tag module inline"');
+          .equal('import"/lit-html.d69ea26f.js";import"/lit-element.ea26fec7.js";document.getElementsByClassName("output-script-inline")[0].innerHTML="script tag module inline"');
       });
 
-      it('should have the expected output from inline <script> tag in the page output', async function() {
+      it('should have the expected inline node_modules content in the second inline script tag which should include extra code from rollup', async function() {
+        const inlineScriptTag = dom.window.document.querySelectorAll('head > script:not([src])')[1];
+        
+        expect(inlineScriptTag.textContent.replace('\n', '')).to.equal('import"/lit-html.d69ea26f.js";import"/lit-element.ea26fec7.js";');
+      });
+
+      it('should have the expected output from the first inline <script> tag in the page output', async function() {
         const inlineScriptOutput = dom.window.document.querySelectorAll('body > .output-script-inline');
         
         expect(inlineScriptOutput.length).to.be.equal(1);

--- a/packages/cli/test/cases/build.default.import-node-modules/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.import-node-modules/src/pages/index.html
@@ -8,9 +8,11 @@
 
       document.getElementsByClassName('output-script-inline')[0].innerHTML = 'script tag module inline';
     </script>
+    <script type="module">
+      import { html } from 'lit-element';
+    </script>
     <script type="module" src="/node_modules/lit-html/lit-html.js"></script>
     <link rel="stylesheet" href="/node_modules/prismjs/themes/prism-tomorrow.css"></link>
-
   </head>
 
   <body>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #586 

## Summary of Changes
1. Had to use an alternative token for tracking inline source to bundled rollup source
1. Hardened replace logic to only replace when marker matches bundle
1. Added a new test cases to repro and validate the solution

Would be nice to find a better "marker" than ~~`alert`~~ `console.log`, but need to have it be some kind of "code". (e.g. comments don't work?  🤔 