### PR TITLE
remove un-needed attribution setting from HTML

### DIFF
--- a/www/templates/page.html
+++ b/www/templates/page.html
@@ -23,7 +23,7 @@
     <div class='gwd-content-wrapper'>
       
       <div class="gwd-sidebar">
-        <app-shelf .page="${page}"></app-shelf>
+        <app-shelf></app-shelf>
       </div>
       
       <div class="gwd-content">


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Remove un-needed attribute setting for `<app-shelf>` in page template (since it is set via JS)