### PR TITLE
handle missed cases for files in exports maps and transient dependency imports

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -2,5 +2,5 @@ const path = require('path');
 
 module.exports = {
   spec: path.join(__dirname, 'packages/**/test/**/**/**/*.spec.js'),
-  timeout: 90000
+  timeout: 120000
 };

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -2,5 +2,5 @@ const path = require('path');
 
 module.exports = {
   spec: path.join(__dirname, 'packages/**/test/**/**/**/*.spec.js'),
-  timeout: 30000
+  timeout: 90000
 };

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -2,5 +2,5 @@ const path = require('path');
 
 module.exports = {
   spec: path.join(__dirname, 'packages/**/test/**/**/**/*.spec.js'),
-  timeout: 120000
+  timeout: 30000
 };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,6 +49,8 @@
     "unified": "^9.2.0"
   },
   "devDependencies": {
+    "@lion/button": "~0.12.0",
+    "@lion/calendar": "~0.15.0",
     "@mapbox/rehype-prism": "^0.5.0",
     "lit-element": "^2.4.0",
     "lit-redux-router": "^0.17.1",

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -159,8 +159,6 @@ const walkPackageJson = (packageJson = {}) => {
           } else if (exportMapEntry.endsWith && (exportMapEntry.endsWith('.js') || exportMapEntry.endsWith('.mjs')) && exportMapEntry.indexOf('*') < 0) {
             // is probably a file, so _not_ an export array, package.json, or wildcard export
             packageExport = exportMapEntry;
-          } else {
-            // console.debug('22222????', exportMapEntry);
           }
   
           if (packageExport) {

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -77,12 +77,24 @@ const walkModule = (module, dependency) => {
       if (sourceValue !== '' && sourceValue.indexOf('.') !== 0 && sourceValue.indexOf('http') !== 0) {
         updateImportMap(sourceValue, `/node_modules/${sourceValue}`);
       }
+
+      if (sourceValue.indexOf('.') === 0 && fs.existsSync(path.join(process.cwd(), 'node_modules', dependency, sourceValue))) {
+        const moduleContents = fs.readFileSync(path.join(process.cwd(), 'node_modules', dependency, sourceValue));
+
+        walkModule(moduleContents, dependency);
+      }
     },
     ExportAllDeclaration(node) {
       const sourceValue = node && node.source ? node.source.value : '';
 
       if (sourceValue !== '' && sourceValue.indexOf('.') !== 0 && sourceValue.indexOf('http') !== 0) {
         updateImportMap(sourceValue, `/node_modules/${sourceValue}`);
+      }
+
+      if (sourceValue.indexOf('.') === 0 && fs.existsSync(path.join(process.cwd(), 'node_modules', dependency, sourceValue))) {
+        const moduleContents = fs.readFileSync(path.join(process.cwd(), 'node_modules', dependency, sourceValue));
+
+        walkModule(moduleContents, dependency);
       }
     }
   });

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -77,24 +77,12 @@ const walkModule = (module, dependency) => {
       if (sourceValue !== '' && sourceValue.indexOf('.') !== 0 && sourceValue.indexOf('http') !== 0) {
         updateImportMap(sourceValue, `/node_modules/${sourceValue}`);
       }
-
-      if (sourceValue.indexOf('.') === 0 && fs.existsSync(path.join(process.cwd(), 'node_modules', dependency, sourceValue))) {
-        const moduleContents = fs.readFileSync(path.join(process.cwd(), 'node_modules', dependency, sourceValue));
-
-        walkModule(moduleContents, dependency);
-      }
     },
     ExportAllDeclaration(node) {
       const sourceValue = node && node.source ? node.source.value : '';
 
       if (sourceValue !== '' && sourceValue.indexOf('.') !== 0 && sourceValue.indexOf('http') !== 0) {
         updateImportMap(sourceValue, `/node_modules/${sourceValue}`);
-      }
-
-      if (sourceValue.indexOf('.') === 0 && fs.existsSync(path.join(process.cwd(), 'node_modules', dependency, sourceValue))) {
-        const moduleContents = fs.readFileSync(path.join(process.cwd(), 'node_modules', dependency, sourceValue));
-
-        walkModule(moduleContents, dependency);
       }
     }
   });
