### PR TITLE
integrate linting check for `xxx.only` usage in specs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
     sourceType: 'module'
   },
   plugins: [
-    '@typescript-eslint'
+    '@typescript-eslint',
+    'no-only-tests'
   ],
   env: {
     browser: true,
@@ -37,6 +38,7 @@ module.exports = {
     'no-irregular-whitespace': 2,
     'no-negated-in-lhs': 2,
     'no-obj-calls': 0,
+    'no-only-tests/no-only-tests': 2,
     'no-regex-spaces': 0,
     'no-sparse-arrays': 2,
     'no-unreachable': 2,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chai": "^4.2.0",
     "cross-env": "^7.0.3",
     "eslint": "^6.8.0",
+    "eslint-plugin-no-only-tests": "^2.6.0",
     "gallinago": "^0.3.0",
     "glob-promise": "^3.4.0",
     "jsdom": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5018,6 +5018,11 @@ escodegen@^1.11.0:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-plugin-no-only-tests@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz#19f6c9620bda02b9b9221b436c5f070e42628d76"
+  integrity sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==
+
 eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Added an ESLint plugin for catching "only" usage in specs, e.g. `describe.only` or `it.only`