### PR TITLE
remove duplicate style tag from default page template

### DIFF
--- a/www/templates/page.html
+++ b/www/templates/page.html
@@ -18,8 +18,6 @@
         editButton.href = `https://github.com/ProjectEvergreen/greenwood/tree/master/www/pages/${filePath}`
       }
     </script>
-
-    <link rel="stylesheet" href="../styles/page.css"/>
   </head>
 
   <body>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Remove duplicate `<style>` tag from default page template