@@ -193,7 +181,6 @@ const walkPackageJson = (packageJson = {}) => {
         walkPackageJson(dependencyPackageJson);
       } else {
         const packageEntryPointPath = path.join(process.cwd(), './node_modules', dependency, entry);
-        
         // sometimes a main file is actually just an empty string... :/
         if (fs.existsSync(packageEntryPointPath)) {
           const packageEntryModule = fs.readFileSync(packageEntryPointPath, 'utf-8');

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -47,7 +47,6 @@ const walkModule = (module, dependency) => {
     ImportDeclaration(node) {
       let { value: sourceValue } = node.source;
 
-      console.debug('ImportDeclaration', sourceValue);
       if (path.extname(sourceValue) === '' && sourceValue.indexOf('http') !== 0 && sourceValue.indexOf('./') < 0) {        
         if (!importMap[sourceValue]) {
           // found a _new_ bare import for ${sourceValue}
@@ -101,7 +100,6 @@ const walkPackageJson = (packageJson = {}) => {
     const entry = getPackageEntryPath(dependencyPackageJson);
     const isJavascriptPackage = Array.isArray(entry) || typeof entry === 'string' && entry.endsWith('.js') || entry.endsWith('.mjs');
 
-    // console.debug('WITH ENTRY => ', entry);
     if (isJavascriptPackage) {
       // https://nodejs.org/api/packages.html#packages_determining_module_system
       if (Array.isArray(entry)) {
@@ -133,8 +131,6 @@ const walkPackageJson = (packageJson = {}) => {
                   } else if (entryTypes.default) {
                     console.warn('The package you are requiring may need commonjs support.  If this module is not working for you, consider adding our commonjs plugin.');
                     fallbackPath = entryTypes.default;
-                  } else {
-                    console.debug('####################');
                   }
                   break;
                 default:

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -138,6 +138,10 @@ describe('Develop Greenwood With: ', function() {
         `${process.cwd()}/node_modules/@lion/localize/test-helpers/*.js`,
         `${outputPath}/node_modules/@lion/localize/test-helpers/`
       );
+      const lionLocalizeSrcLibs = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@lion/localize/src/*.js`,
+        `${outputPath}/node_modules/@lion/localize/src/`
+      );
       const owcDepupLibPackageJson = await getDependencyFiles(
         `${process.cwd()}/node_modules/@open-wc/dedupe-mixin/package.json`,
         `${outputPath}/node_modules/@open-wc/dedupe-mixin/`
@@ -147,8 +151,8 @@ describe('Develop Greenwood With: ', function() {
         `${outputPath}/node_modules/@open-wc/scoped-elements/`
       );
       const messageFormatLibs = await getDependencyFiles(
-        `${process.cwd()}/node_modules/@bundles-es-modules/message-format/MessageFormat.js`,
-        `${outputPath}/node_modules/@bundles-es-modules/message-format/`
+        `${process.cwd()}/node_modules/@bundled-es-modules/message-format/MessageFormat.js`,
+        `${outputPath}/node_modules/@bundled-es-modules/message-format/`
       );
       const messageFormatLibsPackageJson = await getDependencyFiles(
         `${process.cwd()}/node_modules/@bundled-es-modules/message-format/package.json`,
@@ -186,6 +190,7 @@ describe('Develop Greenwood With: ', function() {
         ...lionLocalizeLibs,
         ...lionLocalizeLibsPackageJson,
         ...lionLocalizeTesterLibs,
+        ...lionLocalizeSrcLibs,
         ...owcDepupLibPackageJson,
         ...owcScopedLibPackageJson,
         ...messageFormatLibs,
@@ -250,8 +255,8 @@ describe('Develop Greenwood With: ', function() {
         expect(importMap['@lion/button/define']).to.equal('/node_modules/@lion/button/lion-button.js');
 
         // https://github.com/ProjectEvergreen/greenwood/issues/715
-        // transient dependency imports
-        // TODO expect(importMap['@bundled-es-modules/message-format/MessageFormat.js']).to.equal('/node_modules/@bundled-es-modules/message-format/MessageFormat.js');
+        // transient dependency import / exports
+        expect(importMap['@bundled-es-modules/message-format/MessageFormat.js']).to.equal('/node_modules/@bundled-es-modules/message-format/MessageFormat.js');
 
         done();
       });

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -151,7 +151,7 @@ describe('Develop Greenwood With: ', function() {
         `${outputPath}/node_modules/@open-wc/scoped-elements/`
       );
       const messageFormatLibs = await getDependencyFiles(
-        `${process.cwd()}/node_modules/@bundled-es-modules/message-format/MessageFormat.js`,
+        `${process.cwd()}/node_modules/@bundled-es-modules/message-format/*.js`,
         `${outputPath}/node_modules/@bundled-es-modules/message-format/`
       );
       const messageFormatLibsPackageJson = await getDependencyFiles(

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -26,7 +26,7 @@
  *     index.html
  *   styles/
  *     main.css
- *
+ * package.json
  */
 const expect = require('chai').expect;
 const { JSDOM } = require('jsdom');
@@ -90,6 +90,78 @@ describe('Develop Greenwood With: ', function() {
         `${process.cwd()}/node_modules/simpledotcss/package.json`,
         `${outputPath}/node_modules/simpledotcss/`
       );
+      const lionButtonLibs = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@lion/button/*.js`,
+        `${outputPath}/node_modules/@lion/button/`
+      );
+      const lionButtonLibsPackageJson = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@lion/button/package.json`,
+        `${outputPath}/node_modules/@lion/button/`
+      );
+      const lionCoreTesterLibs = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@lion/core/test-helpers/*.js`,
+        `${outputPath}/node_modules/@lion/core/test-helpers/`
+      );
+      const lionCoreSrcLibs = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@lion/core/src/*.js`,
+        `${outputPath}/node_modules/@lion/core/src/`
+      );
+      const lionCoreLibs = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@lion/core/*.js`,
+        `${outputPath}/node_modules/@lion/core/`
+      );
+      const lionCoreLibsPackageJson = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@lion/core/package.json`,
+        `${outputPath}/node_modules/@lion/core/`
+      );
+      const lionCalendarLibs = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@lion/calendar/*.js`,
+        `${outputPath}/node_modules/@lion/calendar/`
+      );
+      const lionCalendarLibsPackageJson = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@lion/calendar/package.json`,
+        `${outputPath}/node_modules/@lion/calendar/`
+      );
+      const lionCalendarTesterLibs = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@lion/calendar/test-helpers/*.js`,
+        `${outputPath}/node_modules/@lion/calendar/test-helpers/`
+      );
+      const lionLocalizeLibs = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@lion/localize/*.js`,
+        `${outputPath}/node_modules/@lion/localize/`
+      );
+      const lionLocalizeLibsPackageJson = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@lion/localize/package.json`,
+        `${outputPath}/node_modules/@lion/localize/`
+      );
+      const lionLocalizeTesterLibs = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@lion/localize/test-helpers/*.js`,
+        `${outputPath}/node_modules/@lion/localize/test-helpers/`
+      );
+      const owcDepupLibPackageJson = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@open-wc/dedupe-mixin/package.json`,
+        `${outputPath}/node_modules/@open-wc/dedupe-mixin/`
+      );
+      const owcScopedLibPackageJson = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@open-wc/scoped-elements/package.json`,
+        `${outputPath}/node_modules/@open-wc/scoped-elements/`
+      );
+      const messageFormatLibs = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@bundles-es-modules/message-format/MessageFormat.js`,
+        `${outputPath}/node_modules/@bundles-es-modules/message-format/`
+      );
+      const messageFormatLibsPackageJson = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@bundled-es-modules/message-format/package.json`,
+        `${outputPath}/node_modules/@bundled-es-modules/message-format/`
+      );
+      const singletonManagerLibs = await getDependencyFiles(
+        `${process.cwd()}/node_modules/singleton-manager/index.js`,
+        `${outputPath}/node_modules/singleton-manager/`
+      );
+      const singletonManagerLibsPackageJson = await getDependencyFiles(
+        `${process.cwd()}/node_modules/singleton-manager/package.json`,
+        `${outputPath}/node_modules/singleton-manager/`
+      );
 
       await runner.setup(outputPath, [
         ...getSetupFiles(outputPath),
@@ -101,7 +173,25 @@ describe('Develop Greenwood With: ', function() {
         ...litHtmlLibs,
         ...litHtmlSourceMap,
         ...simpleCss,
-        ...simpleCssPackageJson
+        ...simpleCssPackageJson,
+        ...lionButtonLibs,
+        ...lionButtonLibsPackageJson,
+        ...lionCoreLibs,
+        ...lionCoreTesterLibs,
+        ...lionCoreLibsPackageJson,
+        ...lionCoreSrcLibs,
+        ...lionCalendarLibs,
+        ...lionCalendarLibsPackageJson,
+        ...lionCalendarTesterLibs,
+        ...lionLocalizeLibs,
+        ...lionLocalizeLibsPackageJson,
+        ...lionLocalizeTesterLibs,
+        ...owcDepupLibPackageJson,
+        ...owcScopedLibPackageJson,
+        ...messageFormatLibs,
+        ...messageFormatLibsPackageJson,
+        ...singletonManagerLibsPackageJson,
+        ...singletonManagerLibs
       ]);
 
       return new Promise(async (resolve) => {
@@ -153,6 +243,15 @@ describe('Develop Greenwood With: ', function() {
         expect(importMap['lit-element']).to.equal('/node_modules/lit-element/lit-element.js');
         expect(importMap['lit-html/lit-html.js']).to.equal('/node_modules/lit-html/lit-html.js');
         expect(importMap['lit-html/lib/shady-render.js']).to.equal('/node_modules/lit-html/lib/shady-render.js');
+
+        // https://github.com/ProjectEvergreen/greenwood/issues/715
+        // export maps with "flat" entries
+        expect(importMap['@lion/button']).to.equal('/node_modules/@lion/button/index.js');
+        expect(importMap['@lion/button/define']).to.equal('/node_modules/@lion/button/lion-button.js');
+
+        // https://github.com/ProjectEvergreen/greenwood/issues/715
+        // transient dependency imports
+        // TODO expect(importMap['@bundled-es-modules/message-format/MessageFormat.js']).to.equal('/node_modules/@bundled-es-modules/message-format/MessageFormat.js');
 
         done();
       });
@@ -556,6 +655,77 @@ describe('Develop Greenwood With: ', function() {
 
       it('should return the correct response body', function(done) {
         expect(response.body).to.equal('console.debug(\'its just a prank bro!\');');
+        done();
+      });
+    });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/715
+    describe('Develop command node_modules resolution for a transient dependency\'s own imports', function() {
+      let response = {};
+
+      before(async function() {
+        return new Promise((resolve, reject) => {
+          request.get(`${hostname}:${port}/node_modules/@bundled-es-modules/message-format/MessageFormat.js`, (err, res, body) => {
+            if (err) {
+              reject();
+            }
+
+            response = res;
+            response.body = body;
+
+            resolve();
+          });
+        });
+      });
+
+      it('should return a 200 status', function(done) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
+
+      it('should return the correct content type', function(done) {
+        expect(response.headers['content-type']).to.equal('text/javascript');
+        done();
+      });
+
+      it('should return the correct response body', function(done) {
+        expect(response.body).to.contain('export default messageFormat;');
+        done();
+      });
+    });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/715
+    // @lion/calendar/define -> /node_modules/@lion/calendar/lion-calendar.js
+    describe('Develop command node_modules resolution for a flat export map entry from a dependency (not import or default)', function() {
+      let response = {};
+
+      before(async function() {
+        return new Promise((resolve, reject) => {
+          request.get(`${hostname}:${port}/node_modules/@lion/calendar/lion-calendar.js`, (err, res, body) => {
+            if (err) {
+              reject();
+            }
+
+            response = res;
+            response.body = body;
+
+            resolve();
+          });
+        });
+      });
+
+      it('should return a 200 status', function(done) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
+
+      it('should return the correct content type', function(done) {
+        expect(response.headers['content-type']).to.equal('text/javascript');
+        done();
+      });
+
+      it('should return the correct response body', function(done) {
+        expect(response.body).to.contain('customElements.define(\'lion-calendar\', LionCalendar);');
         done();
       });
     });

--- a/packages/cli/test/cases/develop.default/package.json
+++ b/packages/cli/test/cases/develop.default/package.json
@@ -1,6 +1,8 @@
 {
   "name": "test-develop-command-default",
   "dependencies": {
+    "@lion/button": "~0.12.0",
+    "@lion/calendar": "~0.15.0",
     "lit-element": "^2.4.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,6 +1222,11 @@
     "@babel/helper-validator-identifier" "^7.14.0"
     to-fast-properties "^2.0.0"
 
+"@bundled-es-modules/message-format@6.0.4":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@bundled-es-modules/message-format/-/message-format-6.0.4.tgz#232da6877adb960f6c8f598c72588a84352de147"
+  integrity sha512-NGUoPxqsBzDwvRhY3A3L/AhS1hzS9OWappfyDOyCwE7G3W4ua28gau7QwvJz7QzA6ArbAdeb8c1mLjvd1WUFAA==
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -2005,6 +2010,40 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
+"@lion/button@~0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@lion/button/-/button-0.12.0.tgz#e93d3772bf4f3384b76598b3d58efd9a9f18b897"
+  integrity sha512-kJ/NkSrnc6hPEtV7ICSGx9cH+H/NiBjSUoEPR6pp3+MQTzEwIfoSEPBe88xMflRLqnrq8GhjPKdhH8Ce/G5yRw==
+  dependencies:
+    "@lion/core" "0.17.0"
+
+"@lion/calendar@~0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@lion/calendar/-/calendar-0.15.0.tgz#9655448250805fd4247b1d1dad003b48682d6407"
+  integrity sha512-MaIZpxuF+tUAwPejI5/bns8VbJXftbAABk+i247fnUvI0Xi4tu0agKE2A13o9RXKQLm2IY/ohLWVjAffBuM9+A==
+  dependencies:
+    "@lion/core" "0.17.0"
+    "@lion/localize" "0.19.0"
+
+"@lion/core@0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@lion/core/-/core-0.17.0.tgz#0af5d7873c1e110fd57d54c331fb22dd01702bb3"
+  integrity sha512-s4z7qxzX+bgMPyxRiZcLuBd3BePPvQRkgTlUxKf+4ao0QBgebuNyoFHUWvZifuWH2gFmcORy3aL7+0HYNMkqoQ==
+  dependencies:
+    "@open-wc/dedupe-mixin" "^1.2.18"
+    "@open-wc/scoped-elements" "^1.3.3"
+    lit-element "~2.4.0"
+    lit-html "^1.3.0"
+
+"@lion/localize@0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@lion/localize/-/localize-0.19.0.tgz#7df884554f1a14d9184241c20bc1939139c566d3"
+  integrity sha512-zkFu5j2eiZYxtmweM96psO7rvzMZqdaX6/+wQwABKGmKdg02I4h1kwdfFvRw5MWZNiFlftyxES/yMY/Q2VJZuA==
+  dependencies:
+    "@bundled-es-modules/message-format" "6.0.4"
+    "@lion/core" "0.17.0"
+    singleton-manager "1.4.2"
+
 "@ls-lint/ls-lint@^1.9.2":
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/@ls-lint/ls-lint/-/ls-lint-1.9.2.tgz#689f1f4c06072823a726802ba167340efcefe19c"
@@ -2161,6 +2200,19 @@
   integrity sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==
   dependencies:
     "@types/node" ">= 8"
+
+"@open-wc/dedupe-mixin@^1.2.18", "@open-wc/dedupe-mixin@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@open-wc/dedupe-mixin/-/dedupe-mixin-1.3.0.tgz#0df5d438285fc3482838786ee81895318f0ff778"
+  integrity sha512-UfdK1MPnR6T7f3svzzYBfu3qBkkZ/KsPhcpc3JYhsUY4hbpwNF9wEQtD4Z+/mRqMTJrKg++YSxIxE0FBhY3RIw==
+
+"@open-wc/scoped-elements@^1.3.3":
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-1.3.4.tgz#96e27e13c8b09668ee631e9fccd5623a05af5cc2"
+  integrity sha512-WD+ObocdzcFCpBxnc8bQa7NoATeA+tJrK0/c/yV1Nx4leV+1PmJNNu+WCcuckBEGd0Op6FP8w1TidoqmVVba6g==
+  dependencies:
+    "@open-wc/dedupe-mixin" "^1.3.0"
+    lit-html "^1.0.0"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -7427,14 +7479,14 @@ list-item@^1.1.1:
     is-number "^2.1.0"
     repeat-string "^1.5.2"
 
-lit-element@^2.0.1, lit-element@^2.4.0:
+lit-element@^2.0.1, lit-element@^2.4.0, lit-element@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.4.0.tgz#b22607a037a8fc08f5a80736dddf7f3f5d401452"
   integrity sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==
   dependencies:
     lit-html "^1.1.1"
 
-lit-html@^1.1.1:
+lit-html@^1.0.0, lit-html@^1.1.1, lit-html@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-1.3.0.tgz#c80f3cc5793a6dea6c07172be90a70ab20e56034"
   integrity sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q==
@@ -10815,6 +10867,11 @@ simpledotcss@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/simpledotcss/-/simpledotcss-1.0.0.tgz#b5ac8fcd73d111938def9c0f43f1839d6eae96be"
   integrity sha512-inneK6Wqh5rUdASxJMAKJORbDeKRySZPlY6H1Jqc6o6t5QbXhd5UZUi5snkKnB0ror0H72in0zlNeeA4Vw+Fiw==
+
+singleton-manager@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/singleton-manager/-/singleton-manager-1.4.2.tgz#4649acafca3eccf987d828ab16369ee59c4a22a5"
+  integrity sha512-3/K7K61TiN0+tw32HRC3AZQBacN0Ky/NmHEnhofFPEFROqZ5T6BXK45Z94OQsvuFD2euOVOU40XDNeTal63Baw==
 
 slash@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #715 

## Summary of Changes
1. Update import map if package "flat" export map entry is a file
1. Add transient dependency imports to import map

## TODO
1. [x] Confirm interop with #611 work
1. [x] Add tests for both cases to develop spec
1. [x] Validate in [Getting Started branches](https://github.com/ProjectEvergreen/greenwood-getting-started/pulls?q=is%3Apr+label%3Aexample+label%3A%22needs+upstream%22) after initial [`v0.16.0-alpha.0`](https://github.com/ProjectEvergreen/greenwood/issues?q=label%3Av0.16.0+label%3Aalpha.0) release, then I will undraft here
1. [x] Figure out what to do about https://github.com/ProjectEvergreen/greenwood/pull/716#discussion_r706357210 - re-opened - https://github.com/ProjectEvergreen/greenwood/issues/557#issuecomment-918414861