### PR TITLE
Bug/issue 736 double ga init requests

### DIFF
--- a/packages/plugin-google-analytics/README.md
+++ b/packages/plugin-google-analytics/README.md
@@ -19,7 +19,9 @@ yarn add @greenwood/plugin-google-analytics --dev
 ```
 
 ## Usage
-Use this plugin in your _greenwood.config.js_ and pass in your Google Analytics ID, e.g. `UA-XXXXX`.
+Use this plugin in your _greenwood.config.js_ and pass in your Google Analytics ID, which can either be a
+* Measurement ID (**recommended**): ex. `G-XXXXXX`
+* Tracking ID (legacy): ex. `UA-XXXXXX`
 
 ```javascript
 const googleAnalyticsPlugin = require('@greenwood/plugin-google-analytics');
@@ -37,6 +39,7 @@ module.exports = {
 
 This will then add the Google Analytics [JavaScript tracker snippet](https://developers.google.com/analytics/devguides/collection/analyticsjs/) to your project's _index.html_.
 
+> _Learn more about [Measurement and Tracking IDs](https://support.google.com/analytics/answer/9539598)_.
 
 ## Options
 - `analyticsId` (required) - Your Google Analytics ID

--- a/packages/plugin-google-analytics/src/index.js
+++ b/packages/plugin-google-analytics/src/index.js
@@ -37,7 +37,6 @@ class GoogleAnalyticsResource extends ResourceInterface {
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
             gtag('config', '${analyticsId}', { 'anonymize_ip': ${trackAnon} });
-            gtag('config', '${analyticsId}');
           </script>
         </head>
         `);

--- a/packages/plugin-google-analytics/test/cases/default/default.spec.js
+++ b/packages/plugin-google-analytics/test/cases/default/default.spec.js
@@ -87,7 +87,6 @@ describe('Build Greenwood With: ', function() {
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
             gtag('config', '${mockAnalyticsId}', { 'anonymize_ip': true });
-            gtag('config', '${mockAnalyticsId}');
         `;
 
         expect(inlineScript[0].textContent).to.contain(expectedContent);

--- a/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
+++ b/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
@@ -76,7 +76,6 @@ describe('Build Greenwood With: ', function() {
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
             gtag('config', '${mockAnalyticsId}', { 'anonymize_ip': false });
-            gtag('config', '${mockAnalyticsId}');
         `;
 
         expect(inlineScript[0].textContent).to.contain(expectedContent);


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #736 

## Summary of Changes
1. Remove extra `gtag` config call and update specs
1. Update docs to reference Measurement vs Tracking ID types