### PR TITLE
make github actions configuration more consistent

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -5,17 +5,15 @@ on: [pull_request]
 jobs:
 
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: windows-latest
 
     strategy:
       matrix:
-        os:
-          - windows-latest
         node: [14]
 
     steps:
     - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Chromium Library Dependencies
       run: |
         sh ./.github/workflows/chromium-lib-install.sh
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,26 +12,20 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14]
+        node: [14]
 
     steps:
     - uses: actions/checkout@v1
     - name: Install Chromium Library Dependencies
       run: |
         sh ./.github/workflows/chromium-lib-install.sh
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v2
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: ${{ matrix.node }}
     - name: Installing project dependencies
       run: |
         yarn install --frozen-lockfile && yarn lerna bootstrap
-    - name: Lint
-      run: |
-        yarn lint
-    - name: Test
-      run: |
-        yarn test
     - name: Build
       run: |
         yarn clean && yarn build

--- a/README.md
+++ b/README.md
@@ -69,3 +69,18 @@ We would love your [contribution](.github/CONTRIBUTING.md) to Greenwood!  Please
 
 ## License
 See the [LICENSE](LICENSE.md) file for license rights and limitations (MIT).
+
+`yarn test`
+```sh
+  999 passing (5m)
+  8 pending
+  93 failing
+
+  1) Develop Greenwood With:
+       Default Greenwood Configuration and Workspace
+         Running Smoke Tests: Default Greenwood Configuration and Workspace
+           Serving Index (Home) page
+             "before all" hook for "should start the server and return 200 status":
+     Error: connect ECONNREFUSED 127.0.0.1:1984
+      at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1146:16)
+```

--- a/README.md
+++ b/README.md
@@ -69,18 +69,3 @@ We would love your [contribution](.github/CONTRIBUTING.md) to Greenwood!  Please
 
 ## License
 See the [LICENSE](LICENSE.md) file for license rights and limitations (MIT).
-
-`yarn test`
-```sh
-  999 passing (5m)
-  8 pending
-  93 failing
-
-  1) Develop Greenwood With:
-       Default Greenwood Configuration and Workspace
-         Running Smoke Tests: Default Greenwood Configuration and Workspace
-           Serving Index (Home) page
-             "before all" hook for "should start the server and return 200 status":
-     Error: connect ECONNREFUSED 127.0.0.1:1984
-      at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1146:16)
-```

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -107,7 +107,7 @@ describe('Develop Greenwood With: ', function() {
       return new Promise(async (resolve) => {
         setTimeout(() => {
           resolve();
-        }, 3000);
+        }, 5000);
 
         await runner.runCommand(cliPath, 'develop');
       });

--- a/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
+++ b/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
@@ -49,7 +49,7 @@ describe('Develop Greenwood With: ', function() {
       return new Promise(async (resolve) => {
         setTimeout(() => {
           resolve();
-        }, 3000);
+        }, 5000);
 
         await runner.runCommand(cliPath, 'develop');
       });

--- a/packages/cli/test/cases/serve.default/serve.default.spec.js
+++ b/packages/cli/test/cases/serve.default/serve.default.spec.js
@@ -43,7 +43,7 @@ describe('Serve Greenwood With: ', function() {
       return new Promise(async (resolve) => {
         setTimeout(() => {
           resolve();
-        }, 6000);
+        }, 10000);
 
         await runner.runCommand(cliPath, 'serve');
       });

--- a/packages/cli/test/cases/theme-pack/theme-pack.develop.spec.js
+++ b/packages/cli/test/cases/theme-pack/theme-pack.develop.spec.js
@@ -56,7 +56,7 @@ describe('Develop Greenwood With: ', function() {
       return new Promise(async (resolve) => {
         setTimeout(() => {
           resolve();
-        }, 3000);
+        }, 5000);
 
         await runner.runCommand(cliPath, 'develop');
       });

--- a/packages/plugin-graphql/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-graphql/test/cases/develop.default/develop.default.spec.js
@@ -47,7 +47,7 @@ describe('Develop Greenwood With: ', function() {
       return new Promise(async (resolve) => {
         setTimeout(() => {
           resolve();
-        }, 3000);
+        }, 5000);
 
         await runner.runCommand(cliPath, 'develop');
       });

--- a/packages/plugin-graphql/test/cases/qraphql-server/graphql-server.spec.js
+++ b/packages/plugin-graphql/test/cases/qraphql-server/graphql-server.spec.js
@@ -39,7 +39,7 @@ describe('Develop Greenwood With: ', function() {
       return new Promise(async (resolve) => {
         setTimeout(() => {
           resolve();
-        }, 3000);
+        }, 5000);
 
         await runner.runCommand(cliPath, 'develop');
       });

--- a/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
@@ -45,7 +45,7 @@ describe('Develop Greenwood With: ', function() {
       return new Promise(async (resolve) => {
         setTimeout(() => {
           resolve();
-        }, 3000);
+        }, 5000);
 
         await runner.runCommand(cliPath, 'develop');
       });

--- a/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
@@ -46,7 +46,7 @@ describe('Develop Greenwood With: ', function() {
       return new Promise(async (resolve) => {
         setTimeout(() => {
           resolve();
-        }, 3000);
+        }, 5000);
 
         await runner.runCommand(cliPath, 'develop');
       });

--- a/packages/plugin-typescript/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-typescript/test/cases/develop.default/develop.default.spec.js
@@ -46,7 +46,7 @@ describe('Develop Greenwood With: ', function() {
       return new Promise(async (resolve) => {
         setTimeout(() => {
           resolve();
-        }, 3000);
+        }, 5000);
 
         await runner.runCommand(cliPath, 'develop');
       });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #729

## Summary of Changes
1. Made github actions configs consistent from file to file
1. Extended timeouts when running servers in tests, which seemed to help with running tests locally on Windows at least
1. [Reran master jobs a couple times](https://github.com/ProjectEvergreen/greenwood/actions/runs/1242701003) and everything seemed fine, so likely just a one off?

> _One observation though in plugin-polyfill, we should probably enable some sort of [`copy` lifecycle or plugin](https://github.com/ProjectEvergreen/greenwood/issues/543) since it seems wasteful to do file copying when building every HTML file, when it really only needs to be done once per build.  This may account for the locked file if multiple async tasks are happening (per page) trying to read / copy the file at once._

## TODO
Will try a few things and run the jobs three times to measure results before trying the next thing and test on Windows locally
1. [x] Validate Windows CI **plugins-polyfill** issue on first run of opening this PR
    - both [Windows](https://github.com/ProjectEvergreen/greenwood/runs/3636376339) and [Linux](https://github.com/ProjectEvergreen/greenwood/runs/3636379908) jobs ran fine two runs in a row though, so there's that
1. [x] Adjust test timeouts
1. [ ] Fiddle with plugin-polyfill code?
1. [x] Restore `lint` and `test` commands on master branch github action? - per discussion, will keep this as is since we have the current master merge / up to date requirement