### PR TITLE
upgrade latest puppeteer (includes M1 Mac support)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
     "node-html-parser": "^1.2.21",
     "postcss": "^7.0.32",
     "postcss-import": "^12.0.0",
-    "puppeteer": "^5.3.0",
+    "puppeteer": "^10.2.0",
     "rehype-raw": "^5.0.0",
     "rehype-stringify": "^8.0.0",
     "remark-frontmatter": "^2.0.0",

--- a/packages/cli/src/lib/browser.js
+++ b/packages/cli/src/lib/browser.js
@@ -33,7 +33,7 @@ class BrowserRunner {
     page.evaluateOnNewDocument('ShadyDOM = {force: true}');
     page.evaluateOnNewDocument('ShadyCSS = {shimcssproperties: true}');
     
-    await page.setCacheEnabled(false);
+    await page.setCacheEnabled(false); // https://github.com/ProjectEvergreen/greenwood/pull/699
     await page.setRequestInterception(true);
 
     // only allow puppeteer to load necessary (local) scripts needed for pre-rendering of the site itself

--- a/packages/cli/src/lib/browser.js
+++ b/packages/cli/src/lib/browser.js
@@ -19,7 +19,6 @@ class BrowserRunner {
 
   async init() {
     this.browser = await puppeteer.launch({
-      headless: true,
       args: ['--no-sandbox']
     });
   }

--- a/packages/cli/src/lib/browser.js
+++ b/packages/cli/src/lib/browser.js
@@ -33,6 +33,7 @@ class BrowserRunner {
     page.evaluateOnNewDocument('ShadyDOM = {force: true}');
     page.evaluateOnNewDocument('ShadyCSS = {shimcssproperties: true}');
     
+    await page.setCacheEnabled(false);
     await page.setRequestInterception(true);
 
     // only allow puppeteer to load necessary (local) scripts needed for pre-rendering of the site itself

--- a/yarn.lock
+++ b/yarn.lock
@@ -2764,10 +2764,12 @@ agent-base@4, agent-base@^4.3.0:
   dependencies:
     es6-promisify "^5.0.0"
 
-agent-base@5:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
-  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+agent-base@6:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
 
 agent-base@~4.2.1:
   version "4.2.1"
@@ -4527,7 +4529,7 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.0, debug@^4.2.0:
+debug@4.3.1, debug@^4.0.0, debug@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -4679,10 +4681,10 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
-devtools-protocol@0.0.799653:
-  version "0.0.799653"
-  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.799653.tgz#86fc95ce5bf4fdf4b77a58047ba9d2301078f119"
-  integrity sha512-t1CcaZbvm8pOlikqrsIM9GOa7Ipp07+4h/q9u0JXBWjPCjHdBl9KkddX87Vv9vBHoBGtwV79sYQNGnQM6iS5gg==
+devtools-protocol@0.0.901419:
+  version "0.0.901419"
+  resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.901419.tgz#79b5459c48fe7e1c5563c02bd72f8fec3e0cebcd"
+  integrity sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==
 
 dezalgo@^1.0.0:
   version "1.0.3"
@@ -5290,7 +5292,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-zip@^2.0.0:
+extract-zip@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
@@ -6412,6 +6414,14 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+https-proxy-agent@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 https-proxy-agent@^2.2.3:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
@@ -6419,14 +6429,6 @@ https-proxy-agent@^2.2.3:
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
-
-https-proxy-agent@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
-  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
-  dependencies:
-    agent-base "5"
-    debug "4"
 
 humanize-ms@^1.2.1:
   version "1.2.1"
@@ -8006,11 +8008,6 @@ mime@1.6.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.0.3:
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
-  integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
-
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
@@ -8093,11 +8090,6 @@ mixin-deep@^1.1.3, mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
-
-mkdirp-classic@^0.5.2:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
-  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 mkdirp-promise@^5.0.1:
   version "5.0.1"
@@ -8274,7 +8266,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.5.0, node-fetch@^2.6.1:
+node-fetch@2.6.1, node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.5.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -9011,19 +9003,19 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
+pkg-dir@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
+
 pkg-dir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
   integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
   dependencies:
     find-up "^3.0.0"
-
-pkg-dir@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
-  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
-  dependencies:
-    find-up "^4.0.0"
 
 pn@^1.1.0:
   version "1.1.0"
@@ -9773,7 +9765,12 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-progress@^2.0.0, progress@^2.0.1:
+progress@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
+  integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
+
+progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -9851,7 +9848,7 @@ proxy-addr@~2.0.5:
     forwarded "~0.1.2"
     ipaddr.js "1.9.1"
 
-proxy-from-env@^1.0.0:
+proxy-from-env@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
@@ -9896,23 +9893,23 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-5.3.0.tgz#0abf83d0f2d1273baf2b56885a813f8052903e33"
-  integrity sha512-GjqMk5GRro3TO0sw3QMsF1H7n+/jaK2OW45qMvqjYUyJ7y4oA//9auy969HHhTG3HZXaMxY/NWXF/NXlAFIvtw==
+puppeteer@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-10.2.0.tgz#7d8d7fda91e19a7cfd56986e0275448e6351849e"
+  integrity sha512-OR2CCHRashF+f30+LBOtAjK6sNtz2HEyTr5FqAvhf8lR/qB3uBRoIZOwQKgwoyZnMBsxX7ZdazlyBgGjpnkiMw==
   dependencies:
-    debug "^4.1.0"
-    devtools-protocol "0.0.799653"
-    extract-zip "^2.0.0"
-    https-proxy-agent "^4.0.0"
-    mime "^2.0.3"
-    pkg-dir "^4.2.0"
-    progress "^2.0.1"
-    proxy-from-env "^1.0.0"
-    rimraf "^3.0.2"
-    tar-fs "^2.0.0"
-    unbzip2-stream "^1.3.3"
-    ws "^7.2.3"
+    debug "4.3.1"
+    devtools-protocol "0.0.901419"
+    extract-zip "2.0.1"
+    https-proxy-agent "5.0.0"
+    node-fetch "2.6.1"
+    pkg-dir "4.2.0"
+    progress "2.0.1"
+    proxy-from-env "1.1.0"
+    rimraf "3.0.2"
+    tar-fs "2.0.0"
+    unbzip2-stream "1.3.3"
+    ws "7.4.6"
 
 pwa-helpers@^0.9.1:
   version "0.9.1"
@@ -10532,17 +10529,17 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@3.0.2, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -11492,13 +11489,13 @@ table@^6.0.3:
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
 
-tar-fs@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.0.tgz#d1cdd121ab465ee0eb9ccde2d35049d3f3daf0d5"
-  integrity sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==
+tar-fs@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.0.0.tgz#677700fc0c8b337a78bee3623fdc235f21d7afad"
+  integrity sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==
   dependencies:
     chownr "^1.1.1"
-    mkdirp-classic "^0.5.2"
+    mkdirp "^0.5.1"
     pump "^3.0.0"
     tar-stream "^2.0.0"
 
@@ -11863,10 +11860,10 @@ unbox-primitive@^1.0.0:
     has-symbols "^1.0.0"
     which-boxed-primitive "^1.0.1"
 
-unbzip2-stream@^1.3.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz#b0da04c4371311df771cdc215e87f2130991ace7"
-  integrity sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
+unbzip2-stream@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz#d156d205e670d8d8c393e1c02ebd506422873f6a"
+  integrity sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
@@ -12364,6 +12361,11 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
+ws@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
 ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
@@ -12377,11 +12379,6 @@ ws@^6.0.0, ws@^6.1.2, ws@^6.2.1:
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
-
-ws@^7.2.3:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
-  integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #675 + #611  /  #630 

~~(my guess is due to one of the issues below, the build github action will likely time out and fail)~~

## Summary of Changes
Was testing out upgrading **puppeteer** in the #611 branch but was seeing an issue where I could build _index.html_ but anything more than that, like just index.html + _pages/about_ would hang and never complete all the pre-rendering.  😕 

[Found a solution!](https://github.com/ProjectEvergreen/greenwood/pull/699#issuecomment-914466043)

<details>
```sh
% yarn clean && yarn build
yarn run v1.22.5
$ rimraf ./**/.greenwood/** && rimraf ./**/public/** && rimraf ./coverage
✨  Done in 7.90s.
yarn run v1.22.5
$ cross-env __GWD_ROLLUP_MODE__=strict node . build
-------------------------------------------------------
Welcome to Greenwood (v0.15.2) ♻️
-------------------------------------------------------
Running Greenwood with the build command.
Initializing project config
Initializing project workspace contexts
Generating graph of workspace files...
Started local development server at localhost:1984
GraphQLServer started at http://localhost:4000/
Prerendering pages at http://127.0.0.1:1984
pages to render
 www/pages/about/community.md
 www/pages/about/features.md
 www/pages/about/goals.md
 www/pages/about/how-it-works.md
 www/pages/about/index.md
 www/pages/docs/component-model.md
 www/pages/docs/configuration.md
 www/pages/docs/css-and-images.md
 www/pages/docs/data.md
 www/pages/docs/front-matter.md
 www/pages/docs/index.md
 www/pages/docs/layouts.md
 www/pages/docs/markdown.md
 www/pages/docs/menus.md
 www/pages/docs/tech-stack.md
 www/pages/getting-started/branding.md
 www/pages/getting-started/build-and-deploy.md
 www/pages/getting-started/creating-content.md
 www/pages/getting-started/index.md
 www/pages/getting-started/key-concepts.md
 www/pages/getting-started/next-steps.md
 www/pages/getting-started/project-setup.md
 www/pages/getting-started/quick-start.md
 www/pages/guides/cloudflare-workers-deployment.md
 www/pages/guides/firebase.md
 www/pages/guides/github-pages.md
 www/pages/guides/index.md
 www/pages/guides/netlify-cms.md
 www/pages/guides/netlify-deploy.md
 www/pages/guides/now.md
 www/pages/guides/s3-cloudfront.md
 www/pages/guides/theme-packs.md
 www/pages/index.html
 www/pages/plugins/context.md
 www/pages/plugins/custom-plugins.md
 www/pages/plugins/index.md
 www/pages/plugins/resource.md
 www/pages/plugins/rollup.md
 www/pages/plugins/server.md
prerendering page... /about/community/
prerendering page... /about/features/
prerendering page... /about/goals/
prerendering page... /about/how-it-works/
prerendering page... /about/
prerendering page... /docs/component-model/
prerendering page... /docs/configuration/
prerendering page... /docs/css-and-images/
prerendering page... /docs/data/
prerendering page... /docs/front-matter/
prerendering page... /docs/
prerendering page... /docs/layouts/
prerendering page... /docs/markdown/
prerendering page... /docs/menus/
prerendering page... /docs/tech-stack/
prerendering page... /getting-started/branding/
prerendering page... /getting-started/build-and-deploy/
prerendering page... /getting-started/creating-content/
prerendering page... /getting-started/
prerendering page... /getting-started/key-concepts/
prerendering page... /getting-started/next-steps/
prerendering page... /getting-started/project-setup/
prerendering page... /getting-started/quick-start/
prerendering page... /guides/cloudflare-workers-deployment/
prerendering page... /guides/firebase/
prerendering page... /guides/github-pages/
prerendering page... /guides/
prerendering page... /guides/netlify-cms/
prerendering page... /guides/netlify-deploy/
prerendering page... /guides/now/
prerendering page... /guides/s3-cloudfront/
prerendering page... /guides/theme-packs/
prerendering page... /
prerendering page... /plugins/context/
prerendering page... /plugins/custom-plugins/
prerendering page... /plugins/
prerendering page... /plugins/resource/
prerendering page... /plugins/rollup/
prerendering page... /plugins/server/
prerendering complete for page /docs/front-matter/.
prerendering complete for page /docs/data/.
prerendering complete for page /docs/markdown/.
prerendering complete for page /docs/layouts/.
prerendering complete for page /getting-started/build-and-deploy/.
prerendering complete for page /guides/firebase/.
prerendering complete for page /getting-started/key-concepts/.
prerendering complete for page /docs/menus/.
prerendering complete for page /getting-started/.
prerendering complete for page /guides/github-pages/.
prerendering complete for page /getting-started/branding/.
prerendering complete for page /guides/.
prerendering complete for page /guides/theme-packs/.
prerendering complete for page /getting-started/quick-start/.
prerendering complete for page /docs/tech-stack/.
prerendering complete for page /getting-started/next-steps/.
prerendering complete for page /about/features/.
prerendering complete for page /docs/component-model/.
prerendering complete for page /plugins/resource/.
prerendering complete for page /plugins/custom-plugins/.
prerendering complete for page /guides/netlify-deploy/.
prerendering complete for page /plugins/context/.
prerendering complete for page /plugins/.
prerendering complete for page /guides/now/.
prerendering complete for page /.
prerendering complete for page /plugins/rollup/.
prerendering complete for page /guides/s3-cloudfront/.
prerendering complete for page /plugins/server/.
```

(I was able to get the issue in #675 somewhat resolved by seemingly attributing it to `<app-banner>` but my results are still mostly inconclusive)


So decided to test it against master and still the same issue with not being able to build more than a few pages.

So aside from that, things work (obviously no menu if no pages 🤷‍♂️ )
</details>

----

## Thoughts / TODOs
1. [x] we may want to throttle the [number of pages open at any one time] - https://github.com/ProjectEvergreen/greenwood/issues/720(https://github.com/puppeteer/puppeteer/issues/486).  Although we are preserving the [same `browser` instance](https://github.com/puppeteer/puppeteer/issues/1569), we are opening a `page` / tab for _every_ page in the app _at once_.  Perhaps this is overwhelming the newer version of chromium?
    - probably we should throttle so should make an, but surely it should at least be able to handle 10-12 pages?  If so, then this as a root cause wouldn't explain why by just trying to build index.html + about/ pages, it still hangs 😠 
1. [x] Analyze actual [shadow DOM support](https://web.dev/declarative-shadow-dom/#detection-support) for when we get there, some good links around [polyfilling and shimming](https://github.com/webcomponents/template-shadowroot) in support on our own, see if it's the actual cause of #675 ?
1. [x] Tested to see if we still needed our little work arounds in [_browser.js_](https://github.com/ProjectEvergreen/greenwood/blob/v0.15.2/packages/cli/src/lib/browser.js#L33) and [_plugin-standard-html_](https://github.com/ProjectEvergreen/greenwood/blob/v0.15.2/packages/cli/src/plugins/resource/plugin-standard-html.js#L200) and we do
1. [x] From what I can tell, none of the [breaking changes in puppeteer](https://github.com/puppeteer/puppeteer/releases) seem like they would be relevant / impactful to us...
1. [x] I might also take a side journey on experimenting with actual Lit + SSR ( #576 ) since that might provide us a more programmatic to maintaining this sort of functionality and not having to depend on a real browser so much, though we might have to [roll our own a bit](https://github.com/puppeteer/puppeteer/issues/4171#issuecomment-766270175) as we might have to roll our own if sticking to and / or supporting puppeteer going forward.
    - done and summarized [here](https://github.com/ProjectEvergreen/greenwood/discussions/576#discussioncomment-1261899) and is planned for the next sprint, but we should still continue to try and resolve this since having [puppeteer as a rendering option](https://github.com/ProjectEvergreen/greenwood/issues/709) is desired
1. [x] FWIW, looks like [v6 brings with it support for M1 macs](https://github.com/puppeteer/puppeteer/releases/tag/v6.0.0), so might be worth testing Greenwood out there using the branch to confirm 
    - so [**@ls-lint** is still waiting to get there re: M1 support](https://github.com/loeffel-io/ls-lint/issues/36), and there are some breaking changes in later versions of NodeJS (>= 15.5.x) that fail our tests but was able to get most tests to pass and the build to complete, so from a user's perspective, it should work!  💥 
    <img width="1429" alt="Screen Shot 2021-09-07 at 13 23 14" src="https://user-images.githubusercontent.com/895923/132385953-0e7546c0-6646-4b12-8876-8839871f430f.png">
