### PR TITLE
handle HTML intercepting for static compilations

### DIFF
--- a/packages/plugin-include-html/test/cases/build.default-custom-element/greenwood.config.js
+++ b/packages/plugin-include-html/test/cases/build.default-custom-element/greenwood.config.js
@@ -1,6 +1,7 @@
 import { greenwoodPluginIncludeHTML } from '../../../src/index.js';
 
 export default {
+  prerender: false,
   plugins: [
     ...greenwoodPluginIncludeHTML()
   ]

--- a/packages/plugin-include-html/test/cases/build.default-link-tag/greenwood.config.js
+++ b/packages/plugin-include-html/test/cases/build.default-link-tag/greenwood.config.js
@@ -1,6 +1,7 @@
 import { greenwoodPluginIncludeHTML } from '../../../src/index.js';
 
 export default {
+  prerender: false,
   plugins: [
     ...greenwoodPluginIncludeHTML()
   ]


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #858 

## Summary of Changes
1. Added `intercept` logic to `staticCompilation` for when `prerender: false`
1. Covered with "forced" test case (will undo in #857 )