### PR TITLE
SSR and Serverless experiments [DO NOT MERGE] 

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -12,7 +12,7 @@ const FAVICON_HREF = '/assets/favicon.ico';
 
 module.exports = {
   workspace: path.join(__dirname, 'www'),
-  mode: 'mpa',
+  mode: 'ssr',
   optimization: 'inline',
   title: 'Greenwood',
   meta: [

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -13,6 +13,7 @@ const FAVICON_HREF = '/assets/favicon.ico';
 module.exports = {
   workspace: path.join(__dirname, 'www'),
   mode: 'ssr',
+  prerender: false,
   optimization: 'inline',
   title: 'Greenwood',
   meta: [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,7 @@
   "bin": {
     "greenwood": "./src/index.js"
   },
+  "main": "./src/index.js",
   "files": [
     "src/"
   ],

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -1,5 +1,5 @@
 const generateCompilation = require('../lifecycles/compile');
-const { prodServer } = require('../lifecycles/serve');
+const { staticServer, hybridServer } = require('../lifecycles/serve');
 
 module.exports = runProdServer = async () => {
 
@@ -8,9 +8,10 @@ module.exports = runProdServer = async () => {
     try {
       const compilation = await generateCompilation();
       const port = 8080;
-      
-      prodServer(compilation).listen(port, () => {
-        console.info(`Started production test server at localhost:${port}`);
+      const server = compilation.config.mode === 'ssr' ? hybridServer : staticServer;
+
+      server(compilation).listen(port, () => {
+        console.info(`Started server at localhost:${port}`);
       });
     } catch (err) {
       reject(err);

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -32,6 +32,14 @@ program
   });
 
 program
+  .command('serverless')
+  .description('Build a one off route and return the HTML.')
+  .action((cmd) => {
+    command = cmd._name;
+  });
+
+
+program
   .command('develop')
   .description('Start a local development server.')
   .action((cmd) => {
@@ -60,16 +68,16 @@ if (program.parse.length === 0) {
   program.help();
 }
 
-const run = async() => {  
+const run = async() => {
   try {
     console.info(`Running Greenwood with the ${command} command.`);
     process.env.__GWD_COMMAND__ = command;
     
     switch (command) {
 
-      case 'build':   
+      case 'build':
         await runProductionBuild();
-        
+
         break;
       case 'develop':
         await runDevServer();
@@ -77,7 +85,7 @@ const run = async() => {
         break;
       case 'serve':
         process.env.__GWD_COMMAND__ = 'build';
-        
+
         await runProductionBuild();
         await runProdServer();
 
@@ -86,20 +94,46 @@ const run = async() => {
         await ejectConfiguration();
 
         break;
-      default: 
+      default:
         console.warn(`
-          Error: not able to detect command. try using the --help flag if 
-          you're encountering issues running Greenwood.  Visit our docs for more 
+          Error: not able to detect command. try using the --help flag if
+          you're encountering issues running Greenwood.  Visit our docs for more
           info at https://www.greenwoodjs.io/docs/.
         `);
         break;
 
     }
-    process.exit(0); // eslint-disable-line no-process-exit
+
   } catch (err) {
     console.error(err);
     process.exit(1); // eslint-disable-line no-process-exit
   }
 };
 
-run();
+if (command === 'serverless') {
+  process.env.__GWD_COMMAND__ = 'serverless';
+} else {
+  run();
+}
+
+async function buildRoute(route) {
+  const compilation = await generateCompilation();
+
+  return `
+    <html>
+      <head>
+        <title>Greenwood The Edge - ${route}</title>
+      </head>
+      <body>
+        <h1>HTML from AWS Lambda</h1>
+        <pre>
+          ${JSON.stringify(compilation)}
+        </pre>
+      </body>
+    </html>
+  `.replace(/\n/g, '');
+}
+
+module.exports = {
+  buildRoute
+};

--- a/packages/cli/src/lib/browser.js
+++ b/packages/cli/src/lib/browser.js
@@ -8,7 +8,7 @@
  * Wraps Puppeteer's interface to Headless Chrome to expose high level rendering
  * APIs that are able to handle web components and PWAs.
  */
-const puppeteer = require('puppeteer');
+// const puppeteer = require('puppeteer');
 
 class BrowserRunner {
 

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -25,7 +25,7 @@ const greenwoodPlugins = [
     };
   });
 
-const modes = ['ssg', 'mpa', 'spa'];
+const modes = ['ssg', 'mpa', 'spa', 'ssr'];
 const optimizations = ['default', 'none', 'static', 'inline'];
 const pluginTypes = ['copy', 'context', 'resource', 'rollup', 'server'];
 const defaultConfig = {
@@ -43,6 +43,7 @@ const defaultConfig = {
   markdown: { plugins: [], settings: {} },
   prerender: true,
   pagesDirectory: 'pages',
+  routesDirectory: 'routes',
   templatesDirectory: 'templates'
 };
 

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -11,6 +11,7 @@ module.exports = initContexts = async({ config }) => {
       const projectDirectory = process.cwd();
       const userWorkspace = path.join(config.workspace);
       const pagesDir = path.join(userWorkspace, `${config.pagesDirectory}/`);
+      const routesDir = path.join(userWorkspace, `${config.routesDirectory}/`);
       const userTemplatesDir = path.join(userWorkspace, `${config.templatesDirectory}/`);
 
       const context = {
@@ -18,6 +19,7 @@ module.exports = initContexts = async({ config }) => {
         outputDir,
         userWorkspace,
         pagesDir,
+        routesDir,
         userTemplatesDir,
         scratchDir,
         projectDirectory

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -185,7 +185,8 @@ module.exports = generateGraph = async (compilation) => {
         await fs.promises.mkdir(context.scratchDir);
       }
 
-      await fs.promises.writeFile(`${context.scratchDir}/graph.json`, JSON.stringify(compilation.graph));
+      // serverless (Lambda) doesnt like writing to files
+      // await fs.promises.writeFile(`${context.scratchDir}/graph.json`, JSON.stringify(compilation.graph));
 
       resolve(compilation);
     } catch (err) {

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -123,7 +123,7 @@ function getDevServer(compilation) {
   return app;
 }
 
-function getProdServer(compilation) {
+function getStaticServer(compilation, composable) {
   const app = new Koa();
   const standardResources = compilation.config.plugins.filter((plugin) => {
     // html is intentionally omitted
@@ -141,16 +141,20 @@ function getProdServer(compilation) {
     const { mode } = compilation.config;
     const url = ctx.request.url.replace(/\?(.*)/, ''); // get rid of things like query string parameters
 
+    // only handle static output routes, eg. public/about.html
     if (url.endsWith('/') || url.endsWith('.html')) {
       const barePath = mode === 'spa'
         ? 'index.html'
         : url.endsWith('/')
           ? path.join(url, 'index.html')
           : url;
-      const contents = await fs.promises.readFile(path.join(outputDir, barePath), 'utf-8');
-      
-      ctx.set('content-type', 'text/html');
-      ctx.body = contents;
+
+      if (fs.existsSync(path.join(outputDir, barePath))) {
+        const contents = await fs.promises.readFile(path.join(outputDir, barePath), 'utf-8');
+
+        ctx.set('content-type', 'text/html');
+        ctx.body = contents;
+      }
     }
 
     await next();
@@ -174,7 +178,7 @@ function getProdServer(compilation) {
     await next();
   });
 
-  app.use(async (ctx) => {
+  app.use(async (ctx, next) => {
     const responseAccumulator = {
       body: ctx.body,
       contentType: ctx.response.header['content-type']
@@ -207,12 +211,48 @@ function getProdServer(compilation) {
 
     ctx.set('content-type', reducedResponse.contentType);
     ctx.body = reducedResponse.body;
+
+    if (composable) {
+      await next();
+    }
+  });
+
+  return app;
+}
+
+function getHybridServer(compilation) {
+  const app = getStaticServer(compilation, true);
+
+  app.use(async (ctx, next) => {
+    const { routesDir } = compilation.context;
+    const { mode } = compilation.config;
+    const url = ctx.request.url.replace(/\?(.*)/, ''); // get rid of things like query string parameters
+
+    if (url.endsWith('/') && mode === 'ssr') {
+      if (fs.existsSync(path.join(routesDir, `${url.replace(/\//g, '')}.js`))) {
+        const standardHtmlResource = compilation.config.plugins.filter((plugin) => {
+          // html is intentionally omitted
+          return plugin.isGreenwoodDefaultPlugin
+            && plugin.type === 'resource'
+            && plugin.name.indexOf('plugin-standard-html') === 0;
+        }).map((plugin) => {
+          return plugin.provider(compilation);
+        })[0];
+        const response = await standardHtmlResource.serve(url);
+
+        ctx.status = 200;
+        ctx.set('content-type', response.contentType);
+        ctx.body = response.body;
+      }
+    };
   });
     
   return app;
 }
 
+
 module.exports = {
   devServer: getDevServer,
-  prodServer: getProdServer
-};
+  staticServer: getStaticServer,
+  hybridServer: getHybridServer
+}

--- a/www/routes/artists.js
+++ b/www/routes/artists.js
@@ -1,9 +1,63 @@
+const fetch = require('node-fetch');
+
 async function getTemplate() {
+  const artists = await fetch('http://www.analogstudios.net/api/artists').then(resp => resp.json());
+  const timestamp = new Date().getTime();
+  const artistsListItems = artists
+      .filter(artist => artist.isActive === "1")
+      .map((artist) => {
+        const { id, name, bio, imageUrl } = artist;
+
+        return `
+          <tr>
+            <td>${id}</td>
+            <td>${name}</td>
+            <td>${bio}</td>
+            <td><img src="${imageUrl}"/></td>
+          </tr>
+        `;
+    });
+
   return `
     <html>
+
+      <head>
+        <style>
+          h1, h6 {
+            width: 90%;
+            margin: 0 auto;
+            text-align: center;
+          }
+
+          table {
+            width: 80%;
+            margin: 20px auto;
+            text-align: left;
+          }
+
+          img {
+            width: 50%;
+          }
+        </style>
+      </head>
+
       <body>
-        <h1>Hello from the artists page!!!</h1>
+        <h1>Hello from the server rendered artists page! 👋</h1>
+
+        <table>
+          <tr>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Decription</th>
+            <th>Genre</th>
+          </tr>
+
+          ${artistsListItems.join('')}
+        </table>
+
+        <h6>Fetched at: ${timestamp}</h6>
       </body>
+
     </html>
   `;
 }

--- a/www/routes/artists.js
+++ b/www/routes/artists.js
@@ -1,0 +1,23 @@
+async function getTemplate() {
+  return `
+    <html>
+      <body>
+        <h1>Hello from the artists page!!!</h1>
+      </body>
+    </html>
+  `;
+}
+
+async function getPage() {
+  return '<h1>Content goes here</h1>';
+}
+
+async function getMetadata() {
+  return { meta: 'data' };
+}
+
+module.exports = {
+  getTemplate,
+  getPage,
+  getMetadata
+};


### PR DESCRIPTION
## Overview
Opening this for demonstration and discussion purposes and to flesh out ideas and architecture for implementing [server side](#708 ) and [serverless](#626) capabilities for Greenwood.  The goal is to see what an implementation might look like, how it plays together with other parts of the system, and what implications there are that should be accounted for ahead of actually intending to submit a PR.

## SSR
![Screen Shot 2021-11-24 at 6 53 49 PM](https://user-images.githubusercontent.com/895923/144103363-d8d8ddf9-df83-4de8-bd88-a22ca0d9660e.png)

I think what's really cool about the possibilities here is how seamless it would be to run a hybrid application, such that you can have a set of static and dynamic pages and routes that can all share the same static resources, yet still feel like one app.

```
src/
  pages/
    about.md
    index.html
    contact.html
  routes/
    artists.js
    artist.js
  templates/
    app.html
    page.html
    product.html
  styles/
    theme.css
    artist.css
    main.css
```

In this way
- your landing / marketing "pages" can consist of static pages at build time (either as markdown or from a headless CMS)
- that can co-locate with "routes" that can be server rendered, but still re-use the same templating system

I tried to demonstrate that here in this PR with the "Artists" page, though obviously this will not work on Netlify, but you can try it locally!

### Testing
To run this branch on a server
1. Spin up a server, like an EC2 instance
1. `git clone` the repo and checkout this branch
1. Run `yarn install`
1. Run `yarn serve`

From your public IP (make sure to open up port `8080` through your SGs, etc)
- `http://x.x.x.x:8080/`
- `http://x.x.x.x:8080/artists`

### Live Demos (make sure I've started the server first!)
 - http://184.73.61.125:8080/
 - http://184.73.61.125:8080/artists/
 - http://184.73.61.125:8181/ (https://github.com/thescientist13/lit-ssr-demo)
 
![Screen Shot 2021-11-26 at 7 48 57 PM](https://user-images.githubusercontent.com/895923/144103635-122f00d6-64b0-40ca-865b-0734b1bf95a1.png)
![Screen Shot 2021-11-26 at 7 49 04 PM](https://user-images.githubusercontent.com/895923/144103637-9a27eb91-c608-4582-bb3f-fe4cfa7af4bd.png)

### Caveats
- Wasn't able to get Chromium working on an EC2 instance, had to set `prerender` config setting to `false`
- Seems un related to SSR, but looks like styles are broken when setting `prerender` to `false` - see #810 

## Serverless
![Screen Shot 2021-12-01 at 12 18 37 PM](https://user-images.githubusercontent.com/895923/144282263-8419dbee-e424-4df3-9984-3f67574bdf28.png)

Since there are typically size constraints related to running serverless, for this reason, to limit size, it may be advisable to:
- Do this in a standalone repo
- Manually delete puppeteer from _node_modules_

### Testing
1. Create a directory and run `npx @greenwood/init --install`
1. `cd` into that directory and delete puppeteer from _node_modules_
1. From this PR, copy the contents of the following files from _packages/cli/_ in your own local _node_modules/@greenwood/cli/_ directory
    - _index.js_
    - _src/plugins/resource/plugin-standard-html.js_
    - _src/commands/serve.js_
    - _src/lifecycles/config.js_
    - _src/lifecycles/context.js_
    - _src/lifecycles/serve.js_
    - _src/plugins/resource/plugin-standard-html.js_
1. Copy / paste in _index.js_ as the Lambda handler

Or you can clone this [reference repo](https://github.com/thescientist13/greenwood-ssr).

#### Workflow
1. To test locally, uncomment the `run()` function in _index.js_ and then run `node ./index.js`
1. To create an upload for Lamda by creaunge a zip file
    ```sh
    $ zip -r upload.zip . -x ".git/*"
    ```
1. Or bundle using Rollup by running `yarn dist`
1. Upload this to your cloud hosting and invoke the function

### Live Demos
  - Greenwood + SSR (Artists list) - https://jli1ix2q83.execute-api.us-east-1.amazonaws.com/prod/
  - Declarative Shadow DOM - https://57xdk1noff.execute-api.us-east-1.amazonaws.com/prod/
  - Lit+SSR - https://v8ddb2guie.execute-api.us-east-1.amazonaws.com/prod/

![Screen Shot 2021-12-01 at 12 18 21 PM](https://user-images.githubusercontent.com/895923/144282331-96c8e621-6551-44c3-ac6c-3d72822b6ec4.png)
![Screen Shot 2021-12-01 at 12 19 03 PM](https://user-images.githubusercontent.com/895923/144282336-fdfbe41a-56fc-41db-8af9-56e765754c39.png)

> _For testing, I used AWS Lambda + API Gateway._

#### Caveats
- Most providers don't support ESM _functions_ (AWS, and by proxy Netlify) though it does support [Node v14](https://aws.amazon.com/blogs/compute/node-js-14-x-runtime-now-available-in-aws-lambda/)
    - https://github.com/sveltejs/kit/issues/400
    - https://github.com/aws/aws-sdk-js/issues/1766#issuecomment-778838185
    - https://answers.netlify.com/t/lambda-function-es-module-support/30673/15
- Some "complaints" / warnings about certain platform APIs?
    <details>
    <img src="https://user-images.githubusercontent.com/895923/144103975-14376b4b-819d-49a2-bf33-d7ab69c87360.png">
    <img src="https://user-images.githubusercontent.com/895923/144103977-23b122bd-7f2b-4c12-9041-4d6d1e1d3230.png">
    </details>

## Notes / Takeaways
1. Noticed that ESM has a caching mechanism of modules which is something to be mindful of for development
    - https://github.com/nodejs/node/issues/49442
    - https://github.com/nodejs/help/issues/2806
1. With routes, we'll want to investigate what a hydration strategy could look like for more idiomatic SSR solutions like Lit
1. We will need to open up the ability for users to set ports, not just for the dev server
1. I think we should rethink the [`mode` config option](), and remove it entirely?  I would like to implement "progressive configuration" such that if we see a user has pages and / or routes, _or_ just an _index.html_, we can handle that without needing to have it configured by the user.  I think this is because now we really have a hybrid situation and it should be easy for users to static and add / go dynamic, would be sweet.  Instead, we turn `mpa` mode into a `staticRouter` config such that if users want this static route (since it's not designed for SPA) they can use that instead.
1. We really need to make puppeteer optional i think, and potentially have `prerender` off by default.  The website builds _sooooo_ much faster without it, so it is definitely probably better for us to not force that long time as default, especially if you really just want a static site.

## Open Items
1. [x] Properly encode Lambda response (remove escaping and line breaks from the response) - [this resource](https://kennbrodhagen.net/2016/01/31/how-to-return-html-from-aws-api-gateway-lambda/) helped a lot!
1. [ ] Bundling (rollup) routes (SSR)
1. [ ] Prerendering (puppeteer) routes (SSR)
1. [ ] Bikeshed on serverless API
1. [ ] Handle dynamic routes, e.g. `/artist/:id`
1. [ ] Draft issue for no mode
1. [ ] Draft issue for optional puppeteer