### PR TITLE
have prod server reuse standard plugins

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-dev-proxy.js
+++ b/packages/cli/src/plugins/resource/plugin-dev-proxy.js
@@ -40,6 +40,6 @@ class DevProxyResource extends ResourceInterface {
 
 module.exports = {
   type: 'resource',
-  name: 'plugin-dev-server',
+  name: 'plugin-dev-proxy',
   provider: (compilation, options) => new DevProxyResource(compilation, options)
 };


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #519 

## Summary of Changes
1. Refactor `prodServer` to leverage standard plugins logic instead of it being duplicated