### PR TITLE
refactor and enhance tests for CSS with quotes

### DIFF
--- a/packages/plugin-import-css/src/index.js
+++ b/packages/plugin-import-css/src/index.js
@@ -30,7 +30,7 @@ class ImportCssResource extends ResourceInterface {
   async intercept(url, body) {
     return new Promise(async (resolve, reject) => {
       try {
-        const cssInJsBody = `const css = "${body.replace(/\r?\n|\r/g, ' ').replace(/"/g, '\\"')}";\nexport default css;`;
+        const cssInJsBody = `const css = \`${body.replace(/\r?\n|\r/g, ' ')}\`;\nexport default css;`;
         
         resolve({
           body: cssInJsBody,

--- a/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
@@ -17,7 +17,6 @@
  *
  */
 const expect = require('chai').expect;
-const { JSDOM } = require('jsdom');
 const path = require('path');
 const request = require('request');
 const Runner = require('gallinago').Runner;
@@ -67,8 +66,8 @@ describe('Develop Greenwood With: ', function() {
             }
 
             response = res;
-            
-            dom = new JSDOM(body);
+            response.body = body;
+
             resolve();
           });
         });
@@ -86,7 +85,8 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return an ECMASCript module', function(done) {
-        expect(response.body.replace('\n', '')).to.equal('const css = "* {   color: blue;   background-image: url(\\"/assets/background.jpg\\"); }";export default css;');
+        expect(response.body.replace('\n', ''))
+          .to.equal('const css = `* {   color: \\\'blue\\\';   background-image: url("/assets/background.jpg");   content: \\"\\";   font-family: \'Arial\' }`;export default css;');
         done();
       });
     });

--- a/packages/plugin-import-css/test/cases/develop.default/src/main.css
+++ b/packages/plugin-import-css/test/cases/develop.default/src/main.css
@@ -1,4 +1,6 @@
 * {
-  color: blue;
+  color: \'blue\';
   background-image: url("/assets/background.jpg");
+  content: \"\";
+  font-family: 'Arial'
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #678 

## Summary of Changes
1. Refactor to support nested quotes when wrapping CSS-in-JS for using with ESM
1. Updated specs to test all possible permutations of single and double quote escaping