### PR TITLE
handle puppeteer fixing our invalid HTML

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -177,7 +177,11 @@ const getAppTemplate = (contents, templatesDir, customImports = [], contextPlugi
 
     // merge <style> tags
     if (headStyles.length > 0) {
-      const latestHeadContents = appTemplateContents.match(/<head>.*.<\/head>/s)[0];
+      const matchNeedleStyle = /<style .*/g;
+      const appHeadStyleMatches = appTemplateHeadContents.match(matchNeedleStyle);
+      const lastStyle = appHeadStyleMatches && appHeadStyleMatches.length && appHeadStyleMatches.length > 0
+        ? appHeadStyleMatches[appHeadStyleMatches.length - 1]
+        : '</head>';
       const pageBodyStyles = headStyles.map((style) => {
         const attributes = style.rawAttrs === '' ? '' : ` ${style.rawAttrs}`;
 
@@ -187,13 +191,17 @@ const getAppTemplate = (contents, templatesDir, customImports = [], contextPlugi
           </style>
         `;
       });
-      const lastIndex = latestHeadContents.lastIndexOf('</style>') === -1
-        ? latestHeadContents.lastIndexOf('</head>')
-        : latestHeadContents.lastIndexOf('</style>');
-      const offset = lastIndex === -1 ? '</head>'.length : '</style>'.length;
-      const result = latestHeadContents.substring(0, lastIndex + offset) + pageBodyStyles.join('\n') + latestHeadContents.substring(lastIndex);
 
-      appTemplateContents = appTemplateContents.replace(latestHeadContents, result);
+      if (lastStyle === '</head>') {
+        appTemplateContents = appTemplateContents.replace(lastStyle, `
+          ${pageBodyStyles.join('\n')}
+        ${lastStyle}\n
+      `);
+      } else {
+        appTemplateContents = appTemplateContents.replace(lastStyle, `${lastStyle}\n
+          ${pageBodyStyles.join('\n')}
+        `);
+      }
     }
 
     // merge <meta>

--- a/packages/cli/test/cases/build.default.workspace-template-page/build.default.workspace-template-page.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-template-page/build.default.workspace-template-page.spec.js
@@ -86,8 +86,8 @@ describe('Build Greenwood With: ', function() {
           expect(linkTags.length).to.equal(1);
         });
 
-        it('should have 2 <style> tags in the <head> (1 + one from Puppeteer)', function() {
-          expect(styleTags.length).to.equal(2);
+        it('should have 1 <style> tags in the <head>', function() {
+          expect(styleTags.length).to.equal(1);
         });
 
         it('should add one page template <script> tag', function() {
@@ -101,8 +101,7 @@ describe('Build Greenwood With: ', function() {
         });
 
         it('should add one page template <style> tag', function() {
-          // offset index by one since first <style> tag is from Puppeteer
-          expect(styleTags[1].textContent).to.contain('.owen-test');
+          expect(styleTags[0].textContent).to.contain('.owen-test');
         });
       });
   

--- a/packages/cli/test/cases/build.default.workspace-template-page/greenwood.config.js
+++ b/packages/cli/test/cases/build.default.workspace-template-page/greenwood.config.js
@@ -1,0 +1,3 @@
+export default {
+  prerender: false
+};


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #859 

## Summary of Changes
So yeah, seems like this was a case where puppeteer was "fixing" our invalid HTML which meant it would still pass the smoke test for matching tags.
1. Fix logic to be more similar to other `<head>` tag merging (not sure why I made such an exception for styles over link or scripts 🤷 )
1. Update spec to validate it works with or without puppeteer