### PR TITLE
show a plugin example we actually support

### DIFF
--- a/www/pages/docs/css-and-images.md
+++ b/www/pages/docs/css-and-images.md
@@ -66,11 +66,14 @@ You can do the same in your HTML
 >
 > ```javascript
 > import { html, LitElement } from 'lit-element';
-> import logo from '../../assets/images/logo.png';
+> import headerCss from './header.css';
 >
 > class HeaderComponent extends LitElement {
 >  render() {
 >    return html`
+>      <style>
+>        ${headerCss}
+>      <style>
 >      <header>
 >        <h1>Welcome to My Site!</h1>
 >        <img alt="brand logo" src="${logo}" />

--- a/www/pages/docs/css-and-images.md
+++ b/www/pages/docs/css-and-images.md
@@ -62,7 +62,7 @@ You can do the same in your HTML
 ```
 
 
-> If you like your all-the-things-in-JS approach, Greenwood can be extended with [plugins](/plugins/) to support "webpack" like behavior as seen in the below example:
+> If you like an all-the-things-in-JS approach, Greenwood can be extended with [plugins](/plugins/) to support "webpack" like behavior as seen in the below example:
 >
 > ```javascript
 > import { html, LitElement } from 'lit-element';


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Updated [docs](https://www.greenwoodjs.io/docs/css-and-images/) to show an example of _CSS_ with `import`, not an image since we don't have support for that (yet.  see  #606)