### PR TITLE
handle require.resolve fallback when walking node_modules with no main field in package.json

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,6 +49,7 @@
     "unified": "^9.2.0"
   },
   "devDependencies": {
+    "@babel/runtime": "^7.10.4",
     "@lion/button": "~0.12.0",
     "@lion/calendar": "~0.15.0",
     "@mapbox/rehype-prism": "^0.5.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,6 +52,7 @@
     "@lion/button": "~0.12.0",
     "@lion/calendar": "~0.15.0",
     "@mapbox/rehype-prism": "^0.5.0",
+    "@types/trusted-types": "^2.0.2",
     "lit-element": "^2.4.0",
     "lit-redux-router": "^0.17.1",
     "lodash-es": "^4.17.20",

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -31,7 +31,6 @@ function getNodeModulesResolveLocationForPackageName(packageName) {
     if (fs.existsSync(pathToPackageJson)) {
       const packageJson = require(pathToPackageJson);
 
-      // console.debug('cccc', !!packageJson.main && packageJson.main !== '');
       if (!!packageJson.main && packageJson.main !== '') {
         console.debug(`Unable to look up package using NodeJS require.resolve for => ${packageName}.`);
       }

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -1,9 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
 // defer to NodeJS to find where on disk a package is located using require.resolve
 // and return the root absolute location
 function getNodeModulesResolveLocationForPackageName(packageName) {
   let nodeModulesUrl;
   
   try {
+    // console.debug('require.resolve =>', packageName);
     const packageEntryLocation = require.resolve(packageName).replace(/\\/g, '/'); // force / for consistency and path matching
 
     if (packageName.indexOf('@greenwood') === 0) {
@@ -20,10 +24,31 @@ function getNodeModulesResolveLocationForPackageName(packageName) {
 
       nodeModulesUrl = `${packageRootPath}${packageName}`;
     }
-
   } catch (e) {
-    console.debug(`Unable to look up package using NodeJS require.resolve for => ${packageName}`);
+    // do a quick check to see if this is a package with _NO_ main, which has some issues for require.resolve
+    // https://github.com/ProjectEvergreen/greenwood/issues/557#issuecomment-923332104
+    const pathToPackageJson = `${getFallbackNodeModulesLocation(packageName)}/package.json`;
+
+    if (fs.existsSync(pathToPackageJson)) {
+      const packageJson = require(pathToPackageJson);
+
+      // console.debug('MAIN @@@@@', packageJson.main);
+      // console.debug('aaaa', !!packageJson.main);
+      // console.debug('bbbb', packageJson.main !== '');
+      // console.debug('cccc', !!packageJson.main && packageJson.main !== '');
+      if (!!packageJson.main && packageJson.main !== '') {
+        console.debug(`Unable to look up package using NodeJS require.resolve for => ${packageName}.`);
+      }
+    }
   }
+
+  // console.debug('detected nodeModulesUrl @@@@', nodeModulesUrl);
+  return nodeModulesUrl;
+}
+
+// for some reason if require.resolve doesnt work, assume the current directory and construct path manually
+function getFallbackNodeModulesLocation(packageName) {
+  const nodeModulesUrl = path.join(process.cwd(), 'node_modules', packageName);
 
   return nodeModulesUrl;
 }
@@ -42,6 +67,7 @@ function getPackageNameFromUrl(url) {
 }
 
 module.exports = {
+  getFallbackNodeModulesLocation,
   getNodeModulesResolveLocationForPackageName,
   getPackageNameFromUrl
 };

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -7,7 +7,6 @@ function getNodeModulesResolveLocationForPackageName(packageName) {
   let nodeModulesUrl;
   
   try {
-    // console.debug('require.resolve =>', packageName);
     const packageEntryLocation = require.resolve(packageName).replace(/\\/g, '/'); // force / for consistency and path matching
 
     if (packageName.indexOf('@greenwood') === 0) {
@@ -32,9 +31,6 @@ function getNodeModulesResolveLocationForPackageName(packageName) {
     if (fs.existsSync(pathToPackageJson)) {
       const packageJson = require(pathToPackageJson);
 
-      // console.debug('MAIN @@@@@', packageJson.main);
-      // console.debug('aaaa', !!packageJson.main);
-      // console.debug('bbbb', packageJson.main !== '');
       // console.debug('cccc', !!packageJson.main && packageJson.main !== '');
       if (!!packageJson.main && packageJson.main !== '') {
         console.debug(`Unable to look up package using NodeJS require.resolve for => ${packageName}.`);
@@ -42,7 +38,6 @@ function getNodeModulesResolveLocationForPackageName(packageName) {
     }
   }
 
-  // console.debug('detected nodeModulesUrl @@@@', nodeModulesUrl);
   return nodeModulesUrl;
 }
 

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -47,7 +47,9 @@ const walkModule = (module, dependency) => {
   }), {
     ImportDeclaration(node) {
       let { value: sourceValue } = node.source;
-      const absoluteNodeModulesLocation = getNodeModulesResolveLocationForPackageName(dependency);
+      const absoluteNodeModulesLocation = getNodeModulesResolveLocationForPackageName(dependency)
+        ? getNodeModulesResolveLocationForPackageName(dependency)
+        : path.join(process.cwd(), 'node_modules', dependency);
 
       if (path.extname(sourceValue) === '' && sourceValue.indexOf('http') !== 0 && sourceValue.indexOf('./') < 0) {        
         if (!importMap[sourceValue]) {
@@ -103,7 +105,9 @@ const walkPackageJson = (packageJson = {}) => {
     const isJavascriptPackage = Array.isArray(entry) || typeof entry === 'string' && entry.endsWith('.js') || entry.endsWith('.mjs');
 
     if (isJavascriptPackage) {
-      const absoluteNodeModulesLocation = getNodeModulesResolveLocationForPackageName(dependency);
+      const absoluteNodeModulesLocation = getNodeModulesResolveLocationForPackageName(dependency)
+        ? getNodeModulesResolveLocationForPackageName(dependency)
+        : path.join(process.cwd(), 'node_modules', dependency);
 
       // https://nodejs.org/api/packages.html#packages_determining_module_system
       if (Array.isArray(entry)) {

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const path = require('path');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const replace = require('@rollup/plugin-replace');
-const { getNodeModulesResolveLocationForPackageName, getPackageNameFromUrl } = require('../../lib/node-modules-utils');
+const { getNodeModulesResolveLocationForPackageName, getFallbackNodeModulesLocation, getPackageNameFromUrl } = require('../../lib/node-modules-utils');
 const { ResourceInterface } = require('../../lib/resource-interface');
 const walk = require('acorn-walk');
 
@@ -49,7 +49,7 @@ const walkModule = (module, dependency) => {
       let { value: sourceValue } = node.source;
       const absoluteNodeModulesLocation = getNodeModulesResolveLocationForPackageName(dependency)
         ? getNodeModulesResolveLocationForPackageName(dependency)
-        : path.join(process.cwd(), 'node_modules', dependency);
+        : getFallbackNodeModulesLocation(dependency);
 
       if (path.extname(sourceValue) === '' && sourceValue.indexOf('http') !== 0 && sourceValue.indexOf('./') < 0) {        
         if (!importMap[sourceValue]) {
@@ -107,7 +107,7 @@ const walkPackageJson = (packageJson = {}) => {
     if (isJavascriptPackage) {
       const absoluteNodeModulesLocation = getNodeModulesResolveLocationForPackageName(dependency)
         ? getNodeModulesResolveLocationForPackageName(dependency)
-        : path.join(process.cwd(), 'node_modules', dependency);
+        : getFallbackNodeModulesLocation(dependency);
 
       // https://nodejs.org/api/packages.html#packages_determining_module_system
       if (Array.isArray(entry)) {

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -166,6 +166,10 @@ describe('Develop Greenwood With: ', function() {
         `${process.cwd()}/node_modules/singleton-manager/package.json`,
         `${outputPath}/node_modules/singleton-manager/`
       );
+      const trustedTypesPackageJson = await getDependencyFiles(
+        `${process.cwd()}/node_modules/@types/trusted-types/package.json`,
+        `${outputPath}/node_modules/@types/trusted-types/`
+      );
 
       await runner.setup(outputPath, [
         ...getSetupFiles(outputPath),
@@ -196,7 +200,8 @@ describe('Develop Greenwood With: ', function() {
         ...messageFormatLibs,
         ...messageFormatLibsPackageJson,
         ...singletonManagerLibsPackageJson,
-        ...singletonManagerLibs
+        ...singletonManagerLibs,
+        ...trustedTypesPackageJson
       ]);
 
       return new Promise(async (resolve) => {

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -29,12 +29,44 @@
  * package.json
  */
 const expect = require('chai').expect;
+const fs = require('fs');
 const { JSDOM } = require('jsdom');
 const path = require('path');
 const { getDependencyFiles, getSetupFiles } = require('../../../../../test/utils');
 const request = require('request');
 const Runner = require('gallinago').Runner;
 const runSmokeTest = require('../../../../../test/smoke-test');
+
+async function rreaddir (dir, allFiles = []) {
+  const files = (await fs.promises.readdir(dir)).map(f => path.join(dir, f));
+
+  allFiles.push(...files);
+
+  await Promise.all(files.map(async f => (
+    await fs.promises.stat(f)).isDirectory() && rreaddir(f, allFiles
+  )));
+
+  return allFiles;
+}
+
+// https://stackoverflow.com/a/30405105/417806
+async function copyFile(source, target) {
+  const rd = fs.createReadStream(source);
+  const wr = fs.createWriteStream(target);
+
+  try {
+    return await new Promise((resolve, reject) => {
+      rd.on('error', reject);
+      wr.on('error', reject);
+      wr.on('finish', resolve);
+      rd.pipe(wr);
+    });
+  } catch (error) {
+    console.error('ERROR', error);
+    rd.destroy();
+    wr.end();
+  }
+}
 
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
@@ -171,6 +203,35 @@ describe('Develop Greenwood With: ', function() {
         `${outputPath}/node_modules/@types/trusted-types/`
       );
 
+      // manually copy all these @babel/runtime files recursively since there are too many of them to do it individually
+      const babelRuntimeLibs = await rreaddir(`${process.cwd()}/node_modules/@babel/runtime`);
+
+      await fs.promises.mkdir(`${outputPath}/node_modules/@babel/runtime`, { recursive: true });
+      await fs.promises.copyFile(`${process.cwd()}/node_modules/@babel/runtime/package.json`, `${outputPath}/node_modules/@babel/runtime/package.json`);
+      await Promise.all(babelRuntimeLibs.filter((asset) => {
+        const target = asset.replace(process.cwd(), __dirname);
+        const isDirectory = path.extname(target) === '';
+
+        if (isDirectory && !fs.existsSync(target)) {
+          fs.mkdirSync(target);
+        } else if (!isDirectory) {
+          return asset;
+        }
+      }).map((asset) => {
+        const target = asset.replace(process.cwd(), __dirname);
+
+        return copyFile(asset, target);
+      }));
+
+      const regeneratorRuntimeLibs = await getDependencyFiles(
+        `${process.cwd()}/node_modules/regenerator-runtime/*.js`,
+        `${outputPath}/node_modules/regenerator-runtime/`
+      );
+      const regeneratorRuntimeLibsPackageJson = await getDependencyFiles(
+        `${process.cwd()}/node_modules/regenerator-runtime/package.json`,
+        `${outputPath}/node_modules/regenerator-runtime/`
+      );
+
       await runner.setup(outputPath, [
         ...getSetupFiles(outputPath),
         ...litElementPackageJson,
@@ -201,7 +262,9 @@ describe('Develop Greenwood With: ', function() {
         ...messageFormatLibsPackageJson,
         ...singletonManagerLibsPackageJson,
         ...singletonManagerLibs,
-        ...trustedTypesPackageJson
+        ...trustedTypesPackageJson,
+        ...regeneratorRuntimeLibs,
+        ...regeneratorRuntimeLibsPackageJson
       ]);
 
       return new Promise(async (resolve) => {

--- a/packages/cli/test/cases/develop.default/package.json
+++ b/packages/cli/test/cases/develop.default/package.json
@@ -1,6 +1,7 @@
 {
   "name": "test-develop-command-default",
   "dependencies": {
+    "@babel/runtime": "^7.10.4",
     "@lion/button": "~0.12.0",
     "@lion/calendar": "~0.15.0",
     "@types/trusted-types": "^2.0.2",

--- a/packages/cli/test/cases/develop.default/package.json
+++ b/packages/cli/test/cases/develop.default/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "@lion/button": "~0.12.0",
     "@lion/calendar": "~0.15.0",
+    "@types/trusted-types": "^2.0.2",
     "lit-element": "^2.4.0"
   }
 }

--- a/packages/plugin-polyfills/src/index.js
+++ b/packages/plugin-polyfills/src/index.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const { getNodeModulesResolveLocationForPackageName } = require('@greenwood/cli/src/lib/node-modules-utils');
+const { getNodeModulesLocationForPackage } = require('@greenwood/cli/src/lib/node-modules-utils');
 const path = require('path');
 const { ResourceInterface } = require('@greenwood/cli/src/lib/resource-interface');
 
@@ -15,7 +15,7 @@ class PolyfillsResource extends ResourceInterface {
   async optimize(url, body) {
     const polyfillPackageName = '@webcomponents/webcomponentsjs';
     const filename = 'webcomponents-loader.js';
-    const polyfillNodeModulesLocation = getNodeModulesResolveLocationForPackageName(polyfillPackageName);
+    const polyfillNodeModulesLocation = getNodeModulesLocationForPackage(polyfillPackageName);
 
     return new Promise(async (resolve, reject) => {
       try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,6 +2600,11 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
+"@types/trusted-types@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
+  integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
+
 "@types/ungap__global-this@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz#18ce9f657da556037a29d50604335614ce703f4c"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves https://github.com/ProjectEvergreen/greenwood/issues/557#issuecomment-923332104

## Summary of Changes
1.  Add fallback handling when `require.resolve` can find what we need

## TODOs
1. [x] Understand why it cant be found
    - seems related to how NodeJS treats packages with "unusable" `main` field in its _package.json_ (see edit to above linked comment)
    - this is kind of "disappointing" because while these packages may not have a `"main"` or `exports`, in the case of **@babel/runtime**, they still have their own [`dependencies`](https://unpkg.com/browse/@babel/runtime@7.15.4/package.json), so we still need to get the location to walk that _package.json_
1. [x] Add test cases
1. [x] How to best fallback in the above identified situation?  Maybe as part of #684 or keep #557 open and move into the next project?
    - found it!  [`require.resolve.paths`](https://nodejs.org/api/modules.html#modules_require_resolve_paths_request) should be a good fallback if `require.resolve` itself fails.