### PR TITLE
revert Yarn resolution for Lit now that all libs have updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "lint:css": "stylelint \"./www/**/*.js\", \"./www/**/*.css\"",
     "lint": "ls-lint && yarn lint:js && yarn lint:ts && yarn lint:css"
   },
-  "resolutions": {
-    "lit": "^2.0.0"
-  },
   "devDependencies": {
     "@ls-lint/ls-lint": "^1.10.0",
     "@typescript-eslint/eslint-plugin": "^4.28.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,8 +52,8 @@
   },
   "devDependencies": {
     "@babel/runtime": "^7.10.4",
-    "@lion/button": "^0.14.3",
-    "@lion/calendar": "^0.16.5",
+    "@lion/button": "^0.14.5",
+    "@lion/calendar": "^0.16.7",
     "@mapbox/rehype-prism": "^0.5.0",
     "@material/mwc-button": "^0.25.2",
     "@types/trusted-types": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,37 +1996,37 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@lion/button@^0.14.3":
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/@lion/button/-/button-0.14.3.tgz#5d067f07c72e0da1343066a941297cc8d3390964"
-  integrity sha512-QQ79Nio3HcsF7wX72wi45DA2dzoCsH9bULYEh6E8xEZqM7gF9CMIUSKgTVZ19V9XKycbRLfKjh6dAAH8aamzFw==
+"@lion/button@^0.14.5":
+  version "0.14.5"
+  resolved "https://registry.yarnpkg.com/@lion/button/-/button-0.14.5.tgz#1943dc1c2a7169ec7f4e0d18af490d52c6b18a25"
+  integrity sha512-1PYib3UagCc+GIlaXM4CZfMvq1Nmn0vChdyIuNTBOwy/v6siG7qJaoios4U68+rRqUPbfMJyuft7wOULt/30Vg==
   dependencies:
-    "@lion/core" "0.18.3"
+    "@lion/core" "0.19.0"
 
-"@lion/calendar@^0.16.5":
-  version "0.16.5"
-  resolved "https://registry.yarnpkg.com/@lion/calendar/-/calendar-0.16.5.tgz#3988c0fd86b504b2548f27cc0c209d2eec245a9a"
-  integrity sha512-UnRUtzSym53v+ykCsjq1BpLEaaGupe8RO1F+46ABNiB9fqTXqUz8w9miK10IEyfZgUsf0biQMrJlG9KrZn1l9w==
+"@lion/calendar@^0.16.7":
+  version "0.16.7"
+  resolved "https://registry.yarnpkg.com/@lion/calendar/-/calendar-0.16.7.tgz#45c39629e69f9a6a07cafbd66eb353c80504dbe4"
+  integrity sha512-hDjlW6QxYAM1M/y2aj4F4eyxrRKo4fK0jArh/HNxabsu4t+FQOfRIbFJiKbngJgcBvBwErlnA1B3yEx+N8di8Q==
   dependencies:
-    "@lion/core" "0.18.3"
-    "@lion/localize" "0.21.1"
+    "@lion/core" "0.19.0"
+    "@lion/localize" "0.21.3"
 
-"@lion/core@0.18.3":
-  version "0.18.3"
-  resolved "https://registry.yarnpkg.com/@lion/core/-/core-0.18.3.tgz#fbf649e23b5712d5998ef8233013f48fcc598012"
-  integrity sha512-BDRuwLnsyg/kDE382xBoe4ytsEsiDkov0h3VN66Y9tvMpnChf6BxAkfY7g+LlxgbsNihmZnykE+eGE7cfP5PSw==
+"@lion/core@0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@lion/core/-/core-0.19.0.tgz#4bf86059acd0ef3f74e6d0689250edc4d6664836"
+  integrity sha512-SU2JzKEgGdwOVK9WdsmjKiYkgQ/hOYC05jxyHfG9qJWmOzEUsuvvULjwU8hd1u7gLy5gSxsdEO2nJ2zyWV2ihg==
   dependencies:
-    "@open-wc/dedupe-mixin" "^1.2.18"
-    "@open-wc/scoped-elements" "^2.0.0-next.3"
-    lit "^2.0.0-rc.2"
+    "@open-wc/dedupe-mixin" "^1.3.0"
+    "@open-wc/scoped-elements" "^2.0.1"
+    lit "^2.0.2"
 
-"@lion/localize@0.21.1":
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/@lion/localize/-/localize-0.21.1.tgz#f1b97879448c5953a3a80bf3310ece7d88f59f66"
-  integrity sha512-v9Jb0ZGmCqdaHX3zTqDnGo3cX7L4H5kb9hcTWd3Cvppujr/r3x7XOzWB7tJo6fk49l3El2V7SoV8/FtVvJfK2w==
+"@lion/localize@0.21.3":
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/@lion/localize/-/localize-0.21.3.tgz#6ed63aa79d4a6df37536d8be8d03d11b855c32b6"
+  integrity sha512-BXFuKYYM+XABlULS8tLddj1TviRHK0Bm1AR6cOrdStv8vSrTK9szV63c5Ybl+kD6QstBSQ4qNwbjd3hAIJVGhQ==
   dependencies:
     "@bundled-es-modules/message-format" "6.0.4"
-    "@lion/core" "0.18.3"
+    "@lion/core" "0.19.0"
     singleton-manager "1.4.2"
 
 "@lit/reactive-element@1.0.0-rc.4":
@@ -2034,7 +2034,7 @@
   resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.0.0-rc.4.tgz#3473f6a687e9925fc2e9ff1b716a86b5f4b576ad"
   integrity sha512-dJMha+4NFYdpnUJzRrWTFV5Hdp9QHWFuPnaoqonrKl4lGJVnYez9mu8ev9F/5KM47tjAjh22DuRHrdFDHfOijA==
 
-"@lit/reactive-element@^1.0.0", "@lit/reactive-element@^1.0.0-rc.1":
+"@lit/reactive-element@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.0.0.tgz#7b6e6a85709cda0370c47e425ac2f3b553696a4b"
   integrity sha512-Kpgenb8UNFsKCsFhggiVvUkCbcFQSd6N8hffYEEGjz27/4rw3cTSsmP9t3q1EHOAsdum60Wo64HvuZDFpEwexA==
@@ -2294,19 +2294,19 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@open-wc/dedupe-mixin@^1.2.18", "@open-wc/dedupe-mixin@^1.3.0":
+"@open-wc/dedupe-mixin@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@open-wc/dedupe-mixin/-/dedupe-mixin-1.3.0.tgz#0df5d438285fc3482838786ee81895318f0ff778"
   integrity sha512-UfdK1MPnR6T7f3svzzYBfu3qBkkZ/KsPhcpc3JYhsUY4hbpwNF9wEQtD4Z+/mRqMTJrKg++YSxIxE0FBhY3RIw==
 
-"@open-wc/scoped-elements@^2.0.0-next.3":
-  version "2.0.0-next.5"
-  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-2.0.0-next.5.tgz#46ce9abe3bedbb8c7dc098839f21fe442a93c0c1"
-  integrity sha512-yprRHBRDDKhS3CacWi8+UJHG+avhMUO8k6X91AQiHHOcIO4P9E8v2skdGg4bhE2fF/tg5wVex8Sa5ZlsZ21pDg==
+"@open-wc/scoped-elements@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-2.0.1.tgz#6b1c3535f809bd90710574db80093a81e3a1fc2d"
+  integrity sha512-JS6ozxUFwFX3+Er91v9yQzNIaFn7OnE0iESKTbFvkkKdNwvAPtp1fpckBKIvWk8Ae9ZcoI9DYZuT2DDbMPcadA==
   dependencies:
-    "@lit/reactive-element" "^1.0.0-rc.1"
+    "@lit/reactive-element" "^1.0.0"
     "@open-wc/dedupe-mixin" "^1.3.0"
-    "@webcomponents/scoped-custom-element-registry" "0.0.2"
+    "@webcomponents/scoped-custom-element-registry" "^0.0.3"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -2812,10 +2812,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
-"@webcomponents/scoped-custom-element-registry@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@webcomponents/scoped-custom-element-registry/-/scoped-custom-element-registry-0.0.2.tgz#c863d163cb39c60063808e5ae23e06a1766fbe5f"
-  integrity sha512-lKCoZfKoE3FHvmmj2ytaLBB8Grxp4HaxfSzaGlIZN6xXnOILfpCO0PFJkAxanefLGJWMho4kRY5PhgxWFhmSOw==
+"@webcomponents/scoped-custom-element-registry@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@webcomponents/scoped-custom-element-registry/-/scoped-custom-element-registry-0.0.3.tgz#774591a886b0b0e4914717273ba53fd8d5657522"
+  integrity sha512-lpSzgDCGbM99dytb3+J3Suo4+Bk1E13MPnWB42JK8GwxSAxFz+tC7TTv2hhDSIE2IirGNKNKCf3m08ecu6eAsQ==
 
 "@webcomponents/webcomponentsjs@^2.6.0":
   version "2.6.0"
@@ -7524,10 +7524,10 @@ lit-redux-router@~0.20.0:
   dependencies:
     regexparam "^2.0.0"
 
-lit@^2.0.0, lit@^2.0.0-rc.2:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-2.0.0.tgz#7710095dc518d9858dde579e9c76b9eed71e98ba"
-  integrity sha512-pqi5O/wVzQ9Bn4ERRoYQlt1EAUWyY5Wv888vzpoArbtChc+zfUv1XohRqSdtQZYCogl0eHKd+MQwymg2XJfECg==
+lit@^2.0.0, lit@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lit/-/lit-2.0.2.tgz#5e6f422924e0732258629fb379556b6d23f7179c"
+  integrity sha512-hKA/1YaSB+P+DvKWuR2q1Xzy/iayhNrJ3aveD0OQ9CKn6wUjsdnF/7LavDOJsKP/K5jzW/kXsuduPgRvTFrFJw==
   dependencies:
     "@lit/reactive-element" "^1.0.0"
     lit-element "^3.0.0"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#611 

## Summary of Changes
1. Lion has [now updated to the final `2.x.x` release of **Lit**](https://github.com/ing-bank/lion/releases/tag/%40lion%2Fcore%400.19.0) (no `-rcN`) so can remove the resolution and manual overrides in _yarn.lock_