### PR TITLE
bug/issue 532 esm upgrade with fix for windows

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -5,13 +5,13 @@ import { greenwoodPluginImportJson } from '@greenwood/plugin-import-json';
 import { greenwoodPluginPolyfills } from '@greenwood/plugin-polyfills';
 import { greenwoodPluginPostCss } from '@greenwood/plugin-postcss';
 import rollupPluginAnalyzer from 'rollup-plugin-analyzer';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const META_DESCRIPTION = 'A modern and performant static site generator supporting Web Component based development';
 const FAVICON_HREF = '/assets/favicon.ico';
 
 export default {
-  workspace: new URL('www', import.meta.url).pathname,
+  workspace: fileURLToPath(new URL('./www', import.meta.url)),
   mode: 'mpa',
   optimization: 'inline',
   title: 'Greenwood',

--- a/packages/cli/src/commands/eject.js
+++ b/packages/cli/src/commands/eject.js
@@ -1,17 +1,17 @@
 import fs from 'fs';
 import { generateCompilation } from '../lifecycles/compile.js';
 import path from 'path';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const ejectConfiguration = async () => {
   return new Promise(async (resolve, reject) => {
     try {
       const compilation = await generateCompilation();
-      const configFilePath = new URL(path.join(path.dirname(import.meta.url), '..', 'config'));
+      const configFilePath = fileURLToPath(new URL('../config', import.meta.url));
       const configFiles = fs.readdirSync(configFilePath);
       
       configFiles.forEach((configFile) => {
-        const from = path.join(configFilePath.pathname, configFile);
+        const from = path.join(configFilePath, configFile);
         const to = `${compilation.context.projectDirectory}/${configFile}`;
 
         fs.copyFileSync(from, to);

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import {URL, pathToFileURL } from 'url';
+import { pathToFileURL, URL } from 'url';
 
 // get and "tag" all plugins provided / maintained by the @greenwood/cli
 // and include as the default set, with all user plugins getting appended
@@ -15,7 +15,6 @@ const greenwoodPlugins = (await Promise.all([
 
   return (await Promise.all(files.map(async(file) => {
     const importPaTh = pathToFileURL(`${pluginDirectory}${path.sep}${file}`);
-    console.debug('greenwood plugin importPaTh', importPaTh);
     const pluginImport = await import(importPaTh);
     const plugin = pluginImport[Object.keys(pluginImport)[0]];
 

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import { pathToFileURL, URL } from 'url';
+import { fileURLToPath, pathToFileURL, URL } from 'url';
 
 // get and "tag" all plugins provided / maintained by the @greenwood/cli
 // and include as the default set, with all user plugins getting appended
-const greenwoodPluginsBasePath = path.join(new URL('', import.meta.url).pathname, '../../plugins').replace('\\', '');
+const greenwoodPluginsBasePath = fileURLToPath(new URL('../plugins', import.meta.url));
 
 const greenwoodPlugins = (await Promise.all([
   path.join(greenwoodPluginsBasePath, 'copy'),  
@@ -77,8 +77,7 @@ const readAndMergeConfig = async() => {
             customConfig.workspace = workspace;
           }
 
-          console.debug('customConfig.workspace', customConfig.workspace);
-          if (!fs.existsSync(customConfig.workspace.replace('/', ''))) {
+          if (!fs.existsSync(customConfig.workspace)) {
             reject('Error: greenwood.config.js workspace doesn\'t exist! \n' +
               'common issues to check might be: \n' +
               '- typo in your workspace directory name, or in greenwood.config.js \n' +

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -1,10 +1,11 @@
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath, URL } from 'url';
 
 const initContext = async({ config }) => {
   const scratchDir = path.join(process.cwd(), './.greenwood/');
   const outputDir = path.join(process.cwd(), './public');
-  const dataDir = new URL('../data', import.meta.url).pathname;
+  const dataDir = fileURLToPath(new URL('../data', import.meta.url));
 
   return new Promise(async (resolve, reject) => {
     try {

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -9,7 +9,7 @@ const initContext = async({ config }) => {
   return new Promise(async (resolve, reject) => {
     try {
       const projectDirectory = process.cwd();
-      const userWorkspace = path.join(config.workspace).replace('\\', '');
+      const userWorkspace = path.join(config.workspace);
       const pagesDir = path.join(userWorkspace, `${config.pagesDirectory}/`);
       const userTemplatesDir = path.join(userWorkspace, `${config.templatesDirectory}/`);
 

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -9,7 +9,7 @@ const initContext = async({ config }) => {
   return new Promise(async (resolve, reject) => {
     try {
       const projectDirectory = process.cwd();
-      const userWorkspace = path.join(config.workspace);
+      const userWorkspace = path.join(config.workspace).replace('\\', '');
       const pagesDir = path.join(userWorkspace, `${config.pagesDirectory}/`);
       const userTemplatesDir = path.join(userWorkspace, `${config.templatesDirectory}/`);
 

--- a/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
+++ b/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
@@ -7,6 +7,7 @@
 import fs from 'fs';
 import path from 'path';
 import { ResourceInterface } from '../../lib/resource-interface.js';
+import { fileURLToPath, URL } from 'url';
 
 class OptimizationMPAResource extends ResourceInterface {
   constructor(compilation, options) {
@@ -23,7 +24,7 @@ class OptimizationMPAResource extends ResourceInterface {
   async resolve() {
     return new Promise(async (resolve, reject) => {
       try {
-        const routerUrl = new URL('../../lib/router.js', import.meta.url).pathname;
+        const routerUrl = fileURLToPath(new URL('../../lib/router.js', import.meta.url));
 
         resolve(routerUrl);
       } catch (e) {

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -16,7 +16,7 @@ import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 import unified from 'unified';
-import { URL, pathToFileURL } from 'url';
+import { URL } from 'url';
 
 function getCustomPageTemplates(contextPlugins, templateName) {
   return contextPlugins
@@ -55,10 +55,10 @@ const getPageTemplate = (barePath, templatesDir, template, contextPlugins = [], 
   } else if (is404Page && !fs.existsSync(path.join(pagesDir, '404.html'))) {
     // handle default 404.html
     // path.dirname(new URL('', import.meta.url).pathname)
-    contents = fs.readFileSync(pathToFileURL(path.join(new URL('', import.meta.url).pathname, '../../../templates/404.html')), 'utf-8');
+    contents = fs.readFileSync(path.join(new URL('', import.meta.url).pathname, '../../../templates/404.html').replace('\\', ''), 'utf-8');
   } else {
     // fallback to using Greenwood's stock page template
-    contents = fs.readFileSync(new URL('../../templates/page.html', import.meta.url), 'utf-8');
+    contents = fs.readFileSync(path.join(new URL('', import.meta.url).pathname, '../../../templates/page.html').replace('\\', ''), 'utf-8');
   }
 
   return contents;
@@ -72,7 +72,7 @@ const getAppTemplate = (contents, templatesDir, customImports = [], contextPlugi
     ? fs.readFileSync(`${customAppTemplates[0]}/app.html`, 'utf-8')
     : fs.existsSync(userAppTemplatePath)
       ? fs.readFileSync(userAppTemplatePath, 'utf-8')
-      : fs.readFileSync(new URL('../../templates/app.html', import.meta.url), 'utf-8');
+      : fs.readFileSync(path.join(new URL('', import.meta.url).pathname, '../../../templates/app.html').replace('\\', ''), 'utf-8');
 
   const root = htmlparser.parse(contents, {
     script: true,

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -53,8 +53,6 @@ const getPageTemplate = (barePath, templatesDir, template, contextPlugins = [], 
       ? fs.readFileSync(`${customPluginDefaultPageTemplates[0]}/page.html`, 'utf-8')
       : fs.readFileSync(`${templatesDir}/page.html`, 'utf-8');
   } else if (is404Page && !fs.existsSync(path.join(pagesDir, '404.html'))) {
-    // handle default 404.html
-    // path.dirname(new URL('', import.meta.url).pathname)
     contents = fs.readFileSync(fileURLToPath(new URL('../../templates/404.html', import.meta.url)), 'utf-8');
   } else {
     // fallback to using Greenwood's stock page template
@@ -72,7 +70,7 @@ const getAppTemplate = (contents, templatesDir, customImports = [], contextPlugi
     ? fs.readFileSync(`${customAppTemplates[0]}/app.html`, 'utf-8')
     : fs.existsSync(userAppTemplatePath)
       ? fs.readFileSync(userAppTemplatePath, 'utf-8')
-      : fs.readFileSync(path.join(new URL('', import.meta.url).pathname, '../../../templates/app.html').replace('\\', ''), 'utf-8');
+      : fs.readFileSync(fileURLToPath(new URL('../../templates/app.html', import.meta.url)), 'utf-8');
 
   const root = htmlparser.parse(contents, {
     script: true,
@@ -416,7 +414,7 @@ class StandardHtmlResource extends ResourceInterface {
           body = getPageTemplate(barePath, userTemplatesDir, template, contextPlugins, pagesDir);
         }
 
-        body = getAppTemplate(body, userTemplatesDir, customImports, contextPlugins, config.devServer.hud);  
+        body = getAppTemplate(body, userTemplatesDir, customImports, contextPlugins, config.devServer.hud);
         body = getUserScripts(body, this.compilation.context);
         body = getMetaContent(normalizedUrl.replace(/\\/g, '/'), config, body);
         

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -16,7 +16,7 @@ import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 import unified from 'unified';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 function getCustomPageTemplates(contextPlugins, templateName) {
   return contextPlugins
@@ -55,10 +55,10 @@ const getPageTemplate = (barePath, templatesDir, template, contextPlugins = [], 
   } else if (is404Page && !fs.existsSync(path.join(pagesDir, '404.html'))) {
     // handle default 404.html
     // path.dirname(new URL('', import.meta.url).pathname)
-    contents = fs.readFileSync(path.join(new URL('', import.meta.url).pathname, '../../../templates/404.html').replace('\\', ''), 'utf-8');
+    contents = fs.readFileSync(fileURLToPath(new URL('../../templates/404.html', import.meta.url)), 'utf-8');
   } else {
     // fallback to using Greenwood's stock page template
-    contents = fs.readFileSync(path.join(new URL('', import.meta.url).pathname, '../../../templates/page.html').replace('\\', ''), 'utf-8');
+    contents = fs.readFileSync(fileURLToPath(new URL('../../templates/page.html', import.meta.url)), 'utf-8');
   }
 
   return contents;

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -15,7 +15,8 @@ import remarkFrontmatter from 'remark-frontmatter';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
 import { ResourceInterface } from '../../lib/resource-interface.js';
-import unified from 'unified'; 
+import unified from 'unified';
+import { URL, pathToFileURL } from 'url';
 
 function getCustomPageTemplates(contextPlugins, templateName) {
   return contextPlugins
@@ -54,7 +55,7 @@ const getPageTemplate = (barePath, templatesDir, template, contextPlugins = [], 
   } else if (is404Page && !fs.existsSync(path.join(pagesDir, '404.html'))) {
     // handle default 404.html
     // path.dirname(new URL('', import.meta.url).pathname)
-    contents = fs.readFileSync(path.join(path.dirname(new URL('', import.meta.url).pathname), '../../templates/404.html'), 'utf-8');
+    contents = fs.readFileSync(pathToFileURL(path.join(new URL('', import.meta.url).pathname, '../../../templates/404.html')), 'utf-8');
   } else {
     // fallback to using Greenwood's stock page template
     contents = fs.readFileSync(new URL('../../templates/page.html', import.meta.url), 'utf-8');

--- a/packages/cli/src/plugins/server/plugin-livereload.js
+++ b/packages/cli/src/plugins/server/plugin-livereload.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import livereload from 'livereload';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 import { ServerInterface } from '../../lib/server-interface.js';
-import { fileURLToPath, URL } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 class LiveReloadServer extends ServerInterface {
   constructor(compilation, options = {}) {
@@ -15,7 +15,7 @@ class LiveReloadServer extends ServerInterface {
     const standardPluginsNames = fs.readdirSync(standardPluginsPath)
       .filter(filename => filename.indexOf('plugin-standard') === 0);
     const standardPluginsExtensions = (await Promise.all(standardPluginsNames.map(async (filename) => {
-      const pluginImport = await import(`${standardPluginsPath}/${filename}`);
+      const pluginImport = await import(pathToFileURL(`${standardPluginsPath}/${filename}`));
       const plugin = pluginImport[Object.keys(pluginImport)[0]];
       
       return plugin;

--- a/packages/cli/src/plugins/server/plugin-livereload.js
+++ b/packages/cli/src/plugins/server/plugin-livereload.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import livereload from 'livereload';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 import { ServerInterface } from '../../lib/server-interface.js';
+import { fileURLToPath, URL } from 'url';
 
 class LiveReloadServer extends ServerInterface {
   constructor(compilation, options = {}) {
@@ -10,7 +11,7 @@ class LiveReloadServer extends ServerInterface {
 
   async start() {
     const { userWorkspace } = this.compilation.context;
-    const standardPluginsPath = new URL('../resource', import.meta.url);
+    const standardPluginsPath = fileURLToPath(new URL('../resource', import.meta.url));
     const standardPluginsNames = fs.readdirSync(standardPluginsPath)
       .filter(filename => filename.indexOf('plugin-standard') === 0);
     const standardPluginsExtensions = (await Promise.all(standardPluginsNames.map(async (filename) => {

--- a/packages/cli/test/cases/build.config.default/build.config.default.spec.js
+++ b/packages/cli/test/cases/build.config.default/build.config.default.spec.js
@@ -18,12 +18,12 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Empty Configuration and Default Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.config.error-dev-server-extensions/build.config.error-dev-server-extensions.spec.js
+++ b/packages/cli/test/cases/build.config.error-dev-server-extensions/build.config.error-dev-server-extensions.spec.js
@@ -21,13 +21,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.error-dev-server-hud/build.config.error-dev-server-hud.spec.js
+++ b/packages/cli/test/cases/build.config.error-dev-server-hud/build.config.error-dev-server-hud.spec.js
@@ -21,13 +21,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.error-mode/build.config.error-mode.spec.js
+++ b/packages/cli/test/cases/build.config.error-mode/build.config.error-mode.spec.js
@@ -19,13 +19,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.config.error-optimization/build.config.error-optimization.spec.js
+++ b/packages/cli/test/cases/build.config.error-optimization/build.config.error-optimization.spec.js
@@ -19,13 +19,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.error-pages-directory/build.config.error-pages-directory.spec.js
+++ b/packages/cli/test/cases/build.config.error-pages-directory/build.config.error-pages-directory.spec.js
@@ -19,13 +19,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.error-prerender/build.config.error-prerender.spec.js
+++ b/packages/cli/test/cases/build.config.error-prerender/build.config.error-prerender.spec.js
@@ -19,13 +19,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.error-templates-directory/build.config.error-templates-directory.spec.js
+++ b/packages/cli/test/cases/build.config.error-templates-directory/build.config.error-templates-directory.spec.js
@@ -19,13 +19,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.error-title/build.config.error-title.spec.js
+++ b/packages/cli/test/cases/build.config.error-title/build.config.error-title.spec.js
@@ -19,13 +19,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.error-workspace-absolute/build.config.error-workspace-absolute.spec.js
+++ b/packages/cli/test/cases/build.config.error-workspace-absolute/build.config.error-workspace-absolute.spec.js
@@ -19,13 +19,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.error-workspace-absolute/build.config.error-workspace-absolute.spec.js
+++ b/packages/cli/test/cases/build.config.error-workspace-absolute/build.config.error-workspace-absolute.spec.js
@@ -10,7 +10,7 @@
  *
  * User Config
  * {
- *   workspace: path.join(path.dirname(new URL('', import.meta.url).pathname), 'noop')
+ *   workspace: fileURLToPath(new URL('./noop', import.meta.url))
  * }
  *
  * User Workspace

--- a/packages/cli/test/cases/build.config.error-workspace-absolute/greenwood.config.js
+++ b/packages/cli/test/cases/build.config.error-workspace-absolute/greenwood.config.js
@@ -1,5 +1,5 @@
-import path from 'path';
+import { fileURLToPath, URL } from 'url';
 
 export default {
-  workspace: path.join(path.dirname(new URL('', import.meta.url).pathname), 'noop')
+  workspace: fileURLToPath(new URL('./noop', import.meta.url))
 };

--- a/packages/cli/test/cases/build.config.error-workspace/build.config.error-workspace.spec.js
+++ b/packages/cli/test/cases/build.config.error-workspace/build.config.error-workspace.spec.js
@@ -19,13 +19,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.markdown-custom.plugins/build.config.markdown-custom.spec.js
+++ b/packages/cli/test/cases/build.config.markdown-custom.plugins/build.config.markdown-custom.spec.js
@@ -26,14 +26,14 @@ import chai from 'chai';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Markdown Configuration and Default Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.config.markdown-custom.settings/build.config.markdown-custom.settings.spec.js
+++ b/packages/cli/test/cases/build.config.markdown-custom.settings/build.config.markdown-custom.settings.spec.js
@@ -23,14 +23,14 @@ import chai from 'chai';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Markdown Configuration and Custom Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.meta/build.config.meta.spec.js
+++ b/packages/cli/test/cases/build.config.meta/build.config.meta.spec.js
@@ -37,7 +37,7 @@ import chai from 'chai';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
@@ -45,7 +45,7 @@ describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Meta Configuration and Nested Workspace';
   const meta = greenwoodConfig.meta;
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.config.mode-mpa/build.config.mode-mpa.spec.js
+++ b/packages/cli/test/cases/build.config.mode-mpa/build.config.mode-mpa.spec.js
@@ -28,14 +28,14 @@ import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Mode';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.mode-spa/build.config.mode-spa.spec.js
+++ b/packages/cli/test/cases/build.config.mode-spa/build.config.mode-spa.spec.js
@@ -31,14 +31,14 @@ import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Mode';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
@@ -25,14 +25,14 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Optimization Configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
@@ -28,14 +28,14 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Inline Optimization Configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
@@ -29,14 +29,14 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'None Optimization Configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.config.optimization-overrides/build.config-optimization-overrides.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-overrides/build.config-optimization-overrides.spec.js
@@ -27,14 +27,14 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Optimization Overrides';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.optimization-static/build.config-optimization-static.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-static/build.config-optimization-static.spec.js
@@ -26,14 +26,14 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Static Optimization Configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.config.pages-directory/build.config.pages-directory.spec.js
+++ b/packages/cli/test/cases/build.config.pages-directory/build.config.pages-directory.spec.js
@@ -26,14 +26,14 @@ import chai from 'chai';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Pages Directory from Configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.config.prerender/build.config.prerender.spec.js
+++ b/packages/cli/test/cases/build.config.prerender/build.config.prerender.spec.js
@@ -26,14 +26,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Prerender Configuration turned off';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.config.templates-directory/build.config.templates-directory.spec.js
+++ b/packages/cli/test/cases/build.config.templates-directory/build.config.templates-directory.spec.js
@@ -28,14 +28,14 @@ import chai from 'chai';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Pages Directory from Configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.config.title/build.config.title.spec.js
+++ b/packages/cli/test/cases/build.config.title/build.config.title.spec.js
@@ -28,7 +28,7 @@ import chai from 'chai';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const configTitle = greenwoodConfig.title;
 const expect = chai.expect;
@@ -36,7 +36,7 @@ const expect = chai.expect;
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Title Configuration and Default Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.config.workspace-custom/build.config.workspace-custom.spec.js
+++ b/packages/cli/test/cases/build.config.workspace-custom/build.config.workspace-custom.spec.js
@@ -26,14 +26,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Configuration for Workspace (www) and Default Greenwood configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.config.workspace-custom/build.config.workspace-custom.spec.js
+++ b/packages/cli/test/cases/build.config.workspace-custom/build.config.workspace-custom.spec.js
@@ -10,7 +10,7 @@
  *
  * User Config
  * {
- *   workspace: path.join(path.dirname(new URL('', import.meta.url).pathname);, 'www')
+ *   workspace: fileURLToPath(new URL('./www', import.meta.url))
  * }
  *
  * User Workspace

--- a/packages/cli/test/cases/build.config.workspace-custom/greenwood.config.js
+++ b/packages/cli/test/cases/build.config.workspace-custom/greenwood.config.js
@@ -1,5 +1,5 @@
-import path from 'path';
+import { fileURLToPath, URL } from 'url';
 
 export default {
-  workspace: path.join(path.dirname(new URL('', import.meta.url).pathname), 'www')
+  workspace: fileURLToPath(new URL('./www', import.meta.url))
 };

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -24,14 +24,14 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Importing packages from node modules';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.default.markdown/build.default.markdown.spec.js
+++ b/packages/cli/test/cases/build.default.markdown/build.default.markdown.spec.js
@@ -22,14 +22,14 @@ import chai from 'chai';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Markdown';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.default.quick-start-npx/build.default.quick-start-npx.spec.js
+++ b/packages/cli/test/cases/build.default.quick-start-npx/build.default.quick-start-npx.spec.js
@@ -22,14 +22,14 @@ import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace and emulating npx';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-404-markdown/build.default.workspace-404-markdown.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-404-markdown/build.default.workspace-404-markdown.spec.js
@@ -32,14 +32,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace w/Custom 404 Page in markdown and App Template';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-404/build.default.workspace-404.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-404/build.default.workspace-404.spec.js
@@ -32,14 +32,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace w/Custom 404 Page and App Template';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-assets/build.default.workspace-assets.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-assets/build.default.workspace-assets.spec.js
@@ -18,14 +18,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'A Custom Assets Folder';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-frontmatter-imports/build.default.workspace-frontmatter-imports.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-frontmatter-imports/build.default.workspace-frontmatter-imports.spec.js
@@ -30,14 +30,14 @@ import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace with Frontmatter Imports';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.default.workspace-getting-started/build.default.workspace-getting-started.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-getting-started/build.default.workspace-getting-started.spec.js
@@ -37,14 +37,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles, tagsMatch } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Workspace based on the Getting Started guide and repo';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-javascript-css-remote/build.default.workspace-javascript-css-remote.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css-remote/build.default.workspace-javascript-css-remote.spec.js
@@ -23,14 +23,14 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Loading remote JavaScript and CSS using <script> and <link> tags';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -27,14 +27,14 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Importing JavaScript and CSS using <script>, <style>, and <link> tags';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-nested/build.default.workspace-nested.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-nested/build.default.workspace-nested.spec.js
@@ -47,14 +47,14 @@ import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Default Workspace w/ Nested Directories';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-template-app/build.default.workspace-template-app.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-template-app/build.default.workspace-template-app.spec.js
@@ -23,14 +23,14 @@ import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace w/Custom App Template';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-template-page-and-app/build.default.workspace-template-page-and-app.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-template-page-and-app/build.default.workspace-template-page-and-app.spec.js
@@ -33,14 +33,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace w/Custom App and Page Templates';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-template-page-bare-merging/build.default.workspace-template-page-bare-merging.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-template-page-bare-merging/build.default.workspace-template-page-bare-merging.spec.js
@@ -24,14 +24,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace for Quick Start';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-template-page/build.default.workspace-template-page.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-template-page/build.default.workspace-template-page.spec.js
@@ -26,14 +26,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace w/Custom Page Template';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.default.workspace-templates-empty/build.default.workspace-templates-empty.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-templates-empty/build.default.workspace-templates-empty.spec.js
@@ -31,14 +31,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace w/Custom Page Templates for HTML "forgiveness"';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-templates-relative-paths/build.default.workspace-templates-relative-paths.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-templates-relative-paths/build.default.workspace-templates-relative-paths.spec.js
@@ -38,14 +38,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace w/Custom App and Page Templates using relative paths';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-top-level-pages/build.default.workspace-top-level-pages.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-top-level-pages/build.default.workspace-top-level-pages.spec.js
@@ -25,14 +25,14 @@ import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Default Workspace w/ Top Level Pages';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default.workspace-user-directory-mapping/build.default.workspace-user-directory-mapping.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-user-directory-mapping/build.default.workspace-user-directory-mapping.spec.js
@@ -38,14 +38,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace w/Naming Collisions';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default/build.default.spec.js
+++ b/packages/cli/test/cases/build.default/build.default.spec.js
@@ -20,14 +20,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname.replace('/', ''));
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.default/build.default.spec.js
+++ b/packages/cli/test/cases/build.default/build.default.spec.js
@@ -27,7 +27,7 @@ const expect = chai.expect;
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = path.dirname(new URL('', import.meta.url).pathname.replace('/', ''));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
+++ b/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
@@ -25,14 +25,14 @@ import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Context Plugin and Default Workspace (aka Theme Packs)';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
+++ b/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
@@ -29,7 +29,7 @@ import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
-xdescribe('Build Greenwood With: ', function() {
+describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Context Plugin and Default Workspace (aka Theme Packs)';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));

--- a/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
+++ b/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
@@ -29,7 +29,7 @@ import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
-describe('Build Greenwood With: ', function() {
+xdescribe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Context Plugin and Default Workspace (aka Theme Packs)';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));

--- a/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
+++ b/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
@@ -48,15 +48,15 @@ describe('Build Greenwood With: ', function() {
       // copy fixtures into node_modules
       // to match the location specified in the plugin under test
       const themePacktemplates = await getDependencyFiles(
-        `${path.dirname(new URL('', import.meta.url).pathname)}/fixtures/layouts/*.html`,
+        `${outputPath}/fixtures/layouts/*.html`,
         `${outputPath}/node_modules/my-theme-pack/dist/layouts`
       );
       const themePackStyles = await getDependencyFiles(
-        `${path.dirname(new URL('', import.meta.url).pathname)}/fixtures/styles/*.css`,
+        `${outputPath}/fixtures/styles/*.css`,
         `${outputPath}/node_modules/my-theme-pack/dist/styles`
       );
       const themePackComponents = await getDependencyFiles(
-        `${path.dirname(new URL('', import.meta.url).pathname)}/fixtures/components/*.js`,
+        `${outputPath}/fixtures/components/*.js`,
         `${outputPath}/node_modules/my-theme-pack/dist/components`
       );
 

--- a/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
+++ b/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { spawnSync } from 'child_process';
-import { fileURLToPaTh, URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
 const myThemePackPlugin = () => [{
@@ -16,7 +16,7 @@ const myThemePackPlugin = () => [{
     
     const isInstalled = ls.stdout.toString().indexOf('(empty)') < 0;
     const templateLocation = isInstalled
-      ? path.join(path.dirname(new URL('', import.meta.url).pathname), `${baseDistDir}/layouts`)
+      ? fileURLToPath(new URL(`${baseDistDir}/layouts`, import.meta.url))
       : path.join(process.cwd(), 'fixtures/layouts');
 
     return {

--- a/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
+++ b/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { spawnSync } from 'child_process';
-import { URL } from 'url';
+import { fileURLToPaTh, URL } from 'url';
 
 const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
 const myThemePackPlugin = () => [{

--- a/packages/cli/test/cases/build.plugins.error-name/build.plugins.error-name.spec.js
+++ b/packages/cli/test/cases/build.plugins.error-name/build.plugins.error-name.spec.js
@@ -24,13 +24,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.plugins.error-provider/build.plugins.error-provider.spec.js
+++ b/packages/cli/test/cases/build.plugins.error-provider/build.plugins.error-provider.spec.js
@@ -25,13 +25,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.plugins.error-type/build.plugins.error-type.spec.js
+++ b/packages/cli/test/cases/build.plugins.error-type/build.plugins.error-type.spec.js
@@ -25,13 +25,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/cli/test/cases/build.plugins.resource/build.config.plugins-resource.spec.js
+++ b/packages/cli/test/cases/build.plugins.resource/build.config.plugins-resource.spec.js
@@ -34,14 +34,14 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom FooResource Plugin and Default Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/develop.default.hud-disabled/develop.default.hud-disabled.spec.js
+++ b/packages/cli/test/cases/develop.default.hud-disabled/develop.default.hud-disabled.spec.js
@@ -22,7 +22,7 @@ import path from 'path';
 import { getSetupFiles } from '../../../../../test/utils.js';
 import request from 'request';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
@@ -30,7 +30,7 @@ import { runSmokeTest } from '../../../../../test/smoke-test.js';
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = 'http://localhost';
   const port = 1984;
   let runner;

--- a/packages/cli/test/cases/develop.default.hud-disabled/develop.default.hud-disabled.spec.js
+++ b/packages/cli/test/cases/develop.default.hud-disabled/develop.default.hud-disabled.spec.js
@@ -22,10 +22,10 @@ import path from 'path';
 import { getSetupFiles } from '../../../../../test/utils.js';
 import request from 'request';
 import { Runner } from 'gallinago';
+import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
-import { runSmokeTest } from '../../../../../test/smoke-test.js';
 
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
@@ -78,7 +78,7 @@ describe('Develop Greenwood With: ', function() {
             response = res;
             
             dom = new JSDOM(body);
-            sourceHtml = fs.readFileSync(path.join(path.dirname(new URL('', import.meta.url).pathname), 'src/pages/index.html'), 'utf-8');
+            sourceHtml = fs.readFileSync(fileURLToPath(new URL('./src/pages/index.html', import.meta.url)), 'utf-8');
 
             resolve();
           });

--- a/packages/cli/test/cases/develop.default.hud/develop.default.hud.spec.js
+++ b/packages/cli/test/cases/develop.default.hud/develop.default.hud.spec.js
@@ -22,7 +22,7 @@ import path from 'path';
 import { getSetupFiles } from '../../../../../test/utils.js';
 import request from 'request';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
@@ -30,7 +30,7 @@ import { runSmokeTest } from '../../../../../test/smoke-test.js';
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = 'http://localhost';
   const port = 1984;
   let runner;

--- a/packages/cli/test/cases/develop.default.hud/develop.default.hud.spec.js
+++ b/packages/cli/test/cases/develop.default.hud/develop.default.hud.spec.js
@@ -22,10 +22,10 @@ import path from 'path';
 import { getSetupFiles } from '../../../../../test/utils.js';
 import request from 'request';
 import { Runner } from 'gallinago';
+import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
-import { runSmokeTest } from '../../../../../test/smoke-test.js';
 
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
@@ -78,7 +78,7 @@ describe('Develop Greenwood With: ', function() {
             response = res;
             
             dom = new JSDOM(body);
-            sourceHtml = fs.readFileSync(path.join(path.dirname(new URL('', import.meta.url).pathname), 'src/pages/index.html'), 'utf-8');
+            sourceHtml = fs.readFileSync(fileURLToPath(new URL('./src/pages/index.html', import.meta.url)), 'utf-8');
 
             resolve();
           });

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -344,7 +344,7 @@ describe('Develop Greenwood With: ', function() {
       await fs.promises.mkdir(`${outputPath}/node_modules/@babel/runtime`, { recursive: true });
       await fs.promises.copyFile(`${process.cwd()}/node_modules/@babel/runtime/package.json`, `${outputPath}/node_modules/@babel/runtime/package.json`);
       await Promise.all(babelRuntimeLibs.filter((asset) => {
-        const target = asset.replace(process.cwd(), path.dirname(new URL('', import.meta.url).pathname));
+        const target = asset.replace(process.cwd(), fileURLToPath(new URL('.', import.meta.url)));
         const isDirectory = path.extname(target) === '';
 
         if (isDirectory && !fs.existsSync(target)) {
@@ -353,7 +353,7 @@ describe('Develop Greenwood With: ', function() {
           return asset;
         }
       }).map((asset) => {
-        const target = asset.replace(process.cwd(), path.dirname(new URL('', import.meta.url).pathname));
+        const target = asset.replace(process.cwd(), fileURLToPath(new URL('.', import.meta.url)));
 
         return copyFile(asset, target);
       }));

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -36,7 +36,7 @@ import { getDependencyFiles, getSetupFiles } from '../../../../../test/utils.js'
 import request from 'request';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
@@ -74,7 +74,7 @@ async function copyFile(source, target) {
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = 'http://localhost';
   const port = 1984;
   let runner;

--- a/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
+++ b/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
@@ -25,7 +25,7 @@ import path from 'path';
 import request from 'request';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
@@ -33,7 +33,7 @@ const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.jso
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'Custom Context Plugin and Default Workspace (aka Theme Packs)';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = 'http://localhost';
   const port = 1984;
   let runner;

--- a/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
+++ b/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
@@ -30,7 +30,7 @@ import { fileURLToPath, URL } from 'url';
 const expect = chai.expect;
 const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
 
-xdescribe('Develop Greenwood With: ', function() {
+describe('Develop Greenwood With: ', function() {
   const LABEL = 'Custom Context Plugin and Default Workspace (aka Theme Packs)';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));

--- a/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
+++ b/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
@@ -30,7 +30,7 @@ import { fileURLToPath, URL } from 'url';
 const expect = chai.expect;
 const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
 
-describe('Develop Greenwood With: ', function() {
+xdescribe('Develop Greenwood With: ', function() {
   const LABEL = 'Custom Context Plugin and Default Workspace (aka Theme Packs)';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));

--- a/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
+++ b/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { myThemePackPlugin } from '../build.plugins.context/theme-pack-context-plugin.js';
 import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
-import { fileURLToPath, URL } from 'url';
+import { URL } from 'url';
 
 const packageName = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8')).name;
 

--- a/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
+++ b/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import { myThemePackPlugin } from '../build.plugins.context/theme-pack-context-plugin.js';
 import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const packageName = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8')).name;
 

--- a/packages/cli/test/cases/develop.spa/develop.spa.spec.js
+++ b/packages/cli/test/cases/develop.spa/develop.spa.spec.js
@@ -25,7 +25,7 @@ import { getDependencyFiles } from '../../../../../test/utils.js';
 import request from 'request';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
@@ -38,7 +38,7 @@ function removeWhiteSpace(string = '') {
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'SPA Mode';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = 'http://localhost';
   const BODY_REGEX = /<body>(.*)<\/body>/s;
   const expected = removeWhiteSpace(fs.readFileSync(path.join(outputPath, `src${path.sep}index.html`), 'utf-8').match(BODY_REGEX)[0]);

--- a/packages/cli/test/cases/eject.default/eject.default.spec.js
+++ b/packages/cli/test/cases/eject.default/eject.default.spec.js
@@ -14,13 +14,13 @@ import chai from 'chai';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Eject Greenwood', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
   let configFiles;
 

--- a/packages/cli/test/cases/eject.default/eject.default.spec.js
+++ b/packages/cli/test/cases/eject.default/eject.default.spec.js
@@ -37,7 +37,7 @@ describe('Eject Greenwood', function() {
       await runner.setup(outputPath, getSetupFiles(outputPath));
       await runner.runCommand(cliPath, 'eject');
 
-      configFiles = fs.readdirSync(path.dirname(new URL('', import.meta.url).pathname))
+      configFiles = fs.readdirSync(fileURLToPath(new URL('.', import.meta.url)))
         .filter((file) => path.extname(file) === '.js' && file.indexOf('spec.js') < 0);
     });
 
@@ -46,13 +46,13 @@ describe('Eject Greenwood', function() {
     });
 
     it('should output rollup config file', function() {
-      expect(fs.existsSync(path.join(path.dirname(new URL('', import.meta.url).pathname), 'rollup.config.js'))).to.be.true;
+      expect(fs.existsSync(fileURLToPath(new URL('./rollup.config.js', import.meta.url)))).to.be.true;
     });
 
     after(function() {
       // remove test files
       configFiles.forEach(file => {
-        fs.unlinkSync(path.join(path.dirname(new URL('', import.meta.url).pathname), file));
+        fs.unlinkSync(fileURLToPath(new URL(`./${file}`, import.meta.url)));
       });
     });
   });
@@ -70,7 +70,7 @@ describe('Eject Greenwood', function() {
   after(function() {
     // remove test files
     configFiles.forEach(file => {
-      fs.unlinkSync(path.join(path.dirname(new URL('', import.meta.url).pathname), file));
+      fs.unlinkSync(fileURLToPath(new URL(`./${file}`, import.meta.url)));
     });
 
     runner.teardown(getOutputTeardownFiles(outputPath));

--- a/packages/cli/test/cases/serve.default/serve.default.spec.js
+++ b/packages/cli/test/cases/serve.default/serve.default.spec.js
@@ -20,14 +20,14 @@ import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils
 import request from 'request';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Serve Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = 'http://127.0.0.1:8080';
   let runner;
 

--- a/packages/cli/test/cases/theme-pack/greenwood.config.js
+++ b/packages/cli/test/cases/theme-pack/greenwood.config.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { myThemePack } from './my-theme-pack.js';
 import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const packageName = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8')).name;
 

--- a/packages/cli/test/cases/theme-pack/greenwood.config.js
+++ b/packages/cli/test/cases/theme-pack/greenwood.config.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { myThemePack } from './my-theme-pack.js';
 import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
-import { fileURLToPath, URL } from 'url';
+import { URL } from 'url';
 
 const packageName = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8')).name;
 

--- a/packages/cli/test/cases/theme-pack/my-theme-pack.js
+++ b/packages/cli/test/cases/theme-pack/my-theme-pack.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
 const myThemePack = (options = {}) => [{
@@ -9,7 +9,7 @@ const myThemePack = (options = {}) => [{
   provider: (compilation) => {
     const templateLocation = options.__isDevelopment // eslint-disable-line no-underscore-dangle
       ? path.join(compilation.context.userWorkspace, 'layouts')
-      : path.join(path.dirname(new URL('', import.meta.url).pathname), 'dist/layouts');
+      : fileURLToPath(new URL('./dist/layouts', import.meta.url));
 
     return {
       templates: [

--- a/packages/cli/test/cases/theme-pack/theme-pack.build.spec.js
+++ b/packages/cli/test/cases/theme-pack/theme-pack.build.spec.js
@@ -53,15 +53,15 @@ describe('Build Greenwood With: ', function() {
 
     before(async function() {
       const themePacktemplates = await getDependencyFiles(
-        `${path.dirname(new URL('', import.meta.url).pathname)}/src/layouts/*.html`,
+        `${outputPath}/src/layouts/*.html`,
         `${outputPath}/node_modules/my-theme-pack/dist/layouts`
       );
       const themePackStyles = await getDependencyFiles(
-        `${path.dirname(new URL('', import.meta.url).pathname)}/src/styles/*.css`,
+        `${outputPath}/src/styles/*.css`,
         `${outputPath}/node_modules/my-theme-pack/dist/styles`
       );
       const themePackComponents = await getDependencyFiles(
-        `${path.dirname(new URL('', import.meta.url).pathname)}/src/components/*.js`,
+        `${outputPath}/src/components/*.js`,
         `${outputPath}/node_modules/my-theme-pack/dist/components`
       );
 

--- a/packages/cli/test/cases/theme-pack/theme-pack.build.spec.js
+++ b/packages/cli/test/cases/theme-pack/theme-pack.build.spec.js
@@ -32,14 +32,14 @@ import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Developement environment for a Theme Pack';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/cli/test/cases/theme-pack/theme-pack.develop.spec.js
+++ b/packages/cli/test/cases/theme-pack/theme-pack.develop.spec.js
@@ -32,7 +32,7 @@ import path from 'path';
 import request from 'request';
 import { Runner } from 'gallinago';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
@@ -40,7 +40,7 @@ const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.jso
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'Developement environment for a Theme Pack';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = 'http://localhost';
   const port = 1984;
   let runner;

--- a/packages/init/src/index.js
+++ b/packages/init/src/index.js
@@ -19,10 +19,10 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { spawn } from 'child_process';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
-const scriptPkg = JSON.parse(fs.readFileSync(new URL(path.join(path.dirname(import.meta.url), '..', '/package.json')), 'utf-8'));
-const templateDir = path.join(path.dirname(new URL('', import.meta.url).pathname), 'template');
+const scriptPkg = JSON.parse(fs.readFileSync(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf-8'));
+const templateDir = fileURLToPath(new URL('./template', import.meta.url));
 const TARGET_DIR = process.cwd();
 
 console.log(`${chalk.rgb(175, 207, 71)('-------------------------------------------------------')}`);
@@ -56,18 +56,18 @@ const npmInit = async () => {
 
 // Copy root and src files to target directory
 const srcInit = async () => {
-  const templateFolder = new URL(path.join(path.dirname(import.meta.url), 'template/')).pathname;
+  // const templateFolder = fileURLToPath(new URL('./template', import.meta.url));
   const templateFiles = [];
 
   await createGitIgnore();
 
-  fs.readdirSync(templateFolder).forEach(file => {
+  fs.readdirSync(templateDir).forEach(file => {
     templateFiles.push(file);
   });
 
   await Promise.all(
     templateFiles.map(async file => {
-      const resolvedPath = new URL(path.join(path.dirname(import.meta.url), 'template', file)).pathname;
+      const resolvedPath = path.join(templateDir, file);
       
       if (fs.lstatSync(resolvedPath).isDirectory()) {
         return await copyFolder(resolvedPath, TARGET_DIR);

--- a/packages/init/src/index.js
+++ b/packages/init/src/index.js
@@ -56,7 +56,6 @@ const npmInit = async () => {
 
 // Copy root and src files to target directory
 const srcInit = async () => {
-  // const templateFolder = fileURLToPath(new URL('./template', import.meta.url));
   const templateFiles = [];
 
   await createGitIgnore();

--- a/packages/init/test/cases/build.default/build.default.spec.js
+++ b/packages/init/test/cases/build.default/build.default.spec.js
@@ -16,13 +16,14 @@ import fs from 'fs';
 import path from 'path';
 import { Runner } from 'gallinago';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 xdescribe('Scaffold Greenwood and Run Build command: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
   const initPath = path.join(process.cwd(), 'packages/init/src/index.js');
-  const outputPath = path.join(path.dirname(new URL('', import.meta.url).pathname), 'my-app');
+  const outputPath = fileURLToPath(new URL('./my-app', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/init/test/cases/develop.default/develop.default.spec.js
+++ b/packages/init/test/cases/develop.default/develop.default.spec.js
@@ -19,12 +19,13 @@ import { getSetupFiles } from '../../../../../test/utils.js';
 import request from 'request';
 import { Runner } from 'gallinago';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 xdescribe('Scaffold Greenwood and Run Develop command: ', function() {
   const initPath = path.join(process.cwd(), 'packages/init/src/index.js');
-  const outputPath = path.join(path.dirname(new URL('', import.meta.url).pathname), 'my-app');
+  const outputPath = fileURLToPath(new URL('./my-app', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/init/test/cases/init.default/init.default.spec.js
+++ b/packages/init/test/cases/init.default/init.default.spec.js
@@ -19,7 +19,7 @@ import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
-describe('Scaffold Greenwood With Default Template: ', function() {
+xdescribe('Scaffold Greenwood With Default Template: ', function() {
   const initPath = path.join(process.cwd(), 'packages/init/src/index.js');
   const outputPath = fileURLToPath(new URL('./my-app', import.meta.url));
   let runner;

--- a/packages/init/test/cases/init.default/init.default.spec.js
+++ b/packages/init/test/cases/init.default/init.default.spec.js
@@ -15,11 +15,11 @@ import chai from 'chai';
 import fs from 'fs';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { fileURLToPath, URL } from 'url';
+import { fileURLToPath, pathToFileURL, URL } from 'url';
 
 const expect = chai.expect;
 
-xdescribe('Scaffold Greenwood With Default Template: ', function() {
+describe('Scaffold Greenwood With Default Template: ', function() {
   const initPath = path.join(process.cwd(), 'packages/init/src/index.js');
   const outputPath = fileURLToPath(new URL('./my-app', import.meta.url));
   let runner;
@@ -94,7 +94,7 @@ xdescribe('Scaffold Greenwood With Default Template: ', function() {
       let greenwoodConfig;
 
       before(async function() {
-        greenwoodConfig = (await import(path.join(outputPath, 'greenwood.config.js'))).default;
+        greenwoodConfig = (await import(pathToFileURL(path.join(outputPath, './greenwood.config.js')))).default;
       });
 
       it('should have the correct title configuration', function() {

--- a/packages/init/test/cases/init.default/init.default.spec.js
+++ b/packages/init/test/cases/init.default/init.default.spec.js
@@ -15,17 +15,18 @@ import chai from 'chai';
 import fs from 'fs';
 import path from 'path';
 import { Runner } from 'gallinago';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Scaffold Greenwood With Default Template: ', function() {
   const initPath = path.join(process.cwd(), 'packages/init/src/index.js');
-  const outputPath = path.join(path.dirname(new URL('', import.meta.url).pathname), 'my-app');
+  const outputPath = fileURLToPath(new URL('./my-app', import.meta.url));
   let runner;
 
   before(function() {
     this.context = {
-      publicDir: path.join(outputPath, 'my-app')
+      publicDir: outputPath
     };
     runner = new Runner();
   });

--- a/packages/init/test/cases/init.yarn/init.yarn.spec.js
+++ b/packages/init/test/cases/init.yarn/init.yarn.spec.js
@@ -16,13 +16,14 @@ import fs from 'fs';
 import path from 'path';
 import { Runner } from 'gallinago';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 xdescribe('Scaffold Greenwood With Yarn: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
   const initPath = path.join(process.cwd(), 'packages/init/src/index.js');
-  const outputPath = path.join(path.dirname(new URL('', import.meta.url).pathname), 'my-app');
+  const outputPath = fileURLToPath(new URL('./my-app', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/plugin-babel/test/cases/default/default.spec.js
+++ b/packages/plugin-babel/test/cases/default/default.spec.js
@@ -32,14 +32,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default Babel configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/plugin-babel/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-babel/test/cases/options.extend-config/options.extend-config.spec.js
@@ -42,14 +42,14 @@ import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 xdescribe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Babel Options for extending Default Configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/plugin-google-analytics/test/cases/default/default.spec.js
+++ b/packages/plugin-google-analytics/test/cases/default/default.spec.js
@@ -29,7 +29,7 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
@@ -37,7 +37,7 @@ describe('Build Greenwood With: ', function() {
   const LABEL = 'Google Analytics Plugin with default options and Default Workspace';
   const mockAnalyticsId = 'UA-123456-1';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/plugin-google-analytics/test/cases/error-analytics-id/error-analytics-id.spec.js
+++ b/packages/plugin-google-analytics/test/cases/error-analytics-id/error-analytics-id.spec.js
@@ -24,13 +24,13 @@
 import chai from 'chai';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
+++ b/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
@@ -30,7 +30,7 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
@@ -38,7 +38,7 @@ describe('Build Greenwood With: ', function() {
   const LABEL = 'Google Analytics Plugin with IP Anonymization tracking set to false and Default Workspace';
   const mockAnalyticsId = 'UA-123456-1';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/plugin-graphql/src/schema/schema.js
+++ b/packages/plugin-graphql/src/schema/schema.js
@@ -4,6 +4,7 @@ import { graphTypeDefs, graphResolvers } from './graph.js';
 import fs from 'fs';
 import gql from 'graphql-tag';
 import path from 'path';
+import { pathToFileURL } from 'url';
 
 const createSchema = async (compilation) => {
   const { graph } = compilation;
@@ -41,7 +42,7 @@ const createSchema = async (compilation) => {
         .filter(file => path.extname(file) === '.js');
 
       for (const schemaPath of schemaPaths) {
-        const { customTypeDefs, customResolvers } = await import(`${customSchemasPath}/${schemaPath}`);
+        const { customTypeDefs, customResolvers } = await import(pathToFileURL(`${customSchemasPath}/${schemaPath}`));
         
         customUserDefs.push(customTypeDefs);
         customUserResolvers.push(customResolvers);

--- a/packages/plugin-graphql/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-graphql/test/cases/develop.default/develop.default.spec.js
@@ -22,7 +22,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import request from 'request';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 
 const expect = chai.expect;
@@ -30,7 +30,7 @@ const expect = chai.expect;
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'GraphQL plugin for resolving client facing files';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = 'http://localhost';
   const port = 1984;
   let runner;

--- a/packages/plugin-graphql/test/cases/qraphql-server/graphql-server.spec.js
+++ b/packages/plugin-graphql/test/cases/qraphql-server/graphql-server.spec.js
@@ -18,14 +18,14 @@ import chai from 'chai';
 import request from 'request';
 import path from 'path';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'GraphQL Server';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = '127.0.0.1';
   const port = 4000;
   let runner;

--- a/packages/plugin-graphql/test/cases/query-children/query-children.spec.js
+++ b/packages/plugin-graphql/test/cases/query-children/query-children.spec.js
@@ -30,7 +30,7 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
@@ -38,7 +38,7 @@ describe('Build Greenwood With: ', function() {
   const LABEL = 'Children from GraphQL';
   const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/plugin-graphql/test/cases/query-config/query-config.spec.js
+++ b/packages/plugin-graphql/test/cases/query-config/query-config.spec.js
@@ -27,7 +27,7 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
@@ -35,7 +35,7 @@ describe('Build Greenwood With: ', function() {
   const LABEL = 'ConfigQuery from GraphQL';
   const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/plugin-graphql/test/cases/query-custom-frontmatter/query-custom-frontmatter.spec.js
+++ b/packages/plugin-graphql/test/cases/query-custom-frontmatter/query-custom-frontmatter.spec.js
@@ -32,7 +32,7 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
@@ -40,7 +40,7 @@ describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom GraphQuery for Front Matter from GraphQL';
   const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/plugin-graphql/test/cases/query-custom-schema/query-custom-schema.spec.js
+++ b/packages/plugin-graphql/test/cases/query-custom-schema/query-custom-schema.spec.js
@@ -32,7 +32,7 @@ import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
-describe.only('Build Greenwood With: ', function() {
+describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom Query from GraphQL';
   const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');

--- a/packages/plugin-graphql/test/cases/query-custom-schema/query-custom-schema.spec.js
+++ b/packages/plugin-graphql/test/cases/query-custom-schema/query-custom-schema.spec.js
@@ -28,15 +28,15 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
-describe('Build Greenwood With: ', function() {
+describe.only('Build Greenwood With: ', function() {
   const LABEL = 'Custom Query from GraphQL';
   const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
+++ b/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
@@ -28,7 +28,7 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
@@ -36,7 +36,7 @@ describe('Build Greenwood With: ', function() {
   const LABEL = 'Graph from GraphQL';
   const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/plugin-graphql/test/cases/query-menu/query-menu.spec.js
+++ b/packages/plugin-graphql/test/cases/query-menu/query-menu.spec.js
@@ -30,7 +30,7 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
@@ -38,7 +38,7 @@ describe('Build Greenwood With: ', async function() {
   const LABEL = 'MenuQuery from GraphQL';
   const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/plugin-import-commonjs/test/cases/default/default.spec.js
+++ b/packages/plugin-import-commonjs/test/cases/default/default.spec.js
@@ -31,14 +31,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Import CommonJs Plugin with default options';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/plugin-import-css/test/cases/default/default.spec.js
+++ b/packages/plugin-import-css/test/cases/default/default.spec.js
@@ -30,14 +30,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Import CSS Plugin with default options';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
@@ -26,7 +26,7 @@ import chai from 'chai';
 import path from 'path';
 import request from 'request';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 
 const expect = chai.expect;
@@ -34,7 +34,7 @@ const expect = chai.expect;
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'Import CSS plugin for using ESM with .css files';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = 'http://localhost';
   const port = 1984;
   let runner;

--- a/packages/plugin-import-json/test/cases/default/default.spec.js
+++ b/packages/plugin-import-json/test/cases/default/default.spec.js
@@ -32,14 +32,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Import JSON Plugin with default options';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
@@ -27,7 +27,7 @@ import chai from 'chai';
 import path from 'path';
 import request from 'request';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 
 const expect = chai.expect;
@@ -35,7 +35,7 @@ const expect = chai.expect;
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'Import JSON plugin for using ESM with .json files';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = 'http://localhost';
   const port = 1984;
   let runner;

--- a/packages/plugin-include-html/src/index.js
+++ b/packages/plugin-include-html/src/index.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
+import { pathToFileURL } from 'url';
 
 class IncludeHtmlResource extends ResourceInterface {
   constructor(compilation, options) {
@@ -36,7 +37,7 @@ class IncludeHtmlResource extends ResourceInterface {
           for (const tag of customElementTags) {
             const src = tag.match(/src="(.*)"/)[1];
             const filepath = path.join(this.compilation.context.userWorkspace, this.getBareUrlPath(src.replace(/\.\.\//g, '')));
-            const { getData, getTemplate } = await import(filepath);
+            const { getData, getTemplate } = await import(pathToFileURL(filepath));
             const includeContents = await getTemplate(await getData());
 
             body = body.replace(tag, includeContents);

--- a/packages/plugin-include-html/test/cases/build.default-custom-element/build.default.custom-element.spec.js
+++ b/packages/plugin-include-html/test/cases/build.default-custom-element/build.default.custom-element.spec.js
@@ -31,14 +31,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With HTML Include Plugin: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/plugin-include-html/test/cases/build.default-custom-element/src/components/footer.js
+++ b/packages/plugin-include-html/test/cases/build.default-custom-element/src/components/footer.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
-import path from 'path';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const getTemplate = async (data) => {
   return `
@@ -13,7 +12,7 @@ const getTemplate = async (data) => {
 };
 
 const getData = async () => {
-  const dataPath = path.join(new URL('', import.meta.url).pathname, '../../../package.json');
+  const dataPath = fileURLToPath(new URL('../../package.json', import.meta.url));
   const data = JSON.parse(await fs.promises.readFile(dataPath, 'utf-8'));
 
   const { version } = data;

--- a/packages/plugin-include-html/test/cases/build.default-link-tag/build.default.link-tag.spec.js
+++ b/packages/plugin-include-html/test/cases/build.default-link-tag/build.default.link-tag.spec.js
@@ -31,14 +31,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With HTML Include Plugin: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/plugin-polyfills/test/cases/default/default.spec.js
+++ b/packages/plugin-polyfills/test/cases/default/default.spec.js
@@ -28,7 +28,7 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 const expectedPolyfillFiles = [
@@ -46,7 +46,7 @@ const expectedPolyfillFiles = [
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Polyfill Plugin with default options and Default Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/plugin-polyfills/test/cases/lit/lit.spec.js
+++ b/packages/plugin-polyfills/test/cases/lit/lit.spec.js
@@ -28,7 +28,7 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
@@ -51,7 +51,7 @@ const expectedPolyfillFiles = [
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Lit Polyfill Plugin with default options and Default Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/plugin-postcss/src/index.js
+++ b/packages/plugin-postcss/src/index.js
@@ -7,13 +7,14 @@ import fs from 'fs';
 import path from 'path';
 import postcss from 'postcss';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
+import { pathToFileURL } from 'url';
 
 async function getConfig (compilation, extendConfig = false) {
   const { projectDirectory } = compilation.context;
   const configFile = 'postcss.config';
   const defaultConfig = (await import(new URL(`${configFile}.js`, import.meta.url).pathname)).default;
   const userConfig = fs.existsSync(path.join(projectDirectory, `${configFile}.mjs`))
-    ? (await import(path.join(projectDirectory, `${configFile}.mjs`))).default
+    ? (await import(pathToFileURL(path.join(projectDirectory, `${configFile}.mjs`)))).default
     : {};
   let finalConfig = Object.assign({}, userConfig);
 

--- a/packages/plugin-postcss/test/cases/default/default.spec.js
+++ b/packages/plugin-postcss/test/cases/default/default.spec.js
@@ -31,14 +31,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default PostCSS configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/plugin-postcss/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-postcss/test/cases/options.extend-config/options.extend-config.spec.js
@@ -38,14 +38,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom PostCSS configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(function() {

--- a/packages/plugin-typescript/test/cases/default/default.spec.js
+++ b/packages/plugin-typescript/test/cases/default/default.spec.js
@@ -42,14 +42,14 @@ import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Default TypeScript configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/packages/plugin-typescript/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-typescript/test/cases/develop.default/develop.default.spec.js
@@ -20,7 +20,7 @@ import chai from 'chai';
 import path from 'path';
 import request from 'request';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 
 const expect = chai.expect;
@@ -28,7 +28,7 @@ const expect = chai.expect;
 describe('Develop Greenwood With: ', function() {
   const LABEL = 'TypeScript plugin for resolving .ts files';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = 'http://localhost';
   const port = 1984;
   let runner;

--- a/packages/plugin-typescript/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-typescript/test/cases/options.extend-config/options.extend-config.spec.js
@@ -42,14 +42,14 @@ import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
   const LABEL = 'Custom TypeScript Options for extending Default Configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
-  const outputPath = path.dirname(new URL('', import.meta.url).pathname);
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
   before(async function() {

--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -220,9 +220,9 @@ Path to where all your project files will be located.  Using an absolute path is
 Setting the workspace path to be the _www/_ folder in the current directory from where Greenwood is being run.
 
 ```js
-import path from 'path';
+import { fileURLToPath, URL } from 'url';
 
 export default {
-  workspace: path.join(process.cwd(), 'www')
+  workspace: fileURLToPath(new URL('./www', import.meta.url))
 }
 ```

--- a/www/pages/docs/data.md
+++ b/www/pages/docs/data.md
@@ -284,7 +284,7 @@ This will return an object of your _greenwood.config.js_ as an object.  Example:
     { rel: 'icon', href: '/assets/favicon.ico' }
   ],
   title: 'My App',
-  workspace: 'src'
+  workspace: 'src' // equivalent to => fileURLToPath(new URL('./www', import.meta.url))
 }
 ```
 

--- a/www/pages/guides/theme-packs.md
+++ b/www/pages/guides/theme-packs.md
@@ -123,6 +123,7 @@ The main consideration needed for development is that your files won't be in _no
 
 So using our current example, our final _my-theme-pack.js_ would look like this:
 ```js
+import path from 'path';
 import { fileURLToPath, URL } from 'url';
 
 const myThemePackPlugin = (options = {}) => [{
@@ -131,7 +132,7 @@ const myThemePackPlugin = (options = {}) => [{
   provider: compilation) => {
     // you can use other directory names besides templates/ this way!
     const templateLocation = options.__isDevelopment
-      ? fileURLToPath(new URL('./layouts', compilation.context.userWorkspace))
+      ? path.join(compilation.context.userWorkspace, 'layouts')
       : fileURLToPath(new URL('dist/layouts', import.meta.url));
 
     return {

--- a/www/pages/guides/theme-packs.md
+++ b/www/pages/guides/theme-packs.md
@@ -118,13 +118,12 @@ Lorum Ipsum, this is a test.
 
 The main consideration needed for development is that your files won't be in _node_modules_, which is what the case would be for users when you publish.  So for that reason, we need to add a little boilerplate to _my-theme-pack.js_.  There might be others way to solve it, but for right now, accepting a "developer only" flag can easily make the plugin pivot into local or "published" modes.
 
-1. If the flag _is_ passed, then use `__dirname` (which would resolve to somewhere inside _node_modules_) as the base path
+1. If the flag _is_ passed, then use `new URL('.', import.meta.url)` (which would resolve to the package's location inside _node_modules_) as the base path
 1. If the flag _is not_ installed (like we want for local development) then you can use use whatever location you have defined in your repository.  Most common would just be to use `process.cwd`
 
 So using our current example, our final _my-theme-pack.js_ would look like this:
 ```js
-import path from 'path';
-import { URL } from 'url';
+import { fileURLToPath, URL } from 'url';
 
 const myThemePackPlugin = (options = {}) => [{
   type: 'context',
@@ -132,8 +131,8 @@ const myThemePackPlugin = (options = {}) => [{
   provider: compilation) => {
     // you can use other directory names besides templates/ this way!
     const templateLocation = options.__isDevelopment
-      ? path.join(compilation.context.userWorkspace, 'layouts')
-      : path.join(new URL('', import.meta.url).pathname, 'dist/layouts');
+      ? fileURLToPath(new URL('./layouts', compilation.context.userWorkspace))
+      : fileURLToPath(new URL('dist/layouts', import.meta.url));
 
     return {
       templates: [


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#707 

## Summary of Changes
1. Fixes the build and gets all commands specs passing on Windows and Linux / macOS
1. Implements a consistent standard for replacing usage of `__dirname` that doesn't exist anymore.  Instead, we should use [`new URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)
1. In addition, when using a `URL` with `path` or `import`, it will be important to use [`fileURLToPath`](https://nodejs.org/api/url.html#urlfileurltopathurl) or [`pathToFileURL`](https://nodejs.org/api/url.html#urlpathtofileurlpath), respectively since a `File`'s scheme is [not consistent across platforms](https://github.com/nodejs/node/issues/31710)