### PR TITLE
external data sources for pages

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import { greenwoodPluginGraphQL } from '@greenwood/plugin-graphql';
 import { greenwoodPluginIncludeHTML } from '@greenwood/plugin-include-html';
 import { greenwoodPluginImportCss } from '@greenwood/plugin-import-css';
@@ -10,36 +9,6 @@ import { fileURLToPath, URL } from 'url';
 
 const META_DESCRIPTION = 'A modern and performant static site generator supporting Web Component based development';
 const FAVICON_HREF = '/assets/favicon.ico';
-
-// this could just as easily come from an API, DB, Headless CMS, etc
-const customExternalSourcesPlugin = {
-  type: 'source',
-  name: 'source-plugin-analogstudios',
-  provider: () => {
-    return async function () {
-      const artists = await fetch('http://www.analogstudios.net/api/artists').then(resp => resp.json());
-
-      return artists.map((artist) => {
-        const { bio, id, imageUrl, name } = artist;
-        const route = `/artists/${name.toLowerCase().replace(/ /g, '-')}/`;
-
-        return {
-          title: name,
-          body: `
-            <p>${bio}</p>
-            <img src='${imageUrl}'/>
-          `,
-          route,
-          id,
-          label: name,
-          data: {
-            imageUrl
-          }
-        };
-      });
-    };
-  }
-};
 
 export default {
   workspace: fileURLToPath(new URL('./www', import.meta.url)),
@@ -78,8 +47,7 @@ export default {
         ];
       }
     },
