### PR TITLE
exclude node modules from user workspace resolution

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-user-workspace.js
+++ b/packages/cli/src/plugins/resource/plugin-user-workspace.js
@@ -20,7 +20,7 @@ class UserWorkspaceResource extends ResourceInterface {
     const isAbsoluteWorkspaceFile = fs.existsSync(path.join(userWorkspace, bareUrl));
     const workspaceUrl = isAbsoluteWorkspaceFile
       ? isAbsoluteWorkspaceFile || bareUrl === '/'
-      : this.resolveRelativeUrl(userWorkspace, bareUrl);
+      : url.indexOf('node_modules') < 0 && this.resolveRelativeUrl(userWorkspace, bareUrl);
 
     return Promise.resolve(workspaceUrl);
   }

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -478,6 +478,42 @@ describe('Develop Greenwood With: ', function() {
       });
     });
 
+    // if things work correctly, this workspace file should never resolve for the equivalent node_modules file
+    // https://github.com/ProjectEvergreen/greenwood/pull/687
+    describe('Develop command specific workspace resolution when matching node_modules', function() {
+      let response = {};
+
+      before(async function() {
+        return new Promise((resolve, reject) => {
+          request.get(`${hostname}:${port}/lit-html.js`, (err, res, body) => {
+            if (err) {
+              reject();
+            }
+
+            response = res;
+            response.body = body;
+
+            resolve();
+          });
+        });
+      });
+
+      it('should return a 200 status', function(done) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
+
+      it('should return the correct content type', function(done) {
+        expect(response.headers['content-type']).to.equal('text/javascript');
+        done();
+      });
+
+      it('should return the correct response body', function(done) {
+        expect(response.body).to.equal('console.debug(\'its just a prank bro!\');');
+        done();
+      });
+    });
+
     // need some better 404 handling here (promise reject handling for assets and routes)
     describe('Develop command with default 404 behavior', function() {
       let response = {};

--- a/packages/cli/test/cases/develop.default/src/lit-html.js
+++ b/packages/cli/test/cases/develop.default/src/lit-html.js
@@ -1,3 +1,1 @@
-// if things work correctly, this should never resolve
-// https://github.com/ProjectEvergreen/greenwood/pull/687
 console.debug('its just a prank bro!');

--- a/packages/cli/test/cases/develop.default/src/lit-html.js
+++ b/packages/cli/test/cases/develop.default/src/lit-html.js
@@ -1,0 +1,3 @@
+// if things work correctly, this should never resolve
+// https://github.com/ProjectEvergreen/greenwood/pull/687
+console.debug('its just a prank bro!');


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves https://github.com/ProjectEvergreen/greenwood/issues/686#issuecomment-894470074

## Summary of Changes
1. Ignore resolving _node_modules_ paths from user workspace resolution, leading to "false" positives

For example in the test case, if we _didn't_ have this fix, requesting both files would always return the contents of _src/lit-html.js_.

## TODO
1. [x] Add a test case to cover this scenario