### PR TITLE
wrap all common index specs in the label of the calling spec

### DIFF
--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -14,118 +14,121 @@ const { JSDOM } = require('jsdom');
 const path = require('path');
 const { tagsMatch } = require('./utils');
 
-function commonIndexSpecs(dom, html) {
-  describe('document <html>', function() {
-    it('should have an <html> tag with the DOCTYPE attribute', function() {
-      expect(html.indexOf('<!DOCTYPE html>')).to.be.equal(0);
+function commonIndexSpecs(dom, html, label) {
+  describe(`Running Common Index Smoke Tests for ${label}`, function() {
+
+    describe('document <html>', function() {
+      it('should have an <html> tag with the DOCTYPE attribute', function() {
+        expect(html.indexOf('<!DOCTYPE html>')).to.be.equal(0);
+      });
+
+      it('should have a <head> tag with the lang attribute on it', function() {
+        const htmlTag = dom.window.document.querySelectorAll('html');
+
+        expect(htmlTag.length).to.equal(1);
+        expect(htmlTag[0].getAttribute('lang')).to.be.equal('en');
+        expect(htmlTag[0].getAttribute('prefix')).to.be.equal('og:http://ogp.me/ns#');
+      });
+
+      it('should have matching opening and closing <html> tags', function() {
+        expect(tagsMatch('html', html, 1)).to.be.equal(true);
+      });
     });
 
-    it('should have a <head> tag with the lang attribute on it', function() {
-      const htmlTag = dom.window.document.querySelectorAll('html');
+    describe('document <head>', function() {
+      let metaTags;
 
-      expect(htmlTag.length).to.equal(1);
-      expect(htmlTag[0].getAttribute('lang')).to.be.equal('en');
-      expect(htmlTag[0].getAttribute('prefix')).to.be.equal('og:http://ogp.me/ns#');
+      before(function() {
+        metaTags = dom.window.document.querySelectorAll('head > meta');
+      });
+
+      it('should have matching opening and closing <head> tags in the <head>', function() {
+        // add an expclit > here to avoid conflicting with <header>
+        // which is used in a lot of test case scaffolding
+        expect(tagsMatch('head>', html, 1)).to.be.equal(true);
+      });
+
+      it('should have a <title> tag in the <head>', function() {
+        const title = dom.window.document.querySelector('head title').textContent;
+
+        expect(title).to.not.be.undefined;
+      });
+
+      it('should have matching opening and closing <script> tags in the <head>', function() {
+        expect(tagsMatch('script', html)).to.be.equal(true);
+      });
+
+      it('should have matching opening and closing <link> tags in the <head>', function() {
+        const html = dom.window.document.querySelector('html').textContent;
+
+        expect(tagsMatch('link', html)).to.be.equal(true);
+      });
+
+      // note: one will always be present when using puppeteer
+      it('should have matching opening and closing <style> tags in the <head>', function() {
+        expect(tagsMatch('style', html)).to.be.equal(true);
+      });
+
+      it('should have default viewport <meta> tag', function() {
+        const viewportMeta = Array.from(metaTags).filter(meta => meta.getAttribute('name') === 'viewport');
+
+        expect(viewportMeta.length).to.be.equal(1);
+        expect(viewportMeta[0].getAttribute('name')).to.be.equal('viewport');
+        expect(viewportMeta[0].getAttribute('content')).to.be.equal('width=device-width, initial-scale=1');
+      });
+
+      it('should have default charset <meta> tag', function() {
+        const chartsetMeta = Array.from(metaTags).filter(meta => meta.getAttribute('charset') === 'utf-8');
+
+        expect(chartsetMeta.length).to.be.equal(1);
+        expect(chartsetMeta[0].getAttribute('charset')).to.be.equal('utf-8');
+      });
     });
 
-    it('should have matching opening and closing <html> tags', function() {
-      expect(tagsMatch('html', html, 1)).to.be.equal(true);
-    });
-  });
+    describe('document <body>', function() {
+      it('should have matching opening and closing <body> tags', function() {
+        expect(tagsMatch('body', html, 1)).to.be.equal(true);
+      });
 
-  describe('document <head>', function() {
-    let metaTags;
+      it('should have no <script> tags in the <body>', function() {
+        const bodyScripts = dom.window.document.querySelectorAll('body script');
 
-    before(function() {
-      metaTags = dom.window.document.querySelectorAll('head > meta');
-    });
+        expect(bodyScripts.length).to.be.equal(0);
+      });
 
-    it('should have matching opening and closing <head> tags in the <head>', function() {
-      // add an expclit > here to avoid conflicting with <header>
-      // which is used in a lot of test case scaffolding
-      expect(tagsMatch('head>', html, 1)).to.be.equal(true);
-    });
+      it('should have no <link> tags in the <body>', function() {
+        const bodyLinks = dom.window.document.querySelectorAll('body link');
 
-    it('should have a <title> tag in the <head>', function() {
-      const title = dom.window.document.querySelector('head title').textContent;
+        expect(bodyLinks.length).to.be.equal(0);
+      });
 
-      expect(title).to.not.be.undefined;
-    });
+      it('should have no <style> tags in the <body>', function() {
+        const bodyStyles = dom.window.document.querySelectorAll('body style');
 
-    it('should have matching opening and closing <script> tags in the <head>', function() {
-      expect(tagsMatch('script', html)).to.be.equal(true);
-    });
+        expect(bodyStyles.length).to.be.equal(0);
+      });
 
-    it('should have matching opening and closing <link> tags in the <head>', function() {
-      const html = dom.window.document.querySelector('html').textContent;
+      it('should have no <meta> tags in the <body>', function() {
+        const bodyMetas = dom.window.document.querySelectorAll('body meta');
 
-      expect(tagsMatch('link', html)).to.be.equal(true);
-    });
+        expect(bodyMetas.length).to.be.equal(0);
+      });
 
-    // note: one will always be present when using puppeteer
-    it('should have matching opening and closing <style> tags in the <head>', function() {
-      expect(tagsMatch('style', html)).to.be.equal(true);
-    });
+      it('should have no <content-outlet> tags in the <body>', function() {
+        const contentOutlet = dom.window.document.querySelectorAll('body content-outlet');
 
-    it('should have default viewport <meta> tag', function() {
-      const viewportMeta = Array.from(metaTags).filter(meta => meta.getAttribute('name') === 'viewport');
-      
-      expect(viewportMeta.length).to.be.equal(1);
-      expect(viewportMeta[0].getAttribute('name')).to.be.equal('viewport');
-      expect(viewportMeta[0].getAttribute('content')).to.be.equal('width=device-width, initial-scale=1');
-    });
+        expect(contentOutlet.length).to.be.equal(0);
+      });
 
-    it('should have default charset <meta> tag', function() {
-      const chartsetMeta = Array.from(metaTags).filter(meta => meta.getAttribute('charset') === 'utf-8');
+      it('should have no <page-outlet> tags in the <body>', function() {
+        const pageOutlet = dom.window.document.querySelectorAll('body page-outlet');
 
-      expect(chartsetMeta.length).to.be.equal(1);
-      expect(chartsetMeta[0].getAttribute('charset')).to.be.equal('utf-8');
-    });
-  });
+        expect(pageOutlet.length).to.be.equal(0);
+      });
 
-  describe('document <body>', function() {
-    it('should have matching opening and closing <body> tags', function() {
-      expect(tagsMatch('body', html, 1)).to.be.equal(true);
-    });
-
-    it('should have no <script> tags in the <body>', function() {
-      const bodyScripts = dom.window.document.querySelectorAll('body script');
-
-      expect(bodyScripts.length).to.be.equal(0);
-    });
-
-    it('should have no <link> tags in the <body>', function() {
-      const bodyLinks = dom.window.document.querySelectorAll('body link');
-
-      expect(bodyLinks.length).to.be.equal(0);
-    });
-
-    it('should have no <style> tags in the <body>', function() {
-      const bodyStyles = dom.window.document.querySelectorAll('body style');
-
-      expect(bodyStyles.length).to.be.equal(0);
-    });
-
-    it('should have no <meta> tags in the <body>', function() {
-      const bodyMetas = dom.window.document.querySelectorAll('body meta');
-
-      expect(bodyMetas.length).to.be.equal(0);
-    });
-
-    it('should have no <content-outlet> tags in the <body>', function() {
-      const contentOutlet = dom.window.document.querySelectorAll('body content-outlet');
-
-      expect(contentOutlet.length).to.be.equal(0);
-    });
-
-    it('should have no <page-outlet> tags in the <body>', function() {
-      const pageOutlet = dom.window.document.querySelectorAll('body page-outlet');
-
-      expect(pageOutlet.length).to.be.equal(0);
-    });
-
-    it('should not have any sourcemap inlining for Rollup HTML entry points', function() {
-      expect(html).not.to.contain(/\/\/# sourceMappingURL=(.*)\.html\.map/);
+      it('should not have any sourcemap inlining for Rollup HTML entry points', function() {
+        expect(html).not.to.contain(/\/\/# sourceMappingURL=(.*)\.html\.map/);
+      });
     });
   });
 }
@@ -166,7 +169,7 @@ function defaultIndex(label) {
       });
 
       it('should do all the common checks for an HTML page', function(done) {
-        commonIndexSpecs(dom, html);
+        commonIndexSpecs(dom, html, label);
         done();
       });
     });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

Noticed that in the test output for common index smoke test, there was no way to tell which test the output was coming from, so when something failed, it was hard to debug
```sh
document <html>
    ✓ should have an <html> tag with the DOCTYPE attribute
    ✓ should have a <head> tag with the lang attribute on it
    ✓ should have matching opening and closing <html> tags

  document <head>
    ✓ should have matching opening and closing <head> tags in the <head>
    ✓ should have a <title> tag in the <head>
    ✓ should have matching opening and closing <script> tags in the <head>
    ✓ should have matching opening and closing <link> tags in the <head>
    ✓ should have matching opening and closing <style> tags in the <head>
    ✓ should have default viewport <meta> tag
    ✓ should have default charset <meta> tag

  document <body>
    ✓ should have matching opening and closing <body> tags
    ✓ should have no <script> tags in the <body>
    ✓ should have no <link> tags in the <body>
    ✓ should have no <style> tags in the <body>
    ✓ should have no <meta> tags in the <body>
    ✓ should have no <content-outlet> tags in the <body>
    ✓ should have no <page-outlet> tags in the <body>
    ✓ should not have any sourcemap inlining for Rollup HTML entry points
```

## Summary of Changes
Now like all the other smoke tests, the label for the calling spec is now part of the output.
```sh
Running Common Index Smoke Tests for Default Greenwood Configuration and Workspace
    document <html>
      ✓ should have an <html> tag with the DOCTYPE attribute
      ✓ should have a <head> tag with the lang attribute on it
      ✓ should have matching opening and closing <html> tags
    document <head>
      ✓ should have matching opening and closing <head> tags in the <head>
      ✓ should have a <title> tag in the <head>
      ✓ should have matching opening and closing <script> tags in the <head>
      ✓ should have matching opening and closing <link> tags in the <head>
      ✓ should have matching opening and closing <style> tags in the <head>
      ✓ should have default viewport <meta> tag
      ✓ should have default charset <meta> tag
    document <body>
      ✓ should have matching opening and closing <body> tags
      ✓ should have no <script> tags in the <body>
      ✓ should have no <link> tags in the <body>
      ✓ should have no <style> tags in the <body>
      ✓ should have no <meta> tags in the <body>
      ✓ should have no <content-outlet> tags in the <body>
      ✓ should have no <page-outlet> tags in the <body>
      ✓ should not have any sourcemap inlining for Rollup HTML entry points
```