### PR TITLE
Node 14x minimum version

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [14]
+        node: [14, 16]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [14]
+        node: [14, 16]
 
     steps:
     - uses: actions/checkout@v1

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
     "Web Components"
   ],
   "engines": {
-    "node": ">=12.x"
+    "node": ">=14"
   },
   "bin": {
     "greenwood": "./src/index.js"

--- a/www/pages/guides/cloudflare-workers-deployment.md
+++ b/www/pages/guides/cloudflare-workers-deployment.md
@@ -87,7 +87,7 @@ jobs:
          sh ./.github/workflows/chromium-lib-install.sh
       - uses: actions/setup-node@v1
         with:
-           node-version: "12.x"
+           node-version: "14.x"
       - name: Install deps
         run: npm install
       - name: Build docs

--- a/www/pages/guides/s3-cloudfront.md
+++ b/www/pages/guides/s3-cloudfront.md
@@ -71,7 +71,7 @@ jobs:
          sh ./.github/workflows/chromium-lib-install.sh
       - uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "14.x"
       - name: Install deps
         run: npm install
       - name: Build docs


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
Not sure why [master branch failed](https://github.com/ProjectEvergreen/greenwood/actions/runs/1222579667) but our [CI didn't fail for the same PR](https://github.com/ProjectEvergreen/greenwood/runs/3536283002?check_suite_focus=true), but figured that since [Node 12 is in maintenance mode](https://nodejs.org/en/about/releases/) and will be unsupported soon, can't hurt to align this now and see if it stabilizes things.
<img width="1039" alt="Screen Shot 2021-09-10 at 4 20 59 PM" src="https://user-images.githubusercontent.com/895923/132913295-c1977e10-22bd-44be-8b96-7ca5d3a827c8.png">

## TODO
1. [x] Get things passing
1. [x] Make an issue to track this deprecation as a good first issue seen in the test logs - no longer in the codebase
    ```sh
    Build Greenwood With: 
    (node:5249) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
    ```
<img width="1239" alt="Screen Shot 2021-09-10 at 6 07 43 PM" src="https://user-images.githubusercontent.com/895923/132922793-ed6c293d-c095-4fa7-b6b1-c8dbd96fbb87.png">