### PR TITLE
fix shelf label display for styles and assets

### DIFF
--- a/www/pages/docs/css-and-images.md
+++ b/www/pages/docs/css-and-images.md
@@ -1,5 +1,5 @@
 ---
-label: 'styles-assets'
+label: 'styles-and-assets'
 menu: side
 title: 'Styles and Assets'
 index: 5


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
None

## Summary of Changes
1. Fixes label for _Styles **and** Assets_ shelf item

<img width="438" alt="Screen Shot 2021-06-13 at 12 24 46 PM" src="https://user-images.githubusercontent.com/895923/121815089-7e12c800-cc42-11eb-853d-704d06786493.png">