### PR TITLE
display greenwood version in CLI output

### DIFF
--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -16,7 +16,7 @@ let cmdOption = {};
 let command = '';
 
 console.info('-------------------------------------------------------');
-console.info('Welcome to Greenwood ♻️');
+console.info(`Welcome to Greenwood (v${greenwoodPackageJson.version}) ♻️`);
 console.info('-------------------------------------------------------');
 
 program


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
None

## Summary of Changes
1. Now when running the CLI, the current version of Greenwood will display at the start of the output

```sh
%  yarn build
yarn run v1.12.3
$ cross-env __GWD_ROLLUP_MODE__=strict node . build
-------------------------------------------------------
Welcome to Greenwood (v0.13.0) ♻️
-------------------------------------------------------
Running Greenwood with the build command.
.
.
.
```