### PR TITLE
upgrade to latest rollup and node related dep versions

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@rollup/plugin-node-resolve": "^9.0.0",
+    "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-replace": "^2.3.4",
     "@webcomponents/webcomponentsjs": "^2.6.0",
     "acorn": "^8.0.1",
@@ -44,7 +44,7 @@
     "remark-frontmatter": "^2.0.0",
     "remark-parse": "^8.0.3",
     "remark-rehype": "^7.0.0",
-    "rollup": "^2.34.1",
+    "rollup": "^2.58.0",
     "rollup-plugin-terser": "^7.0.0",
     "unified": "^9.2.0"
   },

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -268,13 +268,13 @@ describe('Build Greenwood With: ', function() {
         
         expect(inlineScriptTag.textContent.replace('\n', '')).to
           // eslint-disable-next-line max-len
-          .equal('import"/lit-element.23ccf9b1.js";import"/lit-html.5ab358db.js";document.getElementsByClassName("output-script-inline")[0].innerHTML="script tag module inline"//# sourceMappingURL=171628389-scratch.f6bbfcb9.js.map');
+          .equal('import"/lit-element.ea26fec7.js";import"/lit-html.d69ea26f.js";document.getElementsByClassName("output-script-inline")[0].innerHTML="script tag module inline"//# sourceMappingURL=1008626452-scratch.a5230e1a.js.map');
       });
 
       it('should have the expected inline node_modules content in the second inline script tag which should include extra code from rollup', async function() {
         const inlineScriptTag = dom.window.document.querySelectorAll('head > script:not([src])')[1];
-
-        expect(inlineScriptTag.textContent.replace('\n', '')).to.equal('import"/lit-element.23ccf9b1.js";import"/lit-html.5ab358db.js";//# sourceMappingURL=866723778-scratch.8010d3c7.js.map');
+        
+        expect(inlineScriptTag.textContent.replace('\n', '')).to.equal('import"/lit-element.ea26fec7.js";import"/lit-html.d69ea26f.js";//# sourceMappingURL=1832243663-scratch.c317be4c.js.map');xw
       });
 
       it('should have the expected output from the first inline <script> tag in the page output', async function() {

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -268,13 +268,13 @@ describe('Build Greenwood With: ', function() {
         
         expect(inlineScriptTag.textContent.replace('\n', '')).to
           // eslint-disable-next-line max-len
-          .equal('import"/lit-element.ea26fec7.js";import"/lit-html.d69ea26f.js";document.getElementsByClassName("output-script-inline")[0].innerHTML="script tag module inline"//# sourceMappingURL=1008626452-scratch.a5230e1a.js.map');
+          .equal('import"/lit-element.4727346b.js";import"/lit-html.5ab358db.js";document.getElementsByClassName("output-script-inline")[0].innerHTML="script tag module inline"//# sourceMappingURL=171628389-scratch.fbf4ad69.js.map');
       });
 
       it('should have the expected inline node_modules content in the second inline script tag which should include extra code from rollup', async function() {
         const inlineScriptTag = dom.window.document.querySelectorAll('head > script:not([src])')[1];
         
-        expect(inlineScriptTag.textContent.replace('\n', '')).to.equal('import"/lit-element.ea26fec7.js";import"/lit-html.d69ea26f.js";//# sourceMappingURL=1832243663-scratch.c317be4c.js.map');xw
+        expect(inlineScriptTag.textContent.replace('\n', '')).to.equal('import"/lit-element.4727346b.js";import"/lit-html.5ab358db.js";//# sourceMappingURL=866723778-scratch.8a3421fb.js.map');
       });
 
       it('should have the expected output from the first inline <script> tag in the page output', async function() {

--- a/packages/plugin-import-commonjs/package.json
+++ b/packages/plugin-import-commonjs/package.json
@@ -22,7 +22,7 @@
     "@greenwood/cli": "^0.4.0"
   },
   "dependencies": {
-    "@rollup/plugin-commonjs": "^17.0.0",
+    "@rollup/plugin-commonjs": "^21.0.0",
     "@rollup/stream": "^2.0.0",
     "cjs-module-lexer": "^1.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2287,10 +2287,10 @@
     "@babel/helper-module-imports" "^7.10.4"
     "@rollup/pluginutils" "^3.1.0"
 
-"@rollup/plugin-commonjs@^17.0.0":
-  version "17.0.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-17.0.0.tgz#2ae2228354cf0fbba6cf9f06f30b2c66a974324c"
-  integrity sha512-/omBIJG1nHQc+bgkYDuLpb/V08QyutP9amOrJRUSlYJZP+b/68gM//D8sxJe3Yry2QnYIr3QjR3x4AlxJEN3GA==
+"@rollup/plugin-commonjs@^21.0.0":
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-21.0.0.tgz#b9e4342855ea20b5528f4587b9a90f642196a502"
+  integrity sha512-XDQimjHl0kNotAV5lLo34XoygaI0teqiKGJ100B3iCU8+15YscJPeqk2KqkqD3NIe1H8ZTUo5lYjUFZyEgASTw==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     commondir "^1.0.1"
@@ -2307,17 +2307,17 @@
   dependencies:
     "@rollup/pluginutils" "^3.0.8"
 
-"@rollup/plugin-node-resolve@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz#39bd0034ce9126b39c1699695f440b4b7d2b62e6"
-  integrity sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==
+"@rollup/plugin-node-resolve@^13.0.0":
+  version "13.0.5"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.5.tgz#016abe58796a4ff544d6beac7818921e3d3777fc"
+  integrity sha512-mVaw6uxtvuGx/XCI4qBQXsDZJUfyx5vp39iE0J/7Hd6wDhEbjHr6aES7Nr9yWbuE0BY+oKp6N7Bq6jX5NCGNmQ==
   dependencies:
     "@rollup/pluginutils" "^3.1.0"
     "@types/resolve" "1.17.1"
     builtin-modules "^3.1.0"
     deepmerge "^4.2.2"
     is-module "^1.0.0"
-    resolve "^1.17.0"
+    resolve "^1.19.0"
 
 "@rollup/plugin-replace@^2.3.4":
   version "2.3.4"
@@ -5735,6 +5735,11 @@ fsevents@~2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
+fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -10547,7 +10552,7 @@ resolve@^1.10.0, resolve@^1.16.1:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.12.0, resolve@^1.14.2, resolve@^1.3.2:
+resolve@^1.12.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.3.2:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -10664,12 +10669,12 @@ rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^2.34.1:
-  version "2.34.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.34.1.tgz#a387230df02c58b242794a213dfb68b42de2c8fb"
-  integrity sha512-tGveB6NU5x4MS/iXaIsjfUkEv4hxzJJ4o0FRy5LO62Ndx3R2cmE1qsLYlSfRkvHUUPqWiFoxEm8pRftzh1a5HA==
+rollup@^2.58.0:
+  version "2.58.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.58.0.tgz#a643983365e7bf7f5b7c62a8331b983b7c4c67fb"
+  integrity sha512-NOXpusKnaRpbS7ZVSzcEXqxcLDOagN6iFS8p45RkoiMqPHDLwJm758UF05KlMoCRbLBTZsPOIa887gZJ1AiXvw==
   optionalDependencies:
-    fsevents "~2.1.2"
+    fsevents "~2.3.2"
 
 run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #630 and fixes the external missing dependency issue from https://github.com/ProjectEvergreen/greenwood-getting-started/pull/45

> Not sure if I will upgrade all deps here or not, as I am just plan on chipping away at #630 open as part of the roadmap to 1.0 anyway and for now just mostly want to unblock modern NPM package resolution.

## Summary of Changes
1. Upgrade to latest Rollup and node modules related to deps for latest features like `sideEffects` and `exports`