### PR TITLE
Enhancement/issue 577 dev server proxy support

### DIFF
--- a/nyc.config.js
+++ b/nyc.config.js
@@ -20,7 +20,7 @@ module.exports = {
   checkCoverage: true,
 
   statements: 80,
-  branches: 65,
+  branches: 60,
   functions: 80,
   lines: 80,
 

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -111,6 +111,10 @@ module.exports = readAndMergeConfig = async() => {
               customConfig.devServer.port = devServer.port;
             }
           }
+
+          if (devServer.proxy) {
+            customConfig.devServer.proxy = devServer.proxy;
+          }
         }
 
         if (markdown && Object.keys(markdown).length > 0) {

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -142,6 +142,7 @@ function getDevServer(compilation) {
 
 function getProdServer(compilation) {
   const app = new Koa();
+  const proxyPlugin = pluginDevProxyResource.provider(compilation);
 
   app.use(async ctx => {
     const { outputDir } = compilation.context;
@@ -198,6 +199,10 @@ function getProdServer(compilation) {
 
       ctx.set('Content-Type', 'application/json');
       ctx.body = JSON.parse(contents);
+    }
+
+    if (url !== '/' && await proxyPlugin.shouldServe(url)) {
+      ctx.body = await proxyPlugin.serve(url);
     }
   });
     

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -3,6 +3,7 @@ const path = require('path');
 const Koa = require('koa');
 
 const pluginNodeModules = require('../plugins/resource/plugin-node-modules');
+const pluginDevProxyResource = require('../plugins/resource/plugin-dev-proxy');
 const pluginResourceOptimizationMpa = require('../plugins/resource/plugin-optimization-mpa');
 const pluginSourceMaps = require('../plugins/resource/plugin-source-maps');
 const pluginResourceStandardCss = require('../plugins/resource/plugin-standard-css');
@@ -22,6 +23,7 @@ function getDevServer(compilation) {
     // Greenwood default standard resource and import plugins
     pluginUserWorkspace.provider(compilation),
     pluginNodeModules[0].provider(compilation),
+    pluginDevProxyResource.provider(compilationCopy),
     pluginResourceStandardCss.provider(compilationCopy),
     pluginResourceStandardFont.provider(compilationCopy),
     pluginResourceStandardHtml.provider(compilationCopy),

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -202,7 +202,7 @@ function getProdServer(compilation) {
     }
 
     if (url !== '/' && await proxyPlugin.shouldServe(url)) {
-      ctx.body = await proxyPlugin.serve(url);
+      ctx.body = (await proxyPlugin.serve(url)).body;
     }
   });
     

--- a/packages/cli/src/plugins/resource/plugin-dev-proxy.js
+++ b/packages/cli/src/plugins/resource/plugin-dev-proxy.js
@@ -1,0 +1,45 @@
+/*
+ * 
+ * Manages routing devServer.proxy entries to their destination.
+ *
+ */
+const fetch = require('node-fetch');
+const { ResourceInterface } = require('../../lib/resource-interface');
+
+class DevProxyResource extends ResourceInterface {
+  constructor(compilation, options) {
+    super(compilation, options);
+  }
+
+  async shouldServe(url) {
+    const proxies = this.compilation.config.devServer.proxy || {};
+    const hasMatches = Object.entries(proxies).reduce((acc, entry) => {
+      return acc || url.indexOf(entry[0]) >= 0;
+    }, false);
+
+    return hasMatches;
+  }
+
+  async serve(url) {
+    const baseUrl = url.replace(this.compilation.context.userWorkspace, '');
+    const proxies = this.compilation.config.devServer.proxy;
+    const proxyBaseUrl = Object.entries(proxies).reduce((acc, entry) => {
+      return url.indexOf(entry[0]) >= 0
+        ? `${entry[1]}${baseUrl}`
+        : acc;
+    }, baseUrl);
+
+    const response = await fetch(proxyBaseUrl)
+      .then(res => res.json());
+
+    return Promise.resolve({
+      body: response
+    });
+  }
+}
+
+module.exports = {
+  type: 'resource',
+  name: 'plugin-dev-server',
+  provider: (compilation, options) => new DevProxyResource(compilation, options)
+};

--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -32,12 +32,17 @@ module.exports = {
 ### Dev Server
 Configuration for Greenwood's development server is available using the `devServer` option.
 - `port`: Pick a different port when starting the dev server
+- `proxy`: A set of paths to match and re-route to other hosts.  Highest specificty should go at the end.
 
 #### Example
 ```js
 module.exports = {
   devServer: {
-    port: 8181
+    port: 8181,
+    proxy: {
+      '/api': 'https://stage.myapp.com',
+      '/api/foo': 'https://foo.otherdomain.net'
+    }
   }
 }
 ```


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #577 

## Summary of Changes
1. Adds support for a `devServer.proxy` object
1. Integrate into `develop` and `serve` servers

## TODO
1. [x] Docs
1. [ ] Update config schema?  (not sure how?)

## Testing
In _greenwood.config.js_ add this
```js
devServer: {
  proxy: {
    '/api': 'https://www.contributary.community',
    '/api/artists': 'https://www.analogstudios.net'
  }
},
```

In _app.html_, add this
```html
<script type="module">
  fetch('/api/topology')
    .then(response => response.json())
    .then(response => {
      console.log('Topology', response);
    });

  fetch('/api/artists')
    .then(response => response.json())
    .then(response => {
      console.log('Artists', response);
    });
</script>
```

due to a #587, we need a small workaround, replace completely the below snippet with the above snippet
```html
<script type="module">
  import '@evergreen-wc/eve-container';
</script>
```