### PR TITLE
enhancement/issue 629 cache unchanged assets in development

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "acorn-walk": "^8.0.0",
     "commander": "^2.20.0",
     "cssnano": "^5.0.11",
-    "es-module-shims": "^0.5.2",
+    "es-module-shims": "^1.2.0",
     "front-matter": "^4.0.2",
     "koa": "^2.13.0",
     "livereload": "^0.9.1",

--- a/packages/cli/src/lib/hashing-utils.js
+++ b/packages/cli/src/lib/hashing-utils.js
@@ -9,6 +9,6 @@ function hashString(inputString) {
   return Math.abs(h).toString();
 }
 
-module.exports = {
+export {
   hashString
 };

--- a/packages/cli/src/lib/hashing-utils.js
+++ b/packages/cli/src/lib/hashing-utils.js
@@ -1,0 +1,14 @@
+// https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0#gistcomment-2775538
+function hashString(inputString) {
+  let h = 0;
+
+  for (let i = 0; i < inputString.length; i += 1) {
+    h = Math.imul(31, h) + inputString.charCodeAt(i) | 0; // eslint-disable-line no-bitwise
+  }
+
+  return Math.abs(h).toString();
+}
+
+module.exports = {
+  hashString
+};

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -143,6 +143,7 @@ async function getDevServer(compilation) {
           ctx.status = 304;
           ctx.body = null;
           ctx.set('Etag', etagHash);
+          ctx.set('Cache-Control', 'no-cache');
         } else if (!inm || inm !== etagHash) {
           ctx.set('Etag', etagHash);
         }

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -128,20 +128,23 @@ async function getDevServer(compilation) {
   // ETag Support - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
   app.use(async (ctx) => {
     const body = ctx.response.body;
-    // console.debug('body', body);
+    const { url } = ctx;
 
-    if (Buffer.isBuffer(body)) {
-      // console.warn(`no body for => ${ctx.url}`);
-    } else {
-      const inm = ctx.headers['if-none-match'];
-      const etagHash = hashString(body);
+    // don't interfere with extrenal requests or API calls
+    if (path.extname(url) !== '' && url.indexOf('http') !== 0) {
+      if (Buffer.isBuffer(body)) {
+        // console.warn(`no body for => ${ctx.url}`);
+      } else {
+        const inm = ctx.headers['if-none-match'];
+        const etagHash = hashString(body);
 
-      if (inm && inm === etagHash) {
-        ctx.status = 304;
-        ctx.body = null;
-        ctx.set('Etag', etagHash);
-      } else if (!inm || inm !== etagHash) {
-        ctx.set('Etag', etagHash);
+        if (inm && inm === etagHash) {
+          ctx.status = 304;
+          ctx.body = null;
+          ctx.set('Etag', etagHash);
+        } else if (!inm || inm !== etagHash) {
+          ctx.set('Etag', etagHash);
+        }
       }
     }
 

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -130,8 +130,9 @@ async function getDevServer(compilation) {
     const body = ctx.response.body;
     const { url } = ctx;
 
-    // don't interfere with extrenal requests or API calls
-    if (path.extname(url) !== '' && url.indexOf('http') !== 0) {
+    // don't interfere with external requests or API calls
+    // and only run in development
+    if (process.env.__GWD_COMMAND__ === 'develop' && path.extname(url) !== '' && url.indexOf('http') !== 0) { // eslint-disable-line no-underscore-dangle
       if (Buffer.isBuffer(body)) {
         // console.warn(`no body for => ${ctx.url}`);
       } else {

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -125,9 +125,7 @@ async function getDevServer(compilation) {
     await next();
   });
 
-  // before or after processing?
-  // otherwise everything next() has to do null check on ctx.body
-  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
+  // ETag Support - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
   app.use(async (ctx) => {
     console.warn(`?????? checking etag for => ${ctx.url}`);
     const body = ctx.response.body;
@@ -154,7 +152,6 @@ async function getDevServer(compilation) {
       }
     }
 
-    console.debug('============================');
   });
 
   return Promise.resolve(app);

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -126,6 +126,7 @@ async function getDevServer(compilation) {
   });
 
   // ETag Support - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
+  // https://stackoverflow.com/questions/43659756/chrome-ignores-the-etag-header-and-just-uses-the-in-memory-cache-disk-cache
   app.use(async (ctx) => {
     const body = ctx.response.body;
     const { url } = ctx;

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -127,27 +127,20 @@ async function getDevServer(compilation) {
 
   // ETag Support - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
   app.use(async (ctx) => {
-    console.warn(`?????? checking etag for => ${ctx.url}`);
     const body = ctx.response.body;
     // console.debug('body', body);
 
     if (Buffer.isBuffer(body)) {
-      console.warn(`no body for => ${ctx.url}`);
+      // console.warn(`no body for => ${ctx.url}`);
     } else {
-      console.debug('HEADERS', ctx.headers);
       const inm = ctx.headers['if-none-match'];
       const etagHash = hashString(body);
 
-      console.debug('inm', inm);
-      console.debug('etagHash', etagHash);
-
       if (inm && inm === etagHash) {
-        console.debug('@@@@@@@@@ PARTY TIME (we can cache this one)!');
         ctx.status = 304;
         ctx.body = null;
         ctx.set('Etag', etagHash);
       } else if (!inm || inm !== etagHash) {
-        console.debug('!!!!! SET AN ETAG HERE');
         ctx.set('Etag', etagHash);
       }
     }

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -306,7 +306,9 @@ class NodeModulesResource extends ResourceInterface {
         // for each entry found in dependencies, find its entry point
         // then walk its entry point (e.g. index.js) for imports / exports to add to the importMap
         // and then walk its package.json for transitive dependencies and all those import / exports
-        await walkPackageJson(userPackageJson);
+        if (Object.keys(importMap).length === 0) {
+          await walkPackageJson(userPackageJson);
+        }
 
         // apply import map and shim for users
         newContents = newContents.replace('<head>', `

--- a/packages/plugin-graphql/src/core/common.js
+++ b/packages/plugin-graphql/src/core/common.js
@@ -1,13 +1,4 @@
-// https://gist.github.com/hyamamoto/fd435505d29ebfa3d9716fd2be8d42f0#gistcomment-2775538
-function hashString(queryKeysString) {
-  let h = 0;
-
-  for (let i = 0; i < queryKeysString.length; i += 1) {
-    h = Math.imul(31, h) + queryKeysString.charCodeAt(i) | 0; // eslint-disable-line no-bitwise
-  }
-
-  return Math.abs(h).toString();
-}
+import { hashString } from '@greenwood/cli/src/lib/hashing-utils.js';
 
 function getQueryHash(query, variables = {}) {
   const queryKeys = query;

--- a/packages/plugin-graphql/src/index.js
+++ b/packages/plugin-graphql/src/index.js
@@ -43,6 +43,7 @@ class GraphQLResource extends ResourceInterface {
           : ',';
         const shimmedBody = body.replace('"imports": {', `
           "imports": {
+            "@greenwood/cli/src/lib/hashing-utils.js": "/node_modules/@greenwood/cli/src/lib/hashing-utils.js",
             "@greenwood/plugin-graphql/core/client": "/node_modules/@greenwood/plugin-graphql/src/core/client.js",
             "@greenwood/plugin-graphql/core/common": "/node_modules/@greenwood/plugin-graphql/src/core/common.js",
             "@greenwood/plugin-graphql/queries/children": "/node_modules/@greenwood/plugin-graphql/src/queries/children.gql",

--- a/www/pages/about/how-it-works.md
+++ b/www/pages/about/how-it-works.md
@@ -24,6 +24,7 @@ During _development_ the CLI will:
 - Process requests on the fly only for the content or code you need for a given page.
 - Supports loading dependencies from _node_modules_ using an [`importMap`](https://github.com/WICG/import-maps) to avoid bundling.
 - While Greenwood is ESM first, we have a [plugin](/plugins/custom-plugins/) to transform CommonJS into ESM (🤞)
+- Leverage `E-Tag` headers to apply [caching techniques for unchanged assets](/blog/release/v0-24-0/#local-development-enhancements)
 
 For _production_ builds:
 - Combine all your code and dependencies into efficient modern bundles including minifying your JavaScript and CSS.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5173,10 +5173,12 @@ es-abstract@^1.18.0-next.2:
     string.prototype.trimstart "^1.0.4"
     unbox-primitive "^1.0.0"
 
-es-module-shims@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/es-module-shims/-/es-module-shims-0.5.2.tgz#9bea003e84a11bdc052b9f52464671176509f520"
-  integrity sha512-cXSy7EPyZc6Iq4AjyWXMqMURXgFguduPN7nxtfI0WsV4C83wNHrdxf0oxhzDPZU/8zB6YFllR24HMG/EBVN/GQ==
+es-module-shims@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-module-shims/-/es-module-shims-1.2.0.tgz#f3b447826c4f4b9d9597b24a7aaa0c639893de2f"
+  integrity sha512-Kupc9HFwmScot1v8vO/3CX9MjNprarG4wdlBk2bv5R76SD63UBhXG53MUTjg8USgHaCMLBOQyGSl7lAEqGUb1g==
+  dependencies:
+    rimraf "^3.0.2"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #629 

## Summary of Changes
1. Cache `importMap` from initial walking of all dependencies
1. Set and check [`ETag` and `If-None-Match` headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) respectively as part of dev server request / response middleware.  Also setting `Cache-Control` header too.
1. Created shareable `hashString` function
1. Upgraded to latest version of **es-module-shims** dependency
1. Added a mention of this to the _How It Works_ section

Benchmarks - https://github.com/ProjectEvergreen/greenwood/pull/760#issuecomment-1046120992

## TODOs 
1. [x] A / B testing against master branch
1. [x] Figure out why [Chrome doesn't seem to support this for ESM specifically](https://stackoverflow.com/questions/43659756/chrome-ignores-the-etag-header-and-just-uses-the-in-memory-cache-disk-cache)?  Is fine with CSS.  maybe need to set a [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
1. [x] Should only happen during development
1. [x] Have packages share `hashString` implementation
1. [x] Verify if **es-module-shims** is [causing double renders / script executions](https://github.com/guybedford/es-module-shims#no-load-event-retriggers)?
    - I think default behavior is working fine, so no need to mess with anything IMO
    
## Testing / Demo
So far this works great in Firefox, but testing (as in this feature) can be thought of as a stepping stone to [HMR](#48).  The value here is in seeing if development is / feels faster with these changes as opposed to not having it. 

⚠️ Make sure you don't have _Disable Cache_ set in your dev tools!  ⚠️ 

1. Open a new tab with the network tab open
1. Load the website with the `develop` command and observe the status of everything should be `200`
![Screen Shot 2021-10-10 at 12 07 58 PM](https://user-images.githubusercontent.com/895923/136704045-30221257-be77-4047-b54e-2ff16cfbf89e.png)
1. Refresh and now the status should change to `304`
![Screen Shot 2021-10-10 at 12 08 14 PM](https://user-images.githubusercontent.com/895923/136704053-c300c782-4e73-46cc-8d53-250dc70c82a2.png)
1. Change a file and observe now that there is new content, the status has changed back to `200` and the page should have changed, but everything else stays `304`
![Screen Shot 2021-10-10 at 12 08 33 PM](https://user-images.githubusercontent.com/895923/136704074-da8095ee-4782-4944-96ae-66c64aaecc0d.png)
1. Keep refreshing, and the status should go back to `304` for everything
![Screen Shot 2021-10-10 at 12 08 45 PM](https://user-images.githubusercontent.com/895923/136704088-2826bd80-f928-44bd-ae4a-8ef1ac5f2981.png)

## Questions
1. [x] Should it be configurable?  Or at least documented for awareness?
    - It's always easy enough to just set_Disable Cache_ from the dev tools to bypass, which we can document as well.
1. [x] I notice with live reload, just saving with no changes causes a reload, I wonder if it only looks for a timestamp?  Not sure if it's something we can do but it would be great if no change didn't cause a reload, like https://github.com/postcss/postcss-cli/issues/320 - added to my personal backlog
1. [ ] Where should this happen, before or after post-processing in middleware chain?  If first, everything after has to do `null` check on `ctx.body`.  Maybe it's something we could apply to `ResourceInterface`?
1. [ ] Should this _exclude_:
    - binary files
    - API calls - Yes
    - external HTTP requests - Yes
    - HTML?