### PR TITLE
make resource resolving more graceful and fallback to original `ctx.url`

### DIFF
--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -57,7 +57,7 @@ function getDevServer(compilation) {
       return resourceShouldResolveUrl
         ? resource.resolve(url)
         : Promise.resolve(response);
-    }, Promise.resolve(''));
+    }, Promise.resolve(ctx.url));
 
     await next();
   });

--- a/packages/cli/src/plugins/resource/plugin-user-workspace.js
+++ b/packages/cli/src/plugins/resource/plugin-user-workspace.js
@@ -20,7 +20,9 @@ class UserWorkspaceResource extends ResourceInterface {
   }
 
   async shouldResolve(url = '/') {
-    return Promise.resolve(fs.existsSync(this.compilation.context.userWorkspace, this.getBareUrlPath(url)) || url === '/');
+    const bareUrl = this.getBareUrlPath(url);
+
+    return Promise.resolve(fs.existsSync(this.compilation.context.userWorkspace, bareUrl) || bareUrl === '/');
   }
 
   async resolve(url = '/') {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #598 

## Summary of Changes
1.  Fallback to original `ctx.url` instead of empty string when resolving 

## Thoughts
There might be a case to create a new issue or discussion to scope out some more capabilities for the dev server.  In light of this issue, I'm wondering what other capabilities users may be expecting / need here that aren't, given the simplicity of the current implementation, for instance
- make sure cookies and headers are properly forward 
- other methods like `PUT`, `POST`, `DELETE`, etc
- others?

> Made a discussion - https://github.com/ProjectEvergreen/greenwood/discussions/607