### PR TITLE
Bug/issue 676 support query params serve dev proxy

### DIFF
--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -195,7 +195,7 @@ function getProdServer(compilation) {
     }
 
     if (url !== '/' && await proxyPlugin.shouldServe(url)) {
-      ctx.body = (await proxyPlugin.serve(url)).body;
+      ctx.body = (await proxyPlugin.serve(ctx.originalUrl)).body;
     }
   });
     

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -195,7 +195,7 @@ function getProdServer(compilation) {
     }
 
     if (url !== '/' && await proxyPlugin.shouldServe(url)) {
-      ctx.body = (await proxyPlugin.serve(ctx.originalUrl)).body;
+      ctx.body = (await proxyPlugin.serve(ctx.url)).body;
     }
   });
     

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -520,7 +520,7 @@ describe('Develop Greenwood With: ', function() {
 
       before(async function() {
         return new Promise((resolve, reject) => {
-          request.get(`${hostname}:${port}/api/events`, (err, res, body) => {
+          request.get(`${hostname}:${port}/api/albums?artistId=2`, (err, res, body) => {
             if (err) {
               reject();
             }
@@ -544,7 +544,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct response body', function(done) {
-        expect(response.body).to.have.lengthOf.at.least(0);
+        expect(response.body).to.have.lengthOf(1);
         done();
       });
     });

--- a/packages/cli/test/cases/serve.default/greenwood.config.js
+++ b/packages/cli/test/cases/serve.default/greenwood.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  devServer: {
+    proxy: {
+      '/api': 'https://www.analogstudios.net'
+    }
+  }
+};

--- a/packages/cli/test/cases/serve.default/serve.default.spec.js
+++ b/packages/cli/test/cases/serve.default/serve.default.spec.js
@@ -14,8 +14,10 @@
  * User Workspace
  * Greenwood default (src/)
  */
+const expect = require('chai').expect;
 const path = require('path');
 const { getSetupFiles, getOutputTeardownFiles } = require('../../../../../test/utils');
+const request = require('request');
 const runSmokeTest = require('../../../../../test/smoke-test');
 const Runner = require('gallinago').Runner;
 
@@ -48,6 +50,42 @@ describe('Serve Greenwood With: ', function() {
     });
 
     runSmokeTest(['serve'], LABEL);
+
+    // proxies to analogstudios.net/api/events vis greenwood.config.js
+    // ideally should find something else to avoid using something "live" in our tests
+    describe('Serve command with dev proxy', function() {
+      let response = {};
+
+      before(async function() {
+        return new Promise((resolve, reject) => {
+          request.get(`${hostname}/api/albums?artistId=2`, (err, res, body) => {
+            if (err) {
+              reject();
+            }
+
+            response = res;
+            response.body = JSON.parse(body);
+
+            resolve();
+          });
+        });
+      });
+
+      it('should return a 200 status', function(done) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
+
+      it('should return the correct content type', function(done) {
+        expect(response.headers['content-type']).to.contain('application/json');
+        done();
+      });
+
+      it('should return the correct response body', function(done) {
+        expect(response.body).to.have.lengthOf(1);
+        done();
+      });
+    });
   });
 
   after(function() {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #676 

## Summary of Changes
1.  Pass full URL to prodServer when proxying
1. Added test cases for `develop` and `serve` commands (assumption being if the call was just `/api/albums/` the response would be > 1)