-    ...greenwoodPluginIncludeHTML(),
-    customExternalSourcesPlugin
+    ...greenwoodPluginIncludeHTML()
   ],
   markdown: {
     plugins: [

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -25,7 +25,7 @@ const customExternalSourcesPlugin = {
 
         return {
           title: name,
-          content: `
+          body: `
             <p>${bio}</p>
             <img src='${imageUrl}'/>
           `,

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -20,7 +20,7 @@ const customExternalSourcesPlugin = {
 
       return artists.map((artist) => {
         const { bio, id, imageUrl, name } = artist;
-        const file = name.toLowerCase().replace(/ /g, '-');
+        const route = `/artists/${name.toLowerCase().replace(/ /g, '-')}/`;
 
         return {
           title: name,
@@ -28,7 +28,7 @@ const customExternalSourcesPlugin = {
             ${bio}
             <img src='${imageUrl}'/>
           `,
-          route: `/artists/${file}/`,
+          route,
           id,
           label: name,
           data: {

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -1,3 +1,4 @@
+import fetch from 'fetch';
 import { greenwoodPluginGraphQL } from '@greenwood/plugin-graphql';
 import { greenwoodPluginIncludeHTML } from '@greenwood/plugin-include-html';
 import { greenwoodPluginImportCss } from '@greenwood/plugin-import-css';
@@ -9,6 +10,35 @@ import { fileURLToPath, URL } from 'url';
 
 const META_DESCRIPTION = 'A modern and performant static site generator supporting Web Component based development';
 const FAVICON_HREF = '/assets/favicon.ico';
+
+const customExternalSourcesPlugin = {
+  type: 'source',
+  name: 'source-plugin-analogstudios',
+  provider: () => {
+    return async function () {
+      const artists = await fetch('http://www.analogstudios.net/api/artists').then(resp => resp.json());
+
+      return artists.map((artist) => {
+        const { bio, id, imageUrl, name } = artist;
+        const file = name.toLowerCase().replace(/ /g, '-');
+
+        return {
+          title: name,
+          content: `
+            ${bio}
+            <img src='${imageUrl}'/>
+          `,
+          route: `/artists/${file}/`,
+          id,
+          label: name,
+          data: {
+            imageUrl
+          }
+        };
+      });
+    };
+  }
+};
 
 export default {
   workspace: fileURLToPath(new URL('./www', import.meta.url)),
@@ -47,7 +77,8 @@ export default {
         ];
       }
     },
-    ...greenwoodPluginIncludeHTML()
+    ...greenwoodPluginIncludeHTML(),
+    customExternalSourcesPlugin
   ],
   markdown: {
     plugins: [

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -1,4 +1,4 @@
-import fetch from 'fetch';
+import fetch from 'node-fetch';
 import { greenwoodPluginGraphQL } from '@greenwood/plugin-graphql';
 import { greenwoodPluginIncludeHTML } from '@greenwood/plugin-include-html';
 import { greenwoodPluginImportCss } from '@greenwood/plugin-import-css';

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -11,6 +11,7 @@ import { fileURLToPath, URL } from 'url';
 const META_DESCRIPTION = 'A modern and performant static site generator supporting Web Component based development';
 const FAVICON_HREF = '/assets/favicon.ico';
 
+// this could just as easily come from an API, DB, Headless CMS, etc
 const customExternalSourcesPlugin = {
   type: 'source',
   name: 'source-plugin-analogstudios',
@@ -25,7 +26,7 @@ const customExternalSourcesPlugin = {
         return {
           title: name,
           content: `
-            ${bio}
+            <p>${bio}</p>
             <img src='${imageUrl}'/>
           `,
           route,

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -31,7 +31,7 @@ const greenwoodPlugins = (await Promise.all([
 
 const modes = ['ssg', 'mpa', 'spa'];
 const optimizations = ['default', 'none', 'static', 'inline'];
-const pluginTypes = ['copy', 'context', 'resource', 'rollup', 'server'];
+const pluginTypes = ['copy', 'context', 'resource', 'rollup', 'server', 'source'];
 const defaultConfig = {
   workspace: path.join(process.cwd(), 'src'),
   devServer: {

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -186,8 +186,13 @@ const generateGraph = async (compilation) => {
           const instance = plugin.provider(compilation);
           const data = await instance();
 
-          // TODO minimum validation - content, route
           for (const node of data) {
+            if (!node.content || !node.route) {
+              const missingKey = !node.content ? 'content' : 'route';
+
+              reject(`ERROR: provided node does not provide a ${missingKey} property.`);
+            }
+
             graph.push({
               filename: null,
               path: null,

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -143,6 +143,7 @@ const generateGraph = async (compilation) => {
         return pages;
       };
 
+      console.debug('building from local source...');
       if (config.mode === 'spa') {
         graph = [{
           ...graph[0],
@@ -177,6 +178,24 @@ const generateGraph = async (compilation) => {
               label: 'Not Found'
             }
           ];
+        }
+      }
+
+      console.debug('building from external sources...');
+      for (const plugin of compilation.config.plugins.filter(plugin => plugin.type === 'source')) {
+        const instance = plugin.provider(this.compilation);
+        const data = await instance();
+
+        for (const node of data) {
+          graph.push({
+            filename: null,
+            path: null,
+            data: {},
+            imports: [],
+            outputPath: 'index.html', // TODO should this even be public?
+            ...node,
+            external: true
+          });
         }
       }
 

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -183,7 +183,7 @@ const generateGraph = async (compilation) => {
 
       console.debug('building from external sources...');
       for (const plugin of compilation.config.plugins.filter(plugin => plugin.type === 'source')) {
-        const instance = plugin.provider(this.compilation);
+        const instance = plugin.provider(compilation);
         const data = await instance();
 
         for (const node of data) {

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -189,10 +189,11 @@ const generateGraph = async (compilation) => {
         for (const node of data) {
           graph.push({
             filename: null,
+            // TODO template: 'page',
             path: null,
             data: {},
             imports: [],
-            outputPath: 'index.html', // TODO should this even be public?
+            outputPath: path.join(node.route, 'index.html'), // TODO should this even be public?
             ...node,
             external: true
           });

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -3,8 +3,6 @@ import fs from 'fs';
 import fm from 'front-matter';
 import path from 'path';
 import toc from 'markdown-toc';
-// const fm = require('front-matter');
-// const toc = require('markdown-toc');
 
 const generateGraph = async (compilation) => {
 
@@ -184,8 +182,6 @@ const generateGraph = async (compilation) => {
       const sourcePlugins = compilation.config.plugins.filter(plugin => plugin.type === 'source');
 
       if (sourcePlugins.length > 0) {
-        console.debug('building from external sources...');
-
         for (const plugin of sourcePlugins) {
           const instance = plugin.provider(compilation);
           const data = await instance();
@@ -197,7 +193,7 @@ const generateGraph = async (compilation) => {
               path: null,
               data: {},
               imports: [],
-              outputPath: path.join(node.route, 'index.html'), // TODO should this even be public?
+              outputPath: path.join(node.route, 'index.html'),
               ...node,
               external: true
             });

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -143,7 +143,7 @@ const generateGraph = async (compilation) => {
         return pages;
       };
 
-      console.debug('building from local source...');
+      console.debug('building from local sources...');
       if (config.mode === 'spa') {
         graph = [{
           ...graph[0],
@@ -181,22 +181,27 @@ const generateGraph = async (compilation) => {
         }
       }
 
-      console.debug('building from external sources...');
-      for (const plugin of compilation.config.plugins.filter(plugin => plugin.type === 'source')) {
-        const instance = plugin.provider(compilation);
-        const data = await instance();
+      const sourcePlugins = compilation.config.plugins.filter(plugin => plugin.type === 'source');
 
-        for (const node of data) {
-          graph.push({
-            filename: null,
-            // TODO template: 'page',
-            path: null,
-            data: {},
-            imports: [],
-            outputPath: path.join(node.route, 'index.html'), // TODO should this even be public?
-            ...node,
-            external: true
-          });
+      if (sourcePlugins.length > 0) {
+        console.debug('building from external sources...');
+
+        for (const plugin of sourcePlugins) {
+          const instance = plugin.provider(compilation);
+          const data = await instance();
+
+          // TODO minimum validation - content, route
+          for (const node of data) {
+            graph.push({
+              filename: null,
+              path: null,
+              data: {},
+              imports: [],
+              outputPath: path.join(node.route, 'index.html'), // TODO should this even be public?
+              ...node,
+              external: true
+            });
+          }
         }
       }
 

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -188,8 +188,8 @@ const generateGraph = async (compilation) => {
           const data = await instance();
 
           for (const node of data) {
-            if (!node.content || !node.route) {
-              const missingKey = !node.content ? 'content' : 'route';
+            if (!node.body || !node.route) {
+              const missingKey = !node.body ? 'body' : 'route';
 
               reject(`ERROR: provided node does not provide a ${missingKey} property.`);
             }

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -182,6 +182,7 @@ const generateGraph = async (compilation) => {
       const sourcePlugins = compilation.config.plugins.filter(plugin => plugin.type === 'source');
 
       if (sourcePlugins.length > 0) {
+        console.debug('building from external sources...');
         for (const plugin of sourcePlugins) {
           const instance = plugin.provider(compilation);
           const data = await instance();

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -81,7 +81,7 @@ async function preRenderCompilation(compilation) {
       const serverAddress = `http://127.0.0.1:${port}`;
 
       console.info(`Prerendering pages at ${serverAddress}`);
-      console.debug('pages to render', `\n ${pages.map(page => page.path).join('\n ')}`);
+      console.debug('pages to render', `\n ${pages.map(page => page.route).join('\n ')}`);
   
       await runBrowser(serverAddress, pages, outputDir);
       

--- a/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
+++ b/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
@@ -49,7 +49,8 @@ class OptimizationMPAResource extends ResourceInterface {
         const routeTags = this.compilation.graph
           .filter(page => page.route !== '/404/')
           .map((page) => {
-            const template = path.extname(page.filename) === '.html'
+            // TOOD refactor this up?
+            const template = page.filename && path.extname(page.filename) === '.html'
               ? page.route
               : page.template;
             const key = page.route === '/'

--- a/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
+++ b/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
@@ -49,7 +49,6 @@ class OptimizationMPAResource extends ResourceInterface {
         const routeTags = this.compilation.graph
           .filter(page => page.route !== '/404/')
           .map((page) => {
-            // TOOD refactor this up?
             const template = page.filename && path.extname(page.filename) === '.html'
               ? page.route
               : page.template;

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -358,6 +358,10 @@ class StandardHtmlResource extends ResourceInterface {
           return node.external && node.route.indexOf(url) >= 0;
         });
 
+        if (externalSource.length === 1) {
+          template = externalSource[0].template || template;
+        }
+
         if (isMarkdownContent) {
           const markdownPath = fs.existsSync(`${barePath}.md`)
             ? `${barePath}.md`

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -447,7 +447,7 @@ class StandardHtmlResource extends ResourceInterface {
 
           body = body.replace(/\<content-outlet>(.*)<\/content-outlet>/s, processedMarkdown.contents);
         } else if (externalSource.length === 1) {
-          body = body.replace(/\<content-outlet>(.*)<\/content-outlet>/s, externalSource[0].content);
+          body = body.replace(/\<content-outlet>(.*)<\/content-outlet>/s, externalSource[0].body);
         }
 
         // give the user something to see so they know it works, if they have no content

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -321,12 +321,16 @@ class StandardHtmlResource extends ResourceInterface {
     const barePath = relativeUrl.endsWith(path.sep)
       ? `${pagesDir}${relativeUrl}index`
       : `${pagesDir}${relativeUrl.replace('.html', '')}`;
-    
+    const isExternalSource = this.compilation.graph.filter((node) => {
+      return node.external && node.route.indexOf(url) >= 0;
+    }).length === 1;
+
     return Promise.resolve(this.extensions.indexOf(path.extname(relativeUrl)) >= 0
       || path.extname(relativeUrl) === '') && (fs.existsSync(`${barePath}.html`) || barePath.substring(barePath.length - 5, barePath.length) === 'index')
       || fs.existsSync(`${barePath}.md`)
       || fs.existsSync(`${barePath.substring(0, barePath.lastIndexOf(`${path.sep}index`))}.md`)
-      || isClientSideRoute;
+      || isClientSideRoute
+      || isExternalSource;
   }
 
   async serve(url) {
@@ -350,7 +354,10 @@ class StandardHtmlResource extends ResourceInterface {
         const isMarkdownContent = fs.existsSync(`${barePath}.md`)
           || fs.existsSync(`${barePath.substring(0, barePath.lastIndexOf(`${path.sep}index`))}.md`)
           || fs.existsSync(`${barePath.replace(`${path.sep}index`, '.md')}`);
-        
+        const externalSource = this.compilation.graph.filter((node) => {
+          return node.external && node.route.indexOf(url) >= 0;
+        });
+
         if (isMarkdownContent) {
           const markdownPath = fs.existsSync(`${barePath}.md`)
             ? `${barePath}.md`
@@ -435,6 +442,8 @@ class StandardHtmlResource extends ResourceInterface {
           }
 
           body = body.replace(/\<content-outlet>(.*)<\/content-outlet>/s, processedMarkdown.contents);
+        } else if (externalSource.length === 1) {
+          body = body.replace(/\<content-outlet>(.*)<\/content-outlet>/s, externalSource[0].content);
         }
 
         // give the user something to see so they know it works, if they have no content

--- a/packages/cli/test/cases/build.plugins.error-type/build.plugins.error-type.spec.js
+++ b/packages/cli/test/cases/build.plugins.error-type/build.plugins.error-type.spec.js
@@ -47,7 +47,7 @@ describe('Build Greenwood With: ', function() {
         await runner.setup(outputPath);
         await runner.runCommand(cliPath, 'build');
       } catch (err) {
-        expect(err).to.contain('Error: greenwood.config.js plugins must be one of type "copy, context, resource, rollup, server". got "indexxx" instead.');
+        expect(err).to.contain('Error: greenwood.config.js plugins must be one of type "copy, context, resource, rollup, server, source". got "indexxx" instead.');
       }
     });
   });

--- a/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
+++ b/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
@@ -42,7 +42,7 @@ import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
-describe.only('Build Greenwood With: ', function() {
+describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Sources Plugin and Custom Template';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
@@ -53,7 +53,7 @@ describe.only('Build Greenwood With: ', function() {
     this.context = {
       publicDir
     };
-    runner = new Runner(true);
+    runner = new Runner();
   });
 
   describe(LABEL, function() {

--- a/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
+++ b/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
@@ -110,8 +110,7 @@ describe.only('Build Greenwood With: ', function() {
         expect(pages.length).to.equal(3);
       });
 
-      // TODO  with custom template
-      xit('should have expected heading content for each artist page template', function() {
+      it('should have expected heading content for each artist page template', function() {
   
         doms.forEach((dom) => {
           const headings = dom.window.document.querySelectorAll('body h1');
@@ -138,8 +137,8 @@ describe.only('Build Greenwood With: ', function() {
           expect(images[0].getAttribute('src')).to.equal(fixtureData[idx].imageUrl);
         });
       });
-
     });
+
   });
 
   after(function() {

--- a/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
+++ b/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
@@ -26,7 +26,8 @@
  * Custom Workspace
  * src/
  *   pages/
- *     about.html
+ *     about.md
+ *     index.md
  *   templates/
  *     artist.html
  */

--- a/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
+++ b/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
@@ -1,0 +1,149 @@
+/*
+ * Use Case
+ * Run Greenwood and get external  custom resource plugin and default workspace.
+ *
+ * Uaer Result
+ * Should generate a bare bones Greenwood build with expected artists data as static files using a custom template.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * const customExternalSourcesPlugin = {
+ *   type: 'source',
+ *   name: 'source-plugin-analogstudios',
+ *   provider: () => {
+ *     // see complete implementation in the greenwood.config.js file used for this spec
+ *   }
+ * }
+ * 
+ * {
+ *   plugins: [
+ *     customExternalSourcesPlugin
+ *   ]
+ * }
+ *
+ * Custom Workspace
+ * src/
+ *   pages/
+ *     about.html
+ *   templates/
+ *     artist.html
+ */
+import chai from 'chai';
+import { JSDOM } from 'jsdom';
+import fs from 'fs/promises';
+import glob from 'glob-promise';
+import path from 'path';
+import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { runSmokeTest } from '../../../../../test/smoke-test.js';
+import { Runner } from 'gallinago';
+import { fileURLToPath, URL } from 'url';
+
+const expect = chai.expect;
+
+describe.only('Build Greenwood With: ', function() {
+  const LABEL = 'Custom Sources Plugin and Custom Template';
+  const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
+  const publicDir = path.join(outputPath, 'public');
+  let runner;
+
+  before(function() {
+    this.context = {
+      publicDir
+    };
+    runner = new Runner(true);
+  });
+
+  describe(LABEL, function() {
+    before(async function() {
+      await runner.setup(outputPath, getSetupFiles(outputPath));
+      await runner.runCommand(cliPath, 'build');
+    });
+
+    // no home page?
+    // runSmokeTest(['public', 'index'], LABEL);
+
+    describe('About Page', function() {
+      let pages;
+      let dom;
+
+      before(async function() {
+        pages = await glob(`${publicDir}/about/index.html`);  
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, 'about/index.html'));
+      });
+
+      it('should emit one about page', function() {
+        expect(pages.length).to.equal(1);
+      });
+
+      it('should have expected heading content on the about page', function() {
+        const heading = dom.window.document.querySelectorAll('body h1'); 
+        
+        expect(heading.length).to.equal(1);
+        expect(heading[0].textContent).to.equal('About Us');
+      });
+
+      it('should have expected paragraph content on the about page', function() {
+        const paragraph = dom.window.document.querySelectorAll('body p'); 
+        
+        expect(paragraph.length).to.equal(1);
+        expect(paragraph[0].textContent).to.equal('Lorem ipsum.');
+      });
+    });
+    
+    describe('Artists Pages', function() {
+      let fixtureData = {};
+      let pages = [];
+      let doms = [];
+
+      before(async function() {
+        fixtureData = JSON.parse(await fs.readFile(new URL('./data.json', import.meta.url), 'utf-8'));
+        pages = await glob(`${publicDir}/artists/**/index.html`);  
+        doms = await Promise.all(pages.map(async (path) => {
+          return JSDOM.fromFile(path);
+        }));
+      });
+
+      it('should emit one about page', function() {
+        expect(pages.length).to.equal(3);
+      });
+
+      // TODO  with custom template
+      xit('should have expected heading content for each artist page template', function() {
+  
+        doms.forEach((dom) => {
+          const headings = dom.window.document.querySelectorAll('body h1');
+          
+          expect(headings.length).to.equal(1);
+          expect(headings[0].textContent).to.equal('Welcome to the artist page.');
+        });
+      });
+
+      it('should have expected artist paragraph content for each artist page', function() {
+        doms.forEach((dom, idx) => {
+          const paragraphs = dom.window.document.querySelectorAll('body p');
+          
+          expect(paragraphs.length).to.equal(1);
+          expect(paragraphs[0].textContent).to.equal(fixtureData[idx].bio);
+        });
+      });
+
+      it('should have expected artist image content for each artist page', function() {
+        doms.forEach((dom, idx) => {
+          const images = dom.window.document.querySelectorAll('body img');
+          
+          expect(images.length).to.equal(1);
+          expect(images[0].getAttribute('src')).to.equal(fixtureData[idx].imageUrl);
+        });
+      });
+
+    });
+  });
+
+  after(function() {
+    runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+
+});

--- a/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
+++ b/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
@@ -62,8 +62,7 @@ describe('Build Greenwood With: ', function() {
       await runner.runCommand(cliPath, 'build');
     });
 
-    // no home page?
-    // runSmokeTest(['public', 'index'], LABEL);
+    runSmokeTest(['public', 'index'], LABEL);
 
     describe('About Page', function() {
       let pages;

--- a/packages/cli/test/cases/build.plugins.source/data.json
+++ b/packages/cli/test/cases/build.plugins.source/data.json
@@ -1,0 +1,34 @@
+[{
+  "id": "1",
+  "name": "Analog",
+  "imageUrl": "//d34k5cjnk2rcze.cloudfront.net/images/artists/analog.jpg",
+  "genre": "Rock and Roll",
+  "location": "Block Island. RI",
+  "label": "Analog Studios",
+  "contactPhone": null,
+  "contactEmail": "dave@analogstudios.net",
+  "bio": "Analog, a power duo consisting of guitar and drums, formed and has performed on Block Island for over 2 years...",
+  "isActive": "1"
+}, {
+  "id": "2",
+  "name": "Electro Calrissian",
+  "imageUrl": "//d34k5cjnk2rcze.cloudfront.net/images/artists/electro-calrissian.jpg",
+  "genre": "Punk Rock",
+  "location": "North Conway, NH",
+  "label": "Analog Studios",
+  "contactPhone": null,
+  "contactEmail": "electrocalrissian@gmail.com",
+  "bio": "A hard rock band from Conway, NH, Electro Calrissian knows how to crank out the tunes. Once a solid three piece...",
+  "isActive": "1"
+}, {
+  "id": "3",
+  "name": "Rory Boyan",
+  "imageUrl": "//d34k5cjnk2rcze.cloudfront.net/images/artists/rory.jpg",
+  "genre": "Jam/Instrumental",
+  "location": "Lowell, MA",
+  "label": "Analog Studios",
+  "contactPhone": null,
+  "contactEmail": "roryboyan@yahoo.com",
+  "bio": "One of my best friends, Rory plays instrumental music in a genre all to his own. Combining elements of blues, reggae, and percussion...",
+  "isActive": "1"
+}]

--- a/packages/cli/test/cases/build.plugins.source/greenwood.config.js
+++ b/packages/cli/test/cases/build.plugins.source/greenwood.config.js
@@ -19,6 +19,7 @@ const customExternalSourcesPlugin = {
           `,
           route,
           id,
+          template: 'artist',
           label: name,
           data: {
             imageUrl

--- a/packages/cli/test/cases/build.plugins.source/greenwood.config.js
+++ b/packages/cli/test/cases/build.plugins.source/greenwood.config.js
@@ -13,7 +13,7 @@ const customExternalSourcesPlugin = {
 
         return {
           title: name,
-          content: `
+          body: `
             <p>${bio}</p>
             <img src='${imageUrl}'/>
           `,

--- a/packages/cli/test/cases/build.plugins.source/greenwood.config.js
+++ b/packages/cli/test/cases/build.plugins.source/greenwood.config.js
@@ -1,0 +1,36 @@
+import fs from 'fs/promises';
+
+const customExternalSourcesPlugin = {
+  type: 'source',
+  name: 'source-plugin-analogstudios',
+  provider: () => {
+    return async function () {
+      const artists = JSON.parse(await fs.readFile(new URL('./data.json', import.meta.url), 'utf-8'));
+
+      return artists.map((artist) => {
+        const { bio, id, imageUrl, name } = artist;
+        const route = `/artists/${name.toLowerCase().replace(/ /g, '-')}/`;
+
+        return {
+          title: name,
+          content: `
+            <p>${bio}</p>
+            <img src='${imageUrl}'/>
+          `,
+          route,
+          id,
+          label: name,
+          data: {
+            imageUrl
+          }
+        };
+      });
+    };
+  }
+};
+
+export default {
+  plugins: [
+    customExternalSourcesPlugin
+  ]
+};

--- a/packages/cli/test/cases/build.plugins.source/src/pages/about.md
+++ b/packages/cli/test/cases/build.plugins.source/src/pages/about.md
@@ -1,0 +1,3 @@
+# About Us
+
+Lorem ipsum.

--- a/packages/cli/test/cases/build.plugins.source/src/pages/index.md
+++ b/packages/cli/test/cases/build.plugins.source/src/pages/index.md
@@ -1,0 +1,3 @@
+## Home Page
+
+Welcome!

--- a/packages/cli/test/cases/build.plugins.source/src/templates/artist.html
+++ b/packages/cli/test/cases/build.plugins.source/src/templates/artist.html
@@ -1,0 +1,8 @@
+<html>
+
+  <body>
+    <h1>Welcome to the artist page.</h1>
+    <content-outlet></content-outlet>
+  </body>
+
+</html>

--- a/www/pages/docs/data.md
+++ b/www/pages/docs/data.md
@@ -389,8 +389,9 @@ graph {
   content, // REQUIRED (string of your content)
   id,
   label,
-  route,  // REQUIRED
+  route,  // REQUIRED and MUST end in a forward slash
   template,
-  title
+  title,
+  data
 }
 ```

--- a/www/pages/docs/data.md
+++ b/www/pages/docs/data.md
@@ -386,7 +386,7 @@ Using our [Source plugin](/plugins/source/), just as you can get your content as
 The supported [fields from Greenwood's schema](/docs/data/#internal-sources) are:
 ```javascript
 graph {
-  content, // REQUIRED (string of your content)
+  body, // REQUIRED (string of your content)
   id,
   label,
   route,  // REQUIRED and MUST end in a forward slash

--- a/www/pages/docs/data.md
+++ b/www/pages/docs/data.md
@@ -40,7 +40,7 @@ render() {
 }
 ```
 
-To assist with this, Greenwood provides all your content as data, accessible from a single _graph.json_ file that you can simply [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) RESTfully or, if you install our [plugin for GraphQL](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-graphql), you can use a GraphQL interfact to make all this a reality! 💯
+To assist with this, Greenwood provides all your content as data, accessible from a single _graph.json_ file that you can simply [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) RESTfully or, if you install our [plugin for GraphQL](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-graphql), you can use a GraphQL from your client side code instead! 💯
 
 
 ### Internal Sources
@@ -380,4 +380,17 @@ customElements.define('app-header', HeaderComponent);
 > _For more information on using GraphQL with Greenwood, please see our [GraphQL plugin's README](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-graphql)._
 
 ### External Sources
-Coming [soon](https://github.com/ProjectEvergreen/greenwood/issues/21)!
+
+Using our [Source plugin](/plugins/source/), just as you can get your content as data _out_ of Greenwood, so can you provide your own sources of data _to_ Greenwood.  This is great for pulling content from a headless CMS, database, or anything else you can imagine!
+
+The supported [fields from Greenwood's schema](/docs/data/#internal-sources) are:
+```javascript
+graph {
+  content, // REQUIRED (string of your content)
+  id,
+  label,
+  route,  // REQUIRED
+  template,
+  title
+}
+```

--- a/www/pages/plugins/copy.md
+++ b/www/pages/plugins/copy.md
@@ -7,7 +7,7 @@ index: 2
 
 ## Copy
 
-The copy plugins allow users to copy files around as part of the [build](/docs/#cli) command.  For example,, Greenwood uses this feature to copy all files in the user's _/assets/_ directory to final output directory automatically.  You can use this plugin to copy single files, or entire directories.
+The copy plugin allows users to copy files around as part of the [build](/docs/#cli) command.  For example,, Greenwood uses this feature to copy all files in the user's _/assets/_ directory to final output directory automatically.  You can use this plugin to copy single files, or entire directories.
 
 ## API
 This plugin supports providing an array of "location" objects that can either be files or directories.

--- a/www/pages/plugins/custom-plugins.md
+++ b/www/pages/plugins/custom-plugins.md
@@ -2,7 +2,7 @@
 label: 'custom-plugins'
 menu: side
 title: 'Custom Plugins'
-index: 6
+index: 7
 ---
 
 ## Custom Plugins

--- a/www/pages/plugins/source.md
+++ b/www/pages/plugins/source.md
@@ -1,0 +1,64 @@
+---
+label: 'source'
+menu: side
+title: 'Source'
+index: 6
+---
+
+## Source
+
+The source plugin allows users to include external content as pages that will be statically generated just like if they were a markdown or HTML in your _pages/_ directory.  This would be the primary API to include content from a headless CMS, database, the filesystem, SaaS provider (Notion, AirTables) or wherever else you keep it.
+
+> See our [docs on _External Sources_](/docs/data/#external-sources) for more information on working with data in Greenwood.
+
+## API
+This plugin supports providing an array of "page" objects that will be added as nodes in [the graph](/docs/data/).
+
+```js
+// my-source-plugin.js
+export const customExternalSourcesPlugin = (options = {}) => {
+  type: 'source',
+  name: 'source-plugin-myapi',
+  provider: () => {
+    return async function () {
+      // this could just as easily come from an API, DB, Headless CMS, etc
+      const artists = await fetch('http://www.myapi.com/...').then(resp => resp.json());
+
+      return artists.map((artist) => {
+        const { bio, id, imageUrl, name } = artist;
+        const route = `/artists/${name.toLowerCase().replace(/ /g, '-')}/`;
+
+        return {
+          title: name,
+          content: `
+            <h1>${name}</h1>
+            <p>${bio}</p>
+            <img src='${imageUrl}'/>
+          `,
+          route,
+          id,
+          label: name
+        };
+      });
+    };
+  }
+};
+```
+
+In the above example, you would have the following three data statically generated in the output directory
+
+```bash
+.
+└── public/
+  └── artists/
+    ├── <name1>/index.html
+    ├── <name2>/index.html
+    └── <nameN>/index.html
+```
+
+
+and accessible at the following routes in the browser
+- `/artists/<name1>/`
+- `/artists/<name2>/`
+- `/artists/<nameN>/`
+- ...

--- a/www/pages/plugins/source.md
+++ b/www/pages/plugins/source.md
@@ -30,7 +30,7 @@ export const customExternalSourcesPlugin = (options = {}) => {
 
         return {
           title: name,
-          content: `
+          body: `
             <h1>${name}</h1>
             <p>${bio}</p>
             <img src='${imageUrl}'/>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #21 

You can test it out like so, using the `name` from the [Artists API response](https://www.analogstudios.net/api/artists)
- http://localhost:[1984|8080]/artists/analog
- http://localhost:[1984|8080]/artists/fave

<img width="835" alt="Screen Shot 2021-11-30 at 1 27 52 PM" src="https://user-images.githubusercontent.com/895923/144106386-5536c4e3-ddd9-48e0-8541-362b26467bfa.png">

## Summary of Changes
1. Added support for a "graph" API via plugins
1. Added tests and documentation

## TODOs
1. [x] `build` command + `mpa` optimization breaks (likely because now not all content is on disk)
    <details>
      <pre>
        prerendering page... /artists/jay-st/
        prerendering page... /artists/various-artists/
        prerendering page... /artists/metal-wings/
        prerendering page... /artists/fave/
        prerendering complete for page /artists/various-artists/.
        (node:47671) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received null
            at validateString (internal/validators.js:124:11)
            at Object.extname (path.js:1318:5)
            at file:///Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/plugins/resource/plugin-optimization-mpa.js:52:35
            at Array.map (<anonymous>)
            at file:///Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/plugins/resource/plugin-optimization-mpa.js:51:12
            at new Promise (<anonymous>)
            at OptimizationMPAResource.optimize (file:///Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/plugins/resource/plugin-optimization-mpa.js:41:12)
            at file:///Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/src/lifecycles/prerender.js:19:18
            at runMicrotasks (<anonymous>)
            at processTicksAndRejections (internal/process/task_queues.js:95:5)
        </pre>
    </details>
1. [x] `build` command + `ssg` mode renders incorrectly for home page, and artists pages don't exist?
    <details>
      <img src="https://user-images.githubusercontent.com/895923/147138762-d489dd1c-aef3-45a7-a71f-dbcbc0286139.png">
      <img src="https://user-images.githubusercontent.com/895923/147138763-23a2d0d6-ccd8-4637-a677-50e7db34c9a5.png">
1. [x] Add test cases
1. [x] Documentation
1. [x] Add minimum validation
1. [x] Remove demo code 
1. [x] Discussion tracking - https://github.com/ProjectEvergreen/greenwood/discussions/839
    - cache external data to avoid excessive refetching, taking a [**React Query**](https://react-query.tanstack.com/) like approach (this feature can be post 1.0, IMO)
    - warn if two external sources match on the same route