### PR TITLE
only use node 14 in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [12, 14]
+        node: [14]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14]
 
     steps:
     - uses: actions/checkout@v1

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,4 +6,4 @@
   skip_processing = true
 
 [build.environment]
-  NODE_VERSION = "12.13.0"
+  NODE_VERSION = "14.16.0"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
As seen in #721 and #722 , it seems after the merge of (presumably) #699 , Node 12 build seems to be failing

## Summary of Changes
1. Not explicitly dropping support for Node 12, but for the sake of stability, dropping Node 12 from GitHub Actions and will fully support Node >= 14 as part of #721 in the next release.  Will update the release notes to hint at eventual Node 12 deprecation.