### PR TITLE
correctly merge page template `<head>` tags with app template `<head>` tags

### DIFF
--- a/packages/cli/test/cases/build.default.workspace-template-page-and-app/build.default.workspace-template-page-and-app.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-template-page-and-app/build.default.workspace-template-page-and-app.spec.js
@@ -53,7 +53,7 @@ describe('Build Greenwood With: ', function() {
       await runner.runCommand(cliPath, 'build');
     });
 
-    runSmokeTest(['public', 'index'], LABEL);
+    runSmokeTest(['public'], LABEL);
 
     describe('Custom App and Page Templates', function() {
       let dom;
@@ -119,6 +119,30 @@ describe('Build Greenwood With: ', function() {
           expect(styleTags[2].textContent).to.contain('app-template-two-style');
           expect(styleTags[3].textContent).to.contain('page-template-one-style');
           expect(styleTags[4].textContent).to.contain('page-template-two-style');
+        });
+      });
+
+      describe('<head> "like" tags that should be in the <body>', function() {
+        let scriptTags;
+        let linkTags;
+        let styleTags;
+
+        before(function() {
+          scriptTags = dom.window.document.querySelectorAll('body > script');
+          linkTags = dom.window.document.querySelectorAll('body > link');
+          styleTags = dom.window.document.querySelectorAll('body > style');
+        });
+
+        it('should have 1 <script> tag in the <body>', function() {
+          expect(scriptTags.length).to.equal(1);
+        });
+
+        it('should have 1 <link> tag in the <body>', function() {
+          expect(linkTags.length).to.equal(1);
+        });
+
+        it('should have 1 <style> tag in the <body>', function() {
+          expect(styleTags.length).to.equal(1);
         });
       });
     });

--- a/packages/cli/test/cases/build.default.workspace-template-page-and-app/src/templates/app.html
+++ b/packages/cli/test/cases/build.default.workspace-template-page-and-app/src/templates/app.html
@@ -25,6 +25,10 @@
   </head>
 
   <body>
+    <script></script>
+    <link rel="html"/>
+    <style></style>
+
     <page-outlet></page-outlet>
   </body>
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #782

## Summary of Changes
1. As outlined in the issue, `<head>` tags from the page were merging anywhere a corresponding tag was found, instead of going into the `<head>` as expected
1. Updated specs accordingly to cover this case