### PR TITLE
remove extraneous Google Analytics meta tag

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -24,8 +24,7 @@ export default {
     { property: 'og:image', content: 'https://www.greenwoodjs.io/assets/greenwood-logo-300w.png' },
     { property: 'og:description', content: META_DESCRIPTION },
     { rel: 'shortcut icon', href: FAVICON_HREF },
-    { rel: 'icon', href: FAVICON_HREF },
-    { name: 'google-site-verification', content: '4rYd8k5aFD0jDnN0CCFgUXNe4eakLP4NnA18mNnK5P0' }
+    { rel: 'icon', href: FAVICON_HREF }
   ],
   plugins: [
     ...greenwoodPluginGraphQL(),


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #496 

## Summary of Changes
1. Forget to remove the GA identification `<meta>` tag