### PR TITLE
fix consistency with user plugin node modules resolution

### DIFF
--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -33,11 +33,10 @@ function getDevServer(compilation) {
   app.use(async (ctx, next) => {
     ctx.url = await resources.reduce(async (responsePromise, resource) => {
       const response = await responsePromise;
-      const { url } = ctx;
-      const resourceShouldResolveUrl = await resource.shouldResolve(url);
+      const resourceShouldResolveUrl = await resource.shouldResolve(response);
       
       return resourceShouldResolveUrl
-        ? resource.resolve(url)
+        ? resource.resolve(response)
         : Promise.resolve(response);
     }, Promise.resolve(ctx.url));
 

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -207,12 +207,13 @@ class NodeModulesResource extends ResourceInterface {
 
   async resolve(url) {
     const { projectDirectory } = this.compilation.context;
-    const isAbsoluteNodeModulesFile = fs.existsSync(path.join(projectDirectory, url));
+    const bareUrl = this.getBareUrlPath(url);
+    const isAbsoluteNodeModulesFile = fs.existsSync(path.join(projectDirectory, bareUrl));
     const nodeModulesUrl = isAbsoluteNodeModulesFile
-      ? path.join(projectDirectory, url)
-      : this.resolveRelativeUrl(projectDirectory, url)
-        ? path.join(projectDirectory, this.resolveRelativeUrl(projectDirectory, url))
-        : url;
+      ? path.join(projectDirectory, bareUrl)
+      : this.resolveRelativeUrl(projectDirectory, bareUrl)
+        ? path.join(projectDirectory, this.resolveRelativeUrl(projectDirectory, bareUrl))
+        : bareUrl;
 
     return Promise.resolve(nodeModulesUrl);
   }

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -17,12 +17,6 @@ class StandardCssResource extends ResourceInterface {
     this.contentType = 'text/css';
   }
 
-  async shouldServe(url) {
-    const isCssFile = path.extname(url) === this.extensions[0];
-    
-    return Promise.resolve(isCssFile);
-  }
-
   async serve(url) {
     return new Promise(async (resolve, reject) => {
       try {  


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #690 

## Summary of Changes
1. Have server resolve middleware "forward" resolved URLs to each resolver (instead of the original URL each time)
1. Have plugin-node-modules resolve to paths _without_ query strings
1. Have plugin-standard-css use default `ResourceInterface.shouldResolve` logic, like most other Greenwood standard resource plugins
1. Added tests

> _Created a discussion to go into this with more depth - #691_

## TODO
1. [x] Should confirm if this is a regression or not due to #520 
    - it still existed in `v0.14.2` - https://github.com/ProjectEvergreen/greenwood/pull/692#issuecomment-894721821