### PR TITLE
Enhancement/issue 557 resolve node modules using node require resolve

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -159,6 +159,37 @@ To test from a VM, you can
 
 You can disable plugins in _webpack.config.prod.js_ to remove production optimizations for testing purposes.
 
+## npx Testing
+[`npx`](https://www.npmjs.com/package/npx) is a useful CLI utitlity bundled with NodeJS that allows users to run npm packages globally but without having to install them.
+
+```sh
+% npx http-server
+Starting up http-server, serving ./public
+Available on:
+  http://127.0.0.1:8080
+  http://192.168.1.153:8080
+Hit CTRL-C to stop the server
+```
+
+It's featured on the Greenwood website [home page](https://www.greenwoodjs.io/) and in the [Quick Start guide](https://www.greenwoodjs.io/getting-started/quick-start/#command-line) as an option for using Greenwood.  There is a [spec for it](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/cli/test/cases/build.default.quick-start-npx) to try and simulate running it.
+
+You can use it for local development with Greenwood by using [npm link](https://docs.npmjs.com/cli/v7/commands/npm-link) to make `greenwood` available to your local CLI.
+```sh
+# From the root of the Greenwood repo
+$ npm link
+
+# then say in a test case folder
+$ cd packages/cli/test/cases/build.default.quick-start-npx
+$ npx greenwood
+-------------------------------------------------------
+Welcome to Greenwood (v0.14.1) ♻️
+-------------------------------------------------------
+Running Greenwood with the  command.
+
+          Error: not able to detect command. try using the --help flag if
+          you're encountering issues running Greenwood.  Visit our docs for more
+          info at https://www.greenwoodjs.io/docs/.
+```
 
 ## Docker
 A Docker container is available within the project to use as a development environment if you like.  It is configured to use the same image that runs as part of the project's [Continuous Integration environment](https://github.com/ProjectEvergreen/greenwood/blob/master/.github/workflows/ci.yml#L9).

--- a/packages/cli/src/lib/browser.js
+++ b/packages/cli/src/lib/browser.js
@@ -42,8 +42,7 @@ class BrowserRunner {
 
       if (
         interceptedRequestUrl.indexOf('http://127.0.0.1') >= 0 ||
-        interceptedRequestUrl.indexOf('localhost') >= 0 ||
-        interceptedRequestUrl.indexOf('unpkg.com') >= 0
+        interceptedRequestUrl.indexOf('localhost') >= 0
       ) {
         interceptedRequest.continue();
       } else {

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -205,7 +205,7 @@ class NodeModulesResource extends ResourceInterface {
     return Promise.resolve(url.indexOf('node_modules/') >= 0);
   }
 
-  sync resolve(url) {
+  async resolve(url) {
     const packagePathPieces = url.split('node_modules/')[1].split('/'); // double split to handle node_modules within nested paths
     let packageName = packagePathPieces.shift();
     let nodeModulesUrl;

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -264,7 +264,7 @@ class NodeModulesResource extends ResourceInterface {
   async intercept(url, body) {
     return new Promise((resolve, reject) => {
       try {
-        const { userWorkspace, projectDirectory } = this.compilation.context;
+        const { userWorkspace } = this.compilation.context;
         let newContents = body;
         const hasHead = body.match(/\<head>(.*)<\/head>/s);
 
@@ -280,10 +280,6 @@ class NodeModulesResource extends ResourceInterface {
           : fs.existsSync(`${process.cwd()}/package.json`)
             ? require(path.join(process.cwd(), 'package.json'))
             : {};
-        const esShimsFilename = '/node_modules/es-module-shims/dist/es-module-shims.js';
-        const esShimsPath = fs.existsSync(path.join(projectDirectory, esShimsFilename))
-          ? esShimsFilename
-          : 'https://unpkg.com/es-module-shims@0.5.2/dist/es-module-shims.js';
         
         // walk the project's pacakge.json for all its direct dependencies
         // for each entry found in dependencies, find its entry point
@@ -291,9 +287,10 @@ class NodeModulesResource extends ResourceInterface {
         // and then walk its package.json for transitive dependencies and all those import / exports
         walkPackageJson(userPackageJson);
 
+        // apply import map and shim for users
         newContents = newContents.replace('<head>', `
           <head>
-            <script defer src="${esShimsPath}"></script>
+            <script defer src="/node_modules/es-module-shims/dist/es-module-shims.js"></script>
             <script type="importmap-shim">
               {
                 "imports": ${JSON.stringify(importMap, null, 1)}

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -206,7 +206,7 @@ class NodeModulesResource extends ResourceInterface {
   }
 
   async resolve(url) {
-    const packagePathPieces = url.split('node_modules/')[1].split('/'); // double split to handle node_modules within nested paths
+    const packagePathPieces = this.getBareUrlPath(url).split('node_modules/')[1].split('/'); // double split to handle node_modules within nested paths
     let packageName = packagePathPieces.shift();
     let nodeModulesUrl;
 
@@ -215,22 +215,39 @@ class NodeModulesResource extends ResourceInterface {
       packageName = `${packageName}/${packagePathPieces.shift()}`;
     }
 
-    const packageEntryLocation = require.resolve(packageName).replace(/\\/g, '/'); // force / for consistency and path matching
-    
-    if (packageName.indexOf('@greenwood') === 0) {
-      const subPackage = packageName.split('/')[1];
-      const packageRootPath = packageEntryLocation.indexOf('@greenwood') > 0
-        ? packageEntryLocation.split(packageName)[0] // we are in the user's node modules
-        : packageEntryLocation.split(subPackage)[0]; // else we are in our monorepo
+    // ideally let NodeJS do the look up for us, but in the evant that fails
+    // do our best to resolve the file (helpful for theme pack testing and development) 
+    // (where things are unpublished and routed around)
+    try {
+      const packageEntryLocation = require.resolve(packageName).replace(/\\/g, '/'); // force / for consistency and path matching
 
-      nodeModulesUrl = `${packageRootPath}${subPackage}/${packagePathPieces.join('/')}`;
-    } else {
-      const packageRootPath = packageEntryLocation.split(packageName)[0];
+      if (packageName.indexOf('@greenwood') === 0) {
+        const subPackage = packageName.split('/')[1];
+        const packageRootPath = packageEntryLocation.indexOf('@greenwood') > 0
+          ? packageEntryLocation.split(packageName)[0] // we are in the user's node modules
+          : packageEntryLocation.split(subPackage)[0]; // else we are in our monorepo
 
-      nodeModulesUrl = `${packageRootPath}${packageName}/${packagePathPieces.join('/')}`;
+        nodeModulesUrl = `${packageRootPath}${subPackage}/${packagePathPieces.join('/')}`;
+      } else {
+        const packageRootPath = packageEntryLocation.split(packageName)[0];
+
+        nodeModulesUrl = `${packageRootPath}${packageName}/${packagePathPieces.join('/')}`;
+      }
+
+      return Promise.resolve(nodeModulesUrl);
+    } catch (e) {
+      console.debug('Error looking of package with NodeJS, falling back to default greenwood node_modules resolution');
+      const { projectDirectory } = this.compilation.context;
+      const bareUrl = this.getBareUrlPath(url);
+      const isAbsoluteNodeModulesFile = fs.existsSync(path.join(projectDirectory, bareUrl));
+      const nodeModulesUrl = isAbsoluteNodeModulesFile
+        ? path.join(projectDirectory, bareUrl)
+        : this.resolveRelativeUrl(projectDirectory, bareUrl)
+          ? path.join(projectDirectory, this.resolveRelativeUrl(projectDirectory, bareUrl))
+          : bareUrl;
+
+      return Promise.resolve(nodeModulesUrl);
     }
-    
-    return Promise.resolve(nodeModulesUrl);
   }
 
   async shouldServe(url) {

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -197,16 +197,12 @@ const getAppTemplate = (contents, templatesDir, customImports = [], contextPlugi
   return appTemplateContents;
 };
 
-const getUserScripts = (contents, projectDirectory) => {
+const getUserScripts = (contents) => {
+  // polyfill chromium for WCs support
   if (process.env.__GWD_COMMAND__ === 'build') { // eslint-disable-line no-underscore-dangle
-    const wcBundleFilename = '/node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js';
-    const wcBundlePath = fs.existsSync(path.join(projectDirectory, wcBundleFilename))
-      ? wcBundleFilename
-      : 'https://unpkg.com/@webcomponents/webcomponentsjs@2.4.4/webcomponents-bundle.js';
-
     contents = contents.replace('<head>', `
       <head>
-        <script src="${wcBundlePath}"></script>
+        <script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
     `);
   }
   return contents;
@@ -356,8 +352,8 @@ class StandardHtmlResource extends ResourceInterface {
           body = getPageTemplate(barePath, userTemplatesDir, template, contextPlugins);
         }
 
-        body = getAppTemplate(body, userTemplatesDir, customImports, contextPlugins);
-        body = getUserScripts(body, projectDirectory);
+        body = getAppTemplate(body, userTemplatesDir, customImports, contextPlugins);  
+        body = getUserScripts(body, customImports);
         body = getMetaContent(normalizedUrl.replace(/\\/g, '/'), config, body);
         
         if (processedMarkdown) {

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -274,7 +274,7 @@ class StandardHtmlResource extends ResourceInterface {
     return new Promise(async (resolve, reject) => {
       try {
         const config = Object.assign({}, this.compilation.config);
-        const { pagesDir, userTemplatesDir, projectDirectory } = this.compilation.context;
+        const { pagesDir, userTemplatesDir } = this.compilation.context;
         const { mode } = this.compilation.config;
         const normalizedUrl = this.getRelativeUserworkspaceUrl(url);
         let customImports;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #557 

## Summary of Changes
1. Updated **plugin-node-modules** to leverage `require.resolve` instead of assuming where _node_modules_ is located on disk (in an effort to better handle #505 / #511 type situations)
2. Per the addition of testing in support of #570, had to add some falback / exception handling in case `require.resolve` blows up like happened for our theme pack specs (should see if I can mock this better or make an issue / discussion)
```sh
Error: Cannot find module 'my-theme-pack'
Require stack:
- /Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/plugins/resource/plugin-node-modules.js
- /Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/lifecycles/config.js
- /Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/lifecycles/compile.js
- /Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/commands/build.js
- /Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.resolve (internal/modules/cjs/helpers.js:94:19)
    at NodeModulesResource.resolve (/Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/plugins/resource/plugin-node-modules.js:29:85)
    at /Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/lifecycles/serve.js:4:421
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
    at async /Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/lifecycles/serve.js:4:216
    at async /Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/lifecycles/serve.js:4:216
    at async /Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/lifecycles/serve.js:4:216
    at async /Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/lifecycles/serve.js:4:216
    at async /Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/lifecycles/serve.js:4:216 {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/plugins/resource/plugin-node-modules.js',
    '/Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/lifecycles/config.js',
    '/Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/lifecycles/compile.js',
    '/Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/commands/build.js',
    '/Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/index.js'
  ]
}
```


> Initial and ongoing analysis and experiments being conducted in this repo - https://github.com/thescientist13/node-resolve-experiments

Was able to confirm things seem to be working as expected now that we are using `require.resolve` in the `npx` test case by changing the content to say `<h2>hello require.resolve</h2>`
```sh
% cd packages/cli/test/cases/build.default.quick-start-npx
owenbuckley@Owens-MBP-2 build.default.quick-start-npx % npx greenwood build
-------------------------------------------------------
Welcome to Greenwood (v0.14.1) ♻️
-------------------------------------------------------
Running Greenwood with the build command.
Initializing project config
Initializing project workspace contexts
Generating graph of workspace files...
Started local development server at localhost:1984
Prerendering pages at http://127.0.0.1:1984
pages to render
 src/pages/index.md
prerendering page... /
prerendering complete for page /.
done prerendering all pages
copying graph.json...
owenbuckley@Owens-MBP-2 build.default.quick-start-npx % cat public/index.html
<!DOCTYPE html><html lang="en" prefix="og:http://ogp.me/ns#">
                        <head>
                        <link rel="modulepreload" href="/header.4557af3c.js" as="script">
                      <!-- Shady DOM styles for app-header --><style>body {transition: opacity ease-in 0.2s; }
body[unresolved] {opacity: 0; display: block; overflow: hidden; position: relative; }
</style>





    <title>My App</title>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <meta name="mobile-web-app-capable" content="yes">
    <meta name="apple-mobile-web-app-capable" content="yes">
    <meta name="apple-mobile-web-app-status-bar-style" content="black">


            <script type="module" src="/header.4557af3c.js"></script>

          </head>

  <body>


    <div>
      <app-header>
      <header class="style-scope app-header">This is the header component.</header>
    </app-header>
      <h2>hello require.resolve</h2>
    </div>



 </body></html>




```

## TODO
1. [x] Fix failing specs for Windows
1. [x] Check for any other hardcoded lookup paths for _node_modules_ when reading from the filesystem in Greenwood (I think ideally it should only need to happen in the plugin though)
    - left some initial thoughts here - https://github.com/ProjectEvergreen/greenwood/pull/674#issuecomment-887838612
1. [x] Update `npx` test case to not require **unpkg** fallback and / or figure out a way to test locally
1. [x] Probably a little room left for some cleanup / refactoring
    -  not sure if we need to [recursively support scoped packages](https://github.com/ProjectEvergreen/greenwood/pull/674/files#diff-e6731c225dc2a78d6caf722587c6ac2eacd3908ce5e23f13a3b6058ab3d7d183R203)?  e.g. can they have names like `@scoped-packages/something/else` - reached out in NodeJS slack, will see, but I think it would definitely be an edge case
    - wondering if we should change our logic [here](https://github.com/ProjectEvergreen/greenwood/blob/v0.14.1/packages/cli/src/plugins/resource/plugin-node-modules.js#L25) at all?  Had some [good lessons learned here](https://github.com/thescientist13/node-resolve-experiments) that might be applicable in terms of prioritization and just make sure we have it right.  👌 - I think it is OK for now
    - re-re-evaluate need for [`walkModule`](https://github.com/ProjectEvergreen/greenwood/pull/672#issuecomment-888359598)? - maybe for another PR / discussion