### PR TITLE
fix bad logic for filtering workspace files to resolve

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-user-workspace.js
+++ b/packages/cli/src/plugins/resource/plugin-user-workspace.js
@@ -21,8 +21,9 @@ class UserWorkspaceResource extends ResourceInterface {
 
   async shouldResolve(url = '/') {
     const bareUrl = this.getBareUrlPath(url);
+    const isWorkspaceFile = fs.existsSync(path.join(this.compilation.context.userWorkspace, bareUrl));
 
-    return Promise.resolve(fs.existsSync(this.compilation.context.userWorkspace, bareUrl) || bareUrl === '/');
+    return Promise.resolve(isWorkspaceFile || bareUrl === '/');
   }
 
   async resolve(url = '/') {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #598 

## Summary of Changes
1. Actually test for the _complete_ URL by using `path.join`