### PR TITLE
lazy load card images

### DIFF
--- a/www/components/card/card.js
+++ b/www/components/card/card.js
@@ -27,7 +27,7 @@ class Card extends LitElement {
     if (this.img) {
       return html`
         <div class="card-img-top">
-          <img src="${this.img}" alt="${this.title}"/>
+          <img src="${this.img}" alt="${this.title}" loading="lazy"/>
         </div>
       `;
     }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1.  Added [native lazy loading](https://web.dev/browser-level-image-lazy-loading/) to card images, since right now are cards are just used for images at the bottom of the home page (e.g. below the fold)

> _Naturally this may not apply to all Cards in the future, so maybe going forward the card can accept an attribute to enable selective usage of `loading="lazy"`_