### PR TITLE
pull card image under greenwoods hosting

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -20,7 +20,7 @@ module.exports = {
     { property: 'og:title', content: 'Greenwood' },
     { property: 'og:type', content: 'website' },
     { property: 'og:url', content: 'https://www.greenwoodjs.io' },
-    { property: 'og:image', content: 'https://s3.amazonaws.com/hosted.greenwoodjs.io/greenwood-logo.png' },
+    { property: 'og:image', content: 'https://www.greenwoodjs.io/assets/greenwood-logo-300w.png' },
     { property: 'og:description', content: META_DESCRIPTION },
     { rel: 'shortcut icon', href: FAVICON_HREF },
     { rel: 'icon', href: FAVICON_HREF },


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Point `og:image` to URL [hosted / managed by Greenwood's website already](https://www.greenwoodjs.io/assets/greenwood-logo-300w.png) to avoid dependency on external system (S3)