### PR TITLE
favor using latest when documenting npx commands

### DIFF
--- a/www/pages/blog/release/v0-19-0.md
+++ b/www/pages/blog/release/v0-19-0.md
@@ -22,10 +22,10 @@ With the new package `@greenwood/init` (contributed by [**@hutchgrant**](https:/
 $ mkdir my-app && cd my-app
 
 # init!
-$ npx @greenwood/init
+$ npx @greenwood/init@latest
 
 # or, init and auto npm install
-$ npx @greenwood/init --install
+$ npx @greenwood/init@latest --install
 ```
 
 ![init](/assets/blog-images/init-scaffolding.png)

--- a/www/pages/docs/index.md
+++ b/www/pages/docs/index.md
@@ -23,7 +23,7 @@ $ yarn add @greeenwood/cli --dev
 Though we recommend installing it locally to your project, you can also run Greenwood globally.  For global usage we recommend using `npx`
 
 ```bash
-$ npx @greenwood/cli <command>
+$ npx @greenwood/cli@latest <command>
 ```
 
 ### CLI

--- a/www/pages/getting-started/quick-start.md
+++ b/www/pages/getting-started/quick-start.md
@@ -22,7 +22,7 @@ You can use Greenwood's [`init` package](https://github.com/ProjectEvergreen/gre
 ```bash
 mkdir my-app && cd my-app
 
-npx @greenwood/init
+npx @greenwood/init@latest
 ```
 
 ### Command Line

--- a/www/pages/index.html
+++ b/www/pages/index.html
@@ -44,7 +44,7 @@
                   $ echo "## hello world" > src/pages/index.md
 
                   # run one of Greenwood's commands, and that's it!
-                  $ npx @greenwood/cli develop
+                  $ npx @greenwood/cli@latest develop
                 </code>
               </pre>
               <p>For anyone new to Greenwood, we encourage you go through our <a href="/getting-started/">Getting Started</a> guide, or to get right to work, head on over to our <a href="/docs/">documentation</a>.</p>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
To avoid any caching issues or confusion for users, making it explicit with `npx` commands to reference `@latest` npm alias
```sh
# before
npx @greenwood/init

# after
npx @greenwood/init@latest
```

----

edit: found this [Reddit thread](https://www.reddit.com/r/reactjs/comments/rif1q4/need_help_npx_createreactapp_not_working/) where other user's are reporting similar situations in needed to use `@latest`, and that this helps avoid caching issues, which appears to be the default behavior of `npx` (now?)

> _If any requested packages are not present in the local project dependencies, then they are installed to a folder in the npm cache_