### PR TITLE
handle double quotes used inside user CSS for import CSS

### DIFF
--- a/packages/plugin-import-css/src/index.js
+++ b/packages/plugin-import-css/src/index.js
@@ -30,7 +30,7 @@ class ImportCssResource extends ResourceInterface {
   async intercept(url, body) {
     return new Promise(async (resolve, reject) => {
       try {
-        const cssInJsBody = `const css = "${body.replace(/\r?\n|\r/g, ' ')}";\nexport default css;`;
+        const cssInJsBody = `const css = "${body.replace(/\r?\n|\r/g, ' ').replace(/"/g, '\\"')}";\nexport default css;`;
         
         resolve({
           body: cssInJsBody,

--- a/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
@@ -86,7 +86,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return an ECMASCript module', function(done) {
-        expect(response.body.replace('\n', '')).to.equal('const css = "* {   color: blue; }";export default css;');
+        expect(response.body.replace('\n', '')).to.equal('const css = "* {   color: blue;   background-image: url(\\"/assets/background.jpg\\"); }";export default css;');
         done();
       });
     });

--- a/packages/plugin-import-css/test/cases/develop.default/src/main.css
+++ b/packages/plugin-import-css/test/cases/develop.default/src/main.css
@@ -1,3 +1,4 @@
 * {
   color: blue;
+  background-image: url("/assets/background.jpg");
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #678 

## Summary of Changes
1. Since we use `"` to wrap CSS via ESM, need to escape `"` in userland code
1. Added test