### PR TITLE
feat/841 add --template argument and clone template to init package

### DIFF
--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -24,6 +24,21 @@ This will then output the following
 
 ## API
 
+### Template
+
+To scaffold your new project based on one of [Greenwood's starter templates](https://github.com/orgs/ProjectEvergreen/repositories?q=greenwood-template-&type=all&language=&sort=), pass the `--template` flag and then follow the prompts to complete the scaffolding.
+
+```bash
+# example
+npx @greenwood/init --template
+
+-------------------------------------------------------
+Initialize Greenwood Template ♻️
+-------------------------------------------------------
+? Which template would you like to use? (Use arrow keys)
+❯ blog 
+```
+
 ### NPM Install
 
 To automatically run `npm install` after scaffolding, pass the `--install` flag.
@@ -41,3 +56,9 @@ To automatically run `yarn install` after scaffolding, pass the `--yarn` flag.
 # example
 npx @greenwood/init --yarn
 ```
+
+> _Flags can be chained together!_
+> ```sh
+> # This will use Yarn, install dependencies, and scaffold from the blog template
+> $ npx @greenwood/init --template --yarn --install
+> ```

--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -39,6 +39,12 @@ Initialize Greenwood Template ♻️
 ❯ blog 
 ```
 
+You can also pass the template you want from the CLI as well.
+```bash
+# example
+npx @greenwood/init --template=blog 
+```
+
 ### NPM Install
 
 To automatically run `npm install` after scaffolding, pass the `--install` flag.

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -24,6 +24,8 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
-    "commander": "^8.2.0"
+    "commander": "^8.2.0",
+    "node-fetch": "^3.1.0",
+    "simple-git": "^2.48.0"
   }
 }

--- a/packages/init/src/index.js
+++ b/packages/init/src/index.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 /* eslint no-console: 0 */
+/* eslint-disable camelcase */
 /*
  * **Note**
  * For the time being, there is an issue that prevents us from running the install based specs for this package as part of CI.
@@ -160,12 +161,12 @@ const listAndSelectTemplate = async () => {
           console.log('Couldn\'t locate any templates, check your connection and try again');
           throw new HTTPResponseError(response);
         }
-      }
+      };
 
       const repos = await fetch(PROJECT_API_URL).then(resp => checkStatus(resp));
 
       // assuming it did resolve but there are no templates listed
-      if(!repos || repos.length === 0) {
+      if (!repos || repos.length === 0) {
         console.log('Couldn\'t locate any templates, check your connection and try again');
         return [];
       }
@@ -174,14 +175,14 @@ const listAndSelectTemplate = async () => {
         return repo.name.includes('greenwood-template');
       });
       
-      return templateRepos.map(({ clone_url, name }) =>  {
+      return templateRepos.map(({ clone_url, name }) => {
         const templateName = name.substring(templateStandardName.length, name.length);
-        return { clone_url, name: templateName }
+        return { clone_url, name: templateName };
       });
-    } catch(err) {
+    } catch (err) {
       throw err;
     }
-  }
+  };
 
   const templates = await getTemplates();
 
@@ -196,8 +197,8 @@ const listAndSelectTemplate = async () => {
       choices: templates.map(template => template.name),
       filter(val) {
         return val.toLowerCase();
-      },
-    },
+      }
+    }
   ];
 
   return inquirer.prompt(questions).then((answers) => {
@@ -206,7 +207,7 @@ const listAndSelectTemplate = async () => {
       return template.name === answers.template;
     });
 
-    if(selectedTemplate) {
+    if (selectedTemplate) {
       console.log('\Installing Selected Template:', selectedTemplate.name);
     }
   });
@@ -225,15 +226,14 @@ const cloneTemplate = async () => {
   try {
     await git.clone(selectedTemplate.clone_url, clonedTemplateDir);
     templateDir = clonedTemplateDir;
-  }
-  catch (e) { throw e }
-}
+  } catch (e) { throw e; }
+};
 
 const run = async () => {
   try {
-    if(program.template) {
+    if (program.template) {
       await listAndSelectTemplate();
-      if(!selectedTemplate) {
+      if (!selectedTemplate) {
         return;
       }
       await cloneTemplate();

--- a/packages/init/src/index.js
+++ b/packages/init/src/index.js
@@ -13,17 +13,24 @@
  *
  */
 import chalk from 'chalk';
+import simpleGit from 'simple-git';
 import commander from 'commander';
 import { copyFolder } from './copy-folder.js';
+import fetch from 'node-fetch';
 import fs from 'fs';
+import inquirer from 'inquirer';
 import os from 'os';
 import path from 'path';
 import { spawn } from 'child_process';
 import { fileURLToPath, URL } from 'url';
 
