### PR TITLE
reset PostCSS plugins when optimizing

### DIFF
--- a/packages/plugin-postcss/src/index.js
+++ b/packages/plugin-postcss/src/index.js
@@ -68,12 +68,12 @@ class PostCssResource extends ResourceInterface {
     const { outputDir, userWorkspace } = this.compilation.context;
     const workspaceUrl = url.replace(outputDir, userWorkspace);
     const config = await getConfig(this.compilation, this.options.extendConfig);
-    const plugins = config.plugins || [];
+    const plugins = config.plugins && config.plugins.length ? [...config.plugins] : [];
     
     plugins.push(
       (await import('cssnano')).default
     );
-    
+
     const css = plugins.length > 0
       ? (await postcss(plugins).process(body, { from: workspaceUrl })).css
       : body;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

Noticed that in the current implementation, `plugins` was getting cached so even though the number of plugins was always the same (two), the length was increasing for every `optimization` call.

```
# before
POSTCSS Plugins Length 2
POSTCSS Plugins Length 3
POSTCSS Plugins Length 4
POSTCSS Plugins Length 5
POSTCSS Plugins Length 6

# after
POSTCSS Plugins Length 2
POSTCSS Plugins Length 2
POSTCSS Plugins Length 2
POSTCSS Plugins Length 2
POSTCSS Plugins Length 2
```

## Summary of Changes
1. "Reset" `plugins` array

---

This should probably lead to a larger discussion around optimizing Greenwood to do a better job of only passing around
1. Immutable objects, e.g, `Object.assign({}, this. compilation)` for every plugin (since JavaScript is pass by reference)
1. Caching for plugins like in this case, to avoid have to constantly call `require`