### PR TITLE
add a section on scripts and imports to the docs section

### DIFF
--- a/www/pages/docs/css-and-images.md
+++ b/www/pages/docs/css-and-images.md
@@ -2,7 +2,7 @@
 label: 'styles-and-assets'
 menu: side
 title: 'Styles and Assets'
-index: 5
+index: 6
 linkheadings: 3
 ---
 

--- a/www/pages/docs/data.md
+++ b/www/pages/docs/data.md
@@ -2,7 +2,7 @@
 label: 'data-sources'
 menu: side
 title: 'Data Sources'
-index: 8
+index: 9
 linkheadings: 3
 ---
 

--- a/www/pages/docs/layouts.md
+++ b/www/pages/docs/layouts.md
@@ -2,7 +2,7 @@
 label: 'templates-and-pages'
 menu: side
 title: 'Templates and Pages'
-index: 6
+index: 7
 linkheadings: 3
 ---
 

--- a/www/pages/docs/menus.md
+++ b/www/pages/docs/menus.md
@@ -2,7 +2,7 @@
 label: 'menus'
 menu: side
 title: 'Menus'
-index: 7
+index: 8
 linkheadings: 3
 ---
 

--- a/www/pages/docs/scripts.md
+++ b/www/pages/docs/scripts.md
@@ -1,0 +1,92 @@
+---
+label: 'scripts-and-imports'
+menu: side
+title: 'Scripts and Imports'
+index: 5
+linkheadings: 3
+---
+
+## Scripts and Imports
+**Greenwood** generally does not have any opinion on how you structure your site, aside from the pre-determined _pages/_ and (optional) _templates/_ directories.  It supports all standard files that you can open in a web browser.
+
+
+### Script Tags
+Script tags can be done in any standards compliant way that will work in a browser.  So just as in HTML, you can do anything you need, like below:
+
+```html
+<!DOCTYPE html>
+<html lang="en" prefix="og:http://ogp.me/ns#">
+
+  <head>
+    <script>
+      alert('hello');
+    </script>
+
+    <script src="/path/to/script.js"></script>
+    <script src="https://unpkg.com/...."></script>
+  </head>
+
+  <body>
+    <!-- content goes here -->
+  </body>
+  
+</html>
+```
+
+### Imports
+Greenwood also supports (and recommends) usage of ECMAScript Modules (ESM), like in the example below.
+
+```html
+<!DOCTYPE html>
+<html lang="en" prefix="og:http://ogp.me/ns#">
+
+  <head>
+    <script type="module">
+      import { Foo } from '/path/to/foo.js';
+
+      Foo.something();
+    </script>
+
+    <script type="module" src="/path/to/script.js"></script>
+  </head>
+
+  <body>
+    <!-- content goes here -->
+  </body>
+  
+</html>
+```
+
+### Extensions and Bare Imports
+
+One important note to consider is that ESM by spec definition, expects a couple important characteristics from an `import` path:
+1. It must be a relative path
+1. It must have an extension
+
+```js
+import { Foo } from './foo.js'; // happy panda
+
+import { Foo } from './foo'; // sad panda
+```
+
+However, Greenwood also supports [bare module specifiers](https://lit.dev/docs/v1/tools/build/#bare-module-specifiers) for packages you install with a package manager from **npm**.
+```js
+import { html, LitElement } from 'lit';
+```
+
+By [creating an import map for you](/about/how-it-works/#cli), Greenwood knows how resolve these but it will _only_ look in _node_modules_.
+
+As a bonus, Greenwood also auto resolves paths with references to _node_modules_ as well if the path starts with `/node_modules/`
+```html
+<script type="module">
+  import { Foo } from '/node_modules/foo/dist/main.js';
+
+  Foo.something();
+</script>
+```
+
+----
+
+So the rule of thumb is:
+- If it's a package from npm, you can use bare specifiers and no extension
+- Otherwise, you will need to use a relative path and the extension

--- a/www/pages/docs/tech-stack.md
+++ b/www/pages/docs/tech-stack.md
@@ -2,7 +2,7 @@
 label: 'stack'
 menu: side
 title: 'Tech Stack'
-index: 9
+index: 10
 linkheadings: 3
 ---
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #536 

## Summary of Changes
1. Added a _Scripts and Imports_ page to the Docs section
1. Gave a basic breaking down of using `<script>` tags and ESM, and called out when bare import specifiers are supported