+const PROJECT_API_URL = 'https://api.github.com/orgs/ProjectEvergreen/repos';
+const templateStandardName = 'greenwood-template-';
+let selectedTemplate = null;
 const scriptPkg = JSON.parse(fs.readFileSync(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf-8'));
-const templateDir = fileURLToPath(new URL('./template', import.meta.url));
+let templateDir = fileURLToPath(new URL('./template', import.meta.url));
 const TARGET_DIR = process.cwd();
+const clonedTemplateDir = path.join(TARGET_DIR, '.template');
 
 console.log(`${chalk.rgb(175, 207, 71)('-------------------------------------------------------')}`);
 console.log(`${chalk.rgb(175, 207, 71)('Initialize Greenwood Template ♻️')}`);
@@ -34,6 +41,7 @@ const program = new commander.Command(scriptPkg.name)
   .usage(`${chalk.green('<application-directory>')} [options]`)
   .option('--yarn', 'Use yarn package manager instead of npm default')
   .option('--install', 'Install dependencies upon init')
+  .option('--template', 'Select from list of Greenwood curated templates')
   .parse(process.argv)
   .opts();
 
@@ -130,8 +138,107 @@ const install = async () => {
   });
 };
 
+const listAndSelectTemplate = async () => {
+  
+  const getTemplates = async () => {
+    try {
+
+      // create error response 
+      class HTTPResponseError extends Error {
+        constructor(response, ...args) {
+          super(`HTTP Error Response: ${response.status} ${response.statusText}`, ...args);
+          this.response = response;
+        }
+      }
+      
+      // check response from repo list fetch
+      const checkStatus = response => {
+        if (response.ok) {
+          // response.status >= 200 && response.status < 300
+          return response.json();
+        } else {
+          console.log('Couldn\'t locate any templates, check your connection and try again');
+          throw new HTTPResponseError(response);
+        }
+      }
+
+      const repos = await fetch(PROJECT_API_URL).then(resp => checkStatus(resp));
+
+      // assuming it did resolve but there are no templates listed
+      if(!repos || repos.length === 0) {
+        console.log('Couldn\'t locate any templates, check your connection and try again');
+        return [];
+      }
+
+      const templateRepos = repos.filter(repo => {
+        return repo.name.includes('greenwood-template');
+      });
+      
+      return templateRepos.map(({ clone_url, name }) =>  {
+        const templateName = name.substring(templateStandardName.length, name.length);
+        return { clone_url, name: templateName }
+      });
+    } catch(err) {
+      throw err;
+    }
+  }
+
+  const templates = await getTemplates();
+
+  // Debug list templates 
+  // console.log('templates', templates);
+
+  const questions = [
+    {
+      type: 'list',
+      name: 'template',
+      message: 'Which template would you like to use?',
+      choices: templates.map(template => template.name),
+      filter(val) {
+        return val.toLowerCase();
+      },
+    },
+  ];
+
+  return inquirer.prompt(questions).then((answers) => {
+    // set the selected template based on the selected template name
+    selectedTemplate = templates.find(template => {
+      return template.name === answers.template;
+    });
+
+    if(selectedTemplate) {
+      console.log('\Installing Selected Template:', selectedTemplate.name);
+    }
+  });
+};
+
+const cloneTemplate = async () => {
+  const git = simpleGit();
+
+  // check if .template directory already exists, if so remove it
+  if (await fs.existsSync(clonedTemplateDir)) {
+    await fs.rmSync(clonedTemplateDir, { recursive: true, force: true });
+  }
+
+  // clone to .template directory 
+  console.log('clone template', selectedTemplate.name, 'to directory', clonedTemplateDir);
+  try {
+    await git.clone(selectedTemplate.clone_url, clonedTemplateDir);
+    templateDir = clonedTemplateDir;
+  }
+  catch (e) { throw e }
+}
+
 const run = async () => {
   try {
+    if(program.template) {
+      await listAndSelectTemplate();
+      if(!selectedTemplate) {
+        return;
+      }
+      await cloneTemplate();
+    }
+
     // map all the template files and copy them to the current working directory
     console.log('Initialzing project with files...');
     await srcInit();

--- a/packages/init/test/cases/init.template/init.template.spec.js
+++ b/packages/init/test/cases/init.template/init.template.spec.js
@@ -1,0 +1,66 @@
+/*
+ * Use Case
+ * Scaffold from minimal template using the --yarn flag.
+ *
+ * User Result
+ * Should scaffold from the blog template.
+ *
+ * User Command
+ * @greenwood/init --template=blog
+ *
+ * User Workspace
+ * N / A
+ */
+import chai from 'chai';
+import fs from 'fs';
+import path from 'path';
+import { Runner } from 'gallinago';
+import { fileURLToPath, URL } from 'url';
+
+const expect = chai.expect;
+
+describe('Scaffold Greenwood From a (Blog) Template: ', function() {
+  const initPath = path.join(process.cwd(), 'packages/init/src/index.js');
+  const outputPath = fileURLToPath(new URL('./my-app', import.meta.url));
+  let runner;
+
+  before(function() {
+    this.context = {
+      publicDir: path.join(outputPath, 'public')
+    };
+    runner = new Runner();
+  });
+
+  describe('default blog template', function () {
+
+    before(async function() {
+      await runner.setup(outputPath);
+      await runner.runCommand(initPath, '--template=blog');
+    });
+
+    describe('expected file output', function () {
+
+      it('should create a src/pages directory', function() {
+        expect(fs.existsSync(path.join(outputPath, 'src', 'pages'))).to.be.true;
+      });
+
+      it('should generate a greenwood.config.js file', function() {
+        expect(fs.existsSync(path.join(outputPath, 'greenwood.config.js'))).to.be.true;
+      });
+
+      it('should generate a .gitignore file', function() {
+        expect(fs.existsSync(path.join(outputPath, '.gitignore'))).to.be.true;
+      });
+  
+      it('should generate a package.json file', function() {
+        expect(fs.existsSync(path.join(outputPath, 'package.json'))).to.be.true;
+      });
+    });
+    
+  });
+
+  after(function() {
+    runner.teardown([outputPath]);
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1314,6 +1314,18 @@
   resolved "https://registry.yarnpkg.com/@josephg/resolvable/-/resolvable-1.0.1.tgz#69bc4db754d79e1a2f17a650d3466e038d94a5eb"
   integrity sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==
 
+"@kwsites/file-exists@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
+  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
+  dependencies:
+    debug "^4.1.1"
+
+"@kwsites/promise-deferred@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
+  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
+
 "@lerna/add@3.21.0":
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.21.0.tgz#27007bde71cc7b0a2969ab3c2f0ae41578b4577b"
@@ -4609,6 +4621,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
+  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
+
 data-urls@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
@@ -4664,6 +4681,13 @@ debug@^3.1.0:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.3.2:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
+  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -5528,6 +5552,13 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fetch-blob@^3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.1.3.tgz#a7dca4855e39d3e3c5a1da62d4ee335c37d26012"
+  integrity sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==
+  dependencies:
+    web-streams-polyfill "^3.0.3"
+
 figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"
@@ -5718,6 +5749,13 @@ format@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -8326,6 +8364,15 @@ node-fetch@2.6.1, node-fetch@^2.5.0, node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-fetch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.1.0.tgz#714f4922dc270239487654eaeeab86b8206cb52e"
+  integrity sha512-QU0WbIfMUjd5+MUzQOYhenAazakV7Irh1SGkWCsRzBwvm4fAhzEUaHMJ6QLP7gWT6WO9/oH2zhKMMGMuIrDyKw==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.2"
+    formdata-polyfill "^4.0.10"
+
 node-gyp@^5.0.2:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-5.1.1.tgz#eb915f7b631c937d282e33aed44cb7a025f62a3e"
@@ -10674,6 +10721,15 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
+simple-git@^2.48.0:
+  version "2.48.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-2.48.0.tgz#87c262dba8f84d7b96bb3a713e9e34701c1f6e3b"
+  integrity sha512-z4qtrRuaAFJS4PUd0g+xy7aN4y+RvEt/QTJpR184lhJguBA1S/LsVlvE/CM95RsYMOFJG3NGGDjqFCzKU19S/A==
+  dependencies:
+    "@kwsites/file-exists" "^1.1.1"
+    "@kwsites/promise-deferred" "^1.1.1"
+    debug "^4.3.2"
+
 simpledotcss@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/simpledotcss/-/simpledotcss-1.0.0.tgz#b5ac8fcd73d111938def9c0f43f1839d6eae96be"
@@ -12041,6 +12097,11 @@ web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
+
+web-streams-polyfill@^3.0.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz#a6b74026b38e4885869fb5c589e90b95ccfc7965"
+  integrity sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## Related Issue
Resolves #841 

## Summary of Changes
1. Adds `--template` option to the `init` command
2. lists all repos with `greenwood-template-x` in name present in ProjectEvergreen org
3. clones template and then scaffolds the app

## Run Example
```
git checkout feat/841-template-command && yarn install
cd .. && mkdir testblog && cd testblog
node ../greenwood/packages/init/src/index.js --template --yarn --install
```

```
-------------------------------------------------------
Initialize Greenwood Template ♻️
-------------------------------------------------------
Yarn Enabled
? Which template would you like to use? (Use arrow keys)
❯ blog 
```


Once merged of course you'll be able to do this with:
```
npx @greenwood/init --template
```

## todo

* [x] docs
* [x] tests