### PR TITLE
use consistent npm install commands in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can follow along with, or clone and go, the [companion repo](https://github.
 Greenwood can be installed with your favorite JavaScript package manager.
 ```bash
 # npm
-npm -i @greenwood/cli --save-dev
+npm install @greenwood/cli --save-dev
 
 # yarn
 yarn add @greenwood/cli --dev

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,7 +9,7 @@ You can use your favorite JavaScript package manager to install this package.
 _examples:_
 ```bash
 # npm
-npm -i @greenwood/cli --save-dev
+npm install @greenwood/cli --save-dev
 
 # yarn
 yarn add @greenwood/cli --dev

--- a/packages/plugin-babel/README.md
+++ b/packages/plugin-babel/README.md
@@ -11,7 +11,7 @@ You can use your favorite JavaScript package manager to install this package.
 _examples:_
 ```bash
 # npm
-npm -i @greenwood/plugin-babel --save-dev
+npm install @greenwood/plugin-babel --save-dev
 
 # yarn
 yarn add @greenwood/plugin-babel --dev
@@ -53,7 +53,7 @@ If you would like to use it, either standalone or with your own custom _babel.co
 1. Install `@babel/runtime` and `regenerator-runtime` as direct dependencies of your project
     ```bash
     # npm
-    npm -i @babel/runtime regenerator-runtime
+    npm install @babel/runtime regenerator-runtime
 
     # yarn
     yarn add @babel/runtime regenerator-runtime

--- a/packages/plugin-google-analytics/README.md
+++ b/packages/plugin-google-analytics/README.md
@@ -12,7 +12,7 @@ You can use your favorite JavaScript package manager to install this package.  T
 _examples:_
 ```bash
 # npm
-npm -i @greenwood/plugin-google-analytics --save-dev
+npm install @greenwood/plugin-google-analytics --save-dev
 
 # yarn
 yarn add @greenwood/plugin-google-analytics --dev

--- a/packages/plugin-graphql/README.md
+++ b/packages/plugin-graphql/README.md
@@ -11,7 +11,7 @@ You can use your favorite JavaScript package manager to install this package.
 _examples:_
 ```bash
 # npm
-npm -i @greenwood/plugin-graphql --save-dev
+npm install @greenwood/plugin-graphql --save-dev
 
 # yarn
 yarn add @greenwood/plugin-graphql --dev

--- a/packages/plugin-import-commonjs/README.md
+++ b/packages/plugin-import-commonjs/README.md
@@ -11,7 +11,7 @@ You can use your favorite JavaScript package manager to install this package.
 _examples:_
 ```bash
 # npm
-npm -i @greenwood/plugin-import-commonjs --save-dev
+npm install @greenwood/plugin-import-commonjs --save-dev
 
 # yarn
 yarn add @greenwood/plugin-import-commonjs --dev

--- a/packages/plugin-import-css/README.md
+++ b/packages/plugin-import-css/README.md
@@ -11,7 +11,7 @@ You can use your favorite JavaScript package manager to install this package.
 _examples:_
 ```bash
 # npm
-npm -i @greenwood/plugin-import-css --save-dev
+npm install @greenwood/plugin-import-css --save-dev
 
 # yarn
 yarn add @greenwood/plugin-import-css --dev

--- a/packages/plugin-import-json/README.md
+++ b/packages/plugin-import-json/README.md
@@ -11,7 +11,7 @@ You can use your favorite JavaScript package manager to install this package.
 _examples:_
 ```bash
 # npm
-npm -i @greenwood/plugin-import-json --save-dev
+npm install @greenwood/plugin-import-json --save-dev
 
 # yarn
 yarn add @greenwood/plugin-import-json --dev

--- a/packages/plugin-polyfills/README.md
+++ b/packages/plugin-polyfills/README.md
@@ -18,7 +18,7 @@ You can use your favorite JavaScript package manager to install this package.  T
 _examples:_
 ```bash
 # npm
-npm -i @greenwood/plugin-polyfills --save-dev
+npm install @greenwood/plugin-polyfills --save-dev
 
 # yarn
 yarn add @greenwood/plugin-polyfills --dev

--- a/packages/plugin-postcss/README.md
+++ b/packages/plugin-postcss/README.md
@@ -11,7 +11,7 @@ You can use your favorite JavaScript package manager to install this package.
 _examples:_
 ```bash
 # npm
-npm -i @greenwood/plugin-postcss --save-dev
+npm install @greenwood/plugin-postcss --save-dev
 
 # yarn
 yarn add @greenwood/plugin-postcss --dev

--- a/packages/plugin-typescript/README.md
+++ b/packages/plugin-typescript/README.md
@@ -11,7 +11,7 @@ You can use your favorite JavaScript package manager to install this package.
 _examples:_
 ```bash
 # npm
-npm -i @greenwood/plugin-typescript --save-dev
+npm install @greenwood/plugin-typescript --save-dev
 
 # yarn
 yarn add @greenwood/plugin-typescript --dev


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #704 

## Summary of Changes
1. Switch all (incorrect) `npm -i` usages to `npm install` to be consistent throughout our docs