### PR TITLE
remove SPA mode coming soon disclaimer

### DIFF
--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -127,9 +127,6 @@ export default {
 }
 ```
 
-> _`spa` (Single Page Application) mode coming soon!_
-
-
 ### Optimization
 
 Greenwood provides a number of different ways to send hints to Greenwood as to how JavaScript and CSS tags in your HTML should get loaded by the browser.  Greenwood supplements, and builds up on top of existing [resource "hints" like `preload` and `prefetch`](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content).  These optimization settings are intended to compliment any `mode` setting you may have selected.


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#518 

## Summary of Changes
1. The `spa` mode disclaimer was never removed when SPA support was added.