### PR TITLE
better handle `<link>` tag closing variants for inline optimization

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -476,7 +476,15 @@ function greenwoodHtmlPlugin(compilation) {
                 const css = fs.readFileSync(outputPath, 'utf-8');
                 scratchFiles[href] = true;
 
+                // https://github.com/ProjectEvergreen/greenwood/issues/810
+                // when preendering, puppeteer normalizes everything to <link .../>
+                // but if not using prerendering, then it could come out as <link ...></link>
+                // not great, but best we can do for now until #742
                 html = html.replace(`<link ${linkTag.rawAttrs}>`, `
+                  <style>
+                    ${css}
+                  </style>
+                `).replace(`<link ${linkTag.rawAttrs}/>`, `
                   <style>
                     ${css}
                   </style>

--- a/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
@@ -16,10 +16,12 @@
  * Custom Workspace
  * src/
  *   components/
+ *     foobar.js
  *     header.js
  *   pages/
  *     index.html
  *   styles/
+ *     color.css
  *     theme.css
  */
 import chai from 'chai';
@@ -134,12 +136,25 @@ describe('Build Greenwood With: ', function() {
           expect(cssFiles).to.have.lengthOf(0);
         });
 
-        it('should contain one <style> tag with the expected CSS content inlined', function() {
+        it('should contain two <style> tags with the expected CSS content inlined for theme.css and pages.css', function() {
           const styleTags = dom.window.document.querySelectorAll('head style');
-          
+
           // one for puppeteer
-          expect(styleTags.length).to.be.equal(2);
+          expect(styleTags.length).to.be.equal(3);
+        });
+
+        it('should contain the expected CSS content inlined for theme.css', function() {
+          const styleTags = dom.window.document.querySelectorAll('head style');
+
+          // one for puppeteer
           expect(styleTags[1].textContent).to.be.contain('*{font-family:Comic Sans,sans-serif;margin:0;padding:0}');
+        });
+
+        it('should contain the expected CSS content inlined for page.css', function() {
+          const styleTags = dom.window.document.querySelectorAll('head style');
+
+          // one for puppeteer
+          expect(styleTags[2].textContent).to.be.contain('body{color:red}');
         });
       });
     });

--- a/packages/cli/test/cases/build.config.optimization-inline/src/pages/index.html
+++ b/packages/cli/test/cases/build.config.optimization-inline/src/pages/index.html
@@ -22,7 +22,8 @@
 
       export { Baz };
     </script>
-    <link rel="stylesheet" href="/styles/theme.css"></link>  
+
+    <link rel="stylesheet" href="/styles/page.css"/>
   </head>
 
   <body>

--- a/packages/cli/test/cases/build.config.optimization-inline/src/styles/page.css
+++ b/packages/cli/test/cases/build.config.optimization-inline/src/styles/page.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/packages/cli/test/cases/build.config.optimization-inline/src/templates/app.html
+++ b/packages/cli/test/cases/build.config.optimization-inline/src/templates/app.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="/styles/theme.css"></link>
+  </head>
+  <body>
+    <page-outlet></page-outlet>
+  </body>
+</html>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #810 

## Summary of Changes
1. Handle variant `<link>` closing tag
1. Add test case

Now with _greenwood.config.js_ for _www/_ set to `prerender: false`, things look good now
![Screen Shot 2021-12-08 at 6 44 00 PM](https://user-images.githubusercontent.com/895923/145308833-9b119a08-b31e-45ed-8947-83d4f96b0fd2.png)