### PR TITLE
Chore/issue 520 consolidate plugins

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -25,8 +25,7 @@ module.exports = runProductionBuild = async () => {
           try {
             devServer(compilation).listen(port, async () => {
               console.info(`Started local development server at localhost:${port}`);
-              
-              // custom user server plugins
+  
               const servers = [...compilation.config.plugins.filter((plugin) => {
                 return plugin.type === 'server';
               }).map((plugin) => {

--- a/packages/cli/src/commands/develop.js
+++ b/packages/cli/src/commands/develop.js
@@ -19,7 +19,6 @@ module.exports = runDevServer = async () => {
         }).map((plugin) => {
           const provider = plugin.provider(compilation);
 
-          // TODO move to config
           if (!(provider instanceof ServerInterface)) {
             console.warn(`WARNING: ${plugin.name}'s provider is not an instance of ServerInterface.`);
           }

--- a/packages/cli/src/commands/develop.js
+++ b/packages/cli/src/commands/develop.js
@@ -1,5 +1,4 @@
 const generateCompilation = require('../lifecycles/compile');
-const pluginLiveReloadServer = require('../plugins/server/plugin-livereload')()[0];
 const { ServerInterface } = require('../lib/server-interface');
 const { devServer } = require('../lifecycles/serve');
 
@@ -14,12 +13,13 @@ module.exports = runDevServer = async () => {
       devServer(compilation).listen(port, () => {
         
         console.info(`Started local development server at localhost:${port}`);
-        // custom user server plugins
-        const servers = [...compilation.config.plugins.concat([pluginLiveReloadServer]).filter((plugin) => {
+
+        const servers = [...compilation.config.plugins.filter((plugin) => {
           return plugin.type === 'server';
         }).map((plugin) => {
           const provider = plugin.provider(compilation);
 
+          // TODO move to config
           if (!(provider instanceof ServerInterface)) {
             console.warn(`WARNING: ${plugin.name}'s provider is not an instance of ServerInterface.`);
           }

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -103,7 +103,7 @@ function greenwoodHtmlPlugin(compilation) {
   const { optimization } = compilation.config;
   const isRemoteUrl = (url = undefined) => url && (url.indexOf('http') === 0 || url.indexOf('//') === 0);
   const customResources = compilation.config.plugins.filter((plugin) => {
-    return plugin.type === 'resource';
+    return plugin.type === 'resource' && !plugin.isGreenwoodPlugin;
   }).map((plugin) => {
     return plugin.provider(compilation);
   });

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -103,7 +103,7 @@ function greenwoodHtmlPlugin(compilation) {
   const { optimization } = compilation.config;
   const isRemoteUrl = (url = undefined) => url && (url.indexOf('http') === 0 || url.indexOf('//') === 0);
   const customResources = compilation.config.plugins.filter((plugin) => {
-    return plugin.type === 'resource' && !plugin.isGreenwoodPlugin;
+    return plugin.type === 'resource' && !plugin.isGreenwoodDefaultPlugin;
   }).map((plugin) => {
     return plugin.provider(compilation);
   });
@@ -514,7 +514,7 @@ module.exports = getRollupConfig = async (compilation) => {
 
   // order matters but so far nodeModulesResource resolve plugin is the first in our list (so far)
   const greenwoodRollupPlugins = compilation.config.plugins.filter((plugin) => {
-    return plugin.type === 'rollup' && plugin.isGreenwoodPlugin;
+    return plugin.type === 'rollup' && plugin.isGreenwoodDefaultPlugin;
   }).map((plugin) => {
     return plugin.provider(compilation).flat();
   }).concat([
@@ -523,7 +523,7 @@ module.exports = getRollupConfig = async (compilation) => {
   ]).flat();
 
   const userRollupPlugins = compilation.config.plugins.filter((plugin) => {
-    return plugin.type === 'rollup' && !plugin.isGreenwoodPlugin;
+    return plugin.type === 'rollup' && !plugin.isGreenwoodDefaultPlugin;
   }).map((plugin) => {
     return plugin.provider(compilation).flat();
   }).flat();

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 
+// get and "tag" all plugins provided / maintained by the @greenwood/cli
+// and include as the default set, with all user plugins getting appended
 const greenwoodPluginsBasePath = path.join(__dirname, '../', 'plugins');
 const greenwoodPlugins = [
   path.join(greenwoodPluginsBasePath, 'resource'),
@@ -17,7 +19,7 @@ const greenwoodPlugins = [
 }).flat()
   .map((plugin) => {
     return {
-      isGreenwoodPlugin: true,
+      isGreenwoodDefaultPlugin: true,
       ...plugin
     };
   });

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -1,9 +1,29 @@
 const fs = require('fs');
 const path = require('path');
 
+const greenwoodPluginsBasePath = path.join(__dirname, '../', 'plugins');
+const greenwoodPlugins = [
+  path.join(greenwoodPluginsBasePath, 'resource'),
+  path.join(greenwoodPluginsBasePath, 'server')
+].map((pluginDirectory) => {
+  return fs.readdirSync(pluginDirectory)
+    .map((filename) => {
+      const plugin = require(`${pluginDirectory}/${filename}`);
+
+      return Array.isArray(plugin)
+        ? plugin
+        : [plugin];
+    }).flat();
+}).flat()
+  .map((plugin) => {
+    return {
+      isGreenwoodPlugin: true,
+      ...plugin
+    };
+  });
+
 const modes = ['ssg', 'mpa', 'spa'];
 const optimizations = ['default', 'none', 'static', 'inline'];
-
 const defaultConfig = {
   workspace: path.join(process.cwd(), 'src'),
   devServer: {
@@ -14,7 +34,7 @@ const defaultConfig = {
   optimization: optimizations[0],
   title: 'My App',
   meta: [],
-  plugins: [],
+  plugins: greenwoodPlugins,
   markdown: { plugins: [], settings: {} },
   prerender: true
 };

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -6,9 +6,10 @@ const pluginOptimizationMpa = require('../plugins/resource/plugin-optimization-m
 
 async function optimizePage(compilation, contents, route, outputDir) {
   const outputPath = `${outputDir}${route}index.html`;
+  // TODO
   const optimizeResources = [
     pluginResourceStandardHtml.provider(compilation),
-    pluginOptimizationMpa().provider(compilation),
+    pluginOptimizationMpa.provider(compilation),
     ...compilation.config.plugins.filter((plugin) => {
       const provider = plugin.provider(compilation);
 

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -1,25 +1,16 @@
 const BrowserRunner = require('../lib/browser');
 const fs = require('fs');
 const path = require('path');
-const pluginResourceStandardHtml = require('../plugins/resource/plugin-standard-html');
-const pluginOptimizationMpa = require('../plugins/resource/plugin-optimization-mpa');
 
 async function optimizePage(compilation, contents, route, outputDir) {
   const outputPath = `${outputDir}${route}index.html`;
-  // TODO
-  const optimizeResources = [
-    pluginResourceStandardHtml.provider(compilation),
-    pluginOptimizationMpa.provider(compilation),
-    ...compilation.config.plugins.filter((plugin) => {
-      const provider = plugin.provider(compilation);
-
-      return plugin.type === 'resource' 
-        && provider.shouldOptimize 
-        && provider.optimize;
-    }).map((plugin) => {
-      return plugin.provider(compilation);
-    })
-  ];
+  const optimizeResources = compilation.config.plugins.filter((plugin) => {
+    return plugin.type === 'resource';
+  }).map((plugin) => {
+    return plugin.provider(compilation);
+  }).filter((provider) => {
+    return provider.shouldOptimize && provider.optimize;
+  });
 
   const htmlOptimized = await optimizeResources.reduce(async (htmlPromise, resource) => {
     const html = await htmlPromise;
@@ -108,7 +99,11 @@ async function preRenderCompilation(compilation) {
 async function staticRenderCompilation(compilation) {
   const pages = compilation.graph;
   const scratchDir = compilation.context.scratchDir;
-  const htmlResource = pluginResourceStandardHtml.provider(compilation);
+  const htmlResource = compilation.config.plugins.filter((plugin) => {
+    return plugin.name === 'plugin-standard-html';
+  }).map((plugin) => {
+    return plugin.provider(compilation);
+  })[0];
 
   console.info('pages to generate', `\n ${pages.map(page => page.path).join('\n ')}`);
   

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -12,7 +12,7 @@ const pluginResourceStandardHtml = require('../plugins/resource/plugin-standard-
 const pluginResourceStandardImage = require('../plugins/resource/plugin-standard-image');
 const pluginResourceStandardJavaScript = require('../plugins/resource/plugin-standard-javascript');
 const pluginResourceStandardJson = require('../plugins/resource/plugin-standard-json');
-const pluginLiveReloadResource = require('../plugins/server/plugin-livereload')()[1];
+const pluginLiveReloadResource = require('../plugins/server/plugin-livereload')[1];
 const pluginUserWorkspace = require('../plugins/resource/plugin-user-workspace');
 const { ResourceInterface } = require('../lib/resource-interface');
 
@@ -21,6 +21,7 @@ function getDevServer(compilation) {
   const compilationCopy = Object.assign({}, compilation);
   const resources = [
     // Greenwood default standard resource and import plugins
+    // TODOs
     pluginUserWorkspace.provider(compilation),
     pluginNodeModules[0].provider(compilation),
     pluginDevProxyResource.provider(compilationCopy),
@@ -31,7 +32,7 @@ function getDevServer(compilation) {
     pluginResourceStandardJavaScript[0].provider(compilationCopy),
     pluginResourceStandardJson[0].provider(compilationCopy),
     pluginSourceMaps.provider(compilationCopy),
-    pluginResourceOptimizationMpa().provider(compilationCopy),
+    pluginResourceOptimizationMpa.provider(compilationCopy),
 
     // custom user resource plugins
     ...compilation.config.plugins.filter((plugin) => {
@@ -39,6 +40,7 @@ function getDevServer(compilation) {
     }).map((plugin) => {
       const provider = plugin.provider(compilationCopy);
 
+      // TODO move to config
       if (!(provider instanceof ResourceInterface)) {
         console.warn(`WARNING: ${plugin.name}'s provider is not an instance of ResourceInterface.`);
       }

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -10,14 +10,14 @@ function getDevServer(compilation) {
   const resources = [
     // Greenwood default standard resource and import plugins
     ...compilation.config.plugins.filter((plugin) => {
-      return plugin.type === 'resource' && plugin.isGreenwoodPlugin;
+      return plugin.type === 'resource' && plugin.isGreenwoodDefaultPlugin;
     }).map((plugin) => {
       return plugin.provider(compilationCopy);
     }),
 
     // custom user resource plugins
     ...compilation.config.plugins.filter((plugin) => {
-      return plugin.type === 'resource' && !plugin.isGreenwoodPlugin;
+      return plugin.type === 'resource' && !plugin.isGreenwoodDefaultPlugin;
     }).map((plugin) => {
       const provider = plugin.provider(compilationCopy);
 

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -2,18 +2,6 @@ const fs = require('fs');
 const path = require('path');
 const Koa = require('koa');
 
-const pluginNodeModules = require('../plugins/resource/plugin-node-modules');
-const pluginDevProxyResource = require('../plugins/resource/plugin-dev-proxy');
-const pluginResourceOptimizationMpa = require('../plugins/resource/plugin-optimization-mpa');
-const pluginSourceMaps = require('../plugins/resource/plugin-source-maps');
-const pluginResourceStandardCss = require('../plugins/resource/plugin-standard-css');
-const pluginResourceStandardFont = require('../plugins/resource/plugin-standard-font');
-const pluginResourceStandardHtml = require('../plugins/resource/plugin-standard-html');
-const pluginResourceStandardImage = require('../plugins/resource/plugin-standard-image');
-const pluginResourceStandardJavaScript = require('../plugins/resource/plugin-standard-javascript');
-const pluginResourceStandardJson = require('../plugins/resource/plugin-standard-json');
-const pluginLiveReloadResource = require('../plugins/server/plugin-livereload')[1];
-const pluginUserWorkspace = require('../plugins/resource/plugin-user-workspace');
 const { ResourceInterface } = require('../lib/resource-interface');
 
 function getDevServer(compilation) {
@@ -21,22 +9,15 @@ function getDevServer(compilation) {
   const compilationCopy = Object.assign({}, compilation);
   const resources = [
     // Greenwood default standard resource and import plugins
-    // TODOs
-    pluginUserWorkspace.provider(compilation),
-    pluginNodeModules[0].provider(compilation),
-    pluginDevProxyResource.provider(compilationCopy),
-    pluginResourceStandardCss.provider(compilationCopy),
-    pluginResourceStandardFont.provider(compilationCopy),
-    pluginResourceStandardHtml.provider(compilationCopy),
-    pluginResourceStandardImage.provider(compilationCopy),
-    pluginResourceStandardJavaScript[0].provider(compilationCopy),
-    pluginResourceStandardJson[0].provider(compilationCopy),
-    pluginSourceMaps.provider(compilationCopy),
-    pluginResourceOptimizationMpa.provider(compilationCopy),
+    ...compilation.config.plugins.filter((plugin) => {
+      return plugin.type === 'resource' && plugin.isGreenwoodPlugin;
+    }).map((plugin) => {
+      return plugin.provider(compilationCopy);
+    }),
 
     // custom user resource plugins
     ...compilation.config.plugins.filter((plugin) => {
-      return plugin.type === 'resource';
+      return plugin.type === 'resource' && !plugin.isGreenwoodPlugin;
     }).map((plugin) => {
       const provider = plugin.provider(compilationCopy);
 
@@ -108,15 +89,12 @@ function getDevServer(compilation) {
 
   // allow intercepting of urls (response)
   app.use(async (ctx) => {
-    const modifiedResources = resources.concat(
-      pluginLiveReloadResource.provider(compilation)
-    );
     const responseAccumulator = {
       body: ctx.body,
       contentType: ctx.response.headers['content-type']
     };
 
-    const reducedResponse = await modifiedResources.reduce(async (responsePromise, resource) => {
+    const reducedResponse = await resources.reduce(async (responsePromise, resource) => {
       const response = await responsePromise;
       const { url } = ctx;
       const { headers } = ctx.response;
@@ -149,7 +127,11 @@ function getDevServer(compilation) {
 
 function getProdServer(compilation) {
   const app = new Koa();
-  const proxyPlugin = pluginDevProxyResource.provider(compilation);
+  const proxyPlugin = compilation.config.plugins.filter((plugin) => {
+    return plugin.name === 'plugin-dev-server';
+  }).map((plugin) => {
+    return plugin.provider(compilation);
+  })[0];
 
   app.use(async ctx => {
     const { outputDir } = compilation.context;

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -21,7 +21,6 @@ function getDevServer(compilation) {
     }).map((plugin) => {
       const provider = plugin.provider(compilationCopy);
 
-      // TODO move to config
       if (!(provider instanceof ResourceInterface)) {
         console.warn(`WARNING: ${plugin.name}'s provider is not an instance of ResourceInterface.`);
       }

--- a/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
+++ b/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
@@ -96,10 +96,8 @@ class OptimizationMPAResource extends ResourceInterface {
   }
 }
 
-module.exports = (options = {}) => {
-  return {
-    type: 'resource',
-    name: 'plugin-optimization-mpa',
-    provider: (compilation) => new OptimizationMPAResource(compilation, options)
-  };
+module.exports = {
+  type: 'resource',
+  name: 'plugin-optimization-mpa',
+  provider: (compilation, options) => new OptimizationMPAResource(compilation, options)
 }; 

--- a/packages/cli/src/plugins/server/plugin-livereload.js
+++ b/packages/cli/src/plugins/server/plugin-livereload.js
@@ -77,14 +77,12 @@ class LiveReloadResource extends ResourceInterface {
   }
 }
 
-module.exports = (options = {}) => {
-  return [{
-    type: 'server',
-    name: 'plugin-live-reload:server',
-    provider: (compilation) => new LiveReloadServer(compilation, options)
-  }, {
-    type: 'resource',
-    name: 'plugin-live-reload:resource',
-    provider: (compilation) => new LiveReloadResource(compilation, options)
-  }];
-};
+module.exports = [{
+  type: 'server',
+  name: 'plugin-live-reload:server',
+  provider: (compilation) => new LiveReloadServer(compilation)
+}, {
+  type: 'resource',
+  name: 'plugin-live-reload:resource',
+  provider: (compilation) => new LiveReloadResource(compilation)
+}];


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #520 

## Summary of Changes
1. Consolidate all plugins into `compilation.config.plugins`
1. "Tag" Greenwood plugins vs user plugins
1. Updated all usages of plugins to reference this new single source of truth

## TODO
1. [x] Noticed a bug with a call to readFile in _plugin-node-modules_ not explicitly using `utf-8` / returning as a string, so should file a bug for that and then rebase here
1. [x] Maybe there is a better name than `isGreenwoodPlugin` and instead should be something like `isGreenwoodDefaultPlugin`?