### PR TITLE
add configuration for prod server port

### DIFF
--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -7,7 +7,7 @@ const runProdServer = async () => {
 
     try {
       const compilation = await generateCompilation();
-      const port = 8080;
+      const port = compilation.config.port;
       const hasRoutes = compilation.graph.find(page => page.isSSR);
       const server = hasRoutes ? getHybridServer : getStaticServer;
 

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -7,7 +7,7 @@ import { fileURLToPath, pathToFileURL, URL } from 'url';
 const greenwoodPluginsBasePath = fileURLToPath(new URL('../plugins', import.meta.url));
 
 const greenwoodPlugins = (await Promise.all([
-  path.join(greenwoodPluginsBasePath, 'copy'),  
+  path.join(greenwoodPluginsBasePath, 'copy'),
   path.join(greenwoodPluginsBasePath, 'renderer'),
   path.join(greenwoodPluginsBasePath, 'resource'),
   path.join(greenwoodPluginsBasePath, 'server')
@@ -39,6 +39,7 @@ const defaultConfig = {
     port: 1984,
     extensions: []
   },
+  port: 8080,
   optimization: optimizations[0],
   title: 'My App',
   meta: [],
@@ -55,10 +56,10 @@ const readAndMergeConfig = async() => {
     try {
       // deep clone of default config
       let customConfig = Object.assign({}, defaultConfig);
-      
+
       if (fs.existsSync(path.join(process.cwd(), 'greenwood.config.js'))) {
         const userCfgFile = (await import(pathToFileURL(path.join(process.cwd(), 'greenwood.config.js')))).default;
-        const { workspace, devServer, title, markdown, meta, optimization, plugins, prerender, staticRouter, pagesDirectory, templatesDirectory } = userCfgFile;
+        const { workspace, devServer, title, markdown, meta, optimization, plugins, port, prerender, staticRouter, pagesDirectory, templatesDirectory } = userCfgFile;
 
         // workspace validation
         if (workspace) {
@@ -166,6 +167,15 @@ const readAndMergeConfig = async() => {
         if (markdown && Object.keys(markdown).length > 0) {
           customConfig.markdown.plugins = markdown.plugins && markdown.plugins.length > 0 ? markdown.plugins : [];
           customConfig.markdown.settings = markdown.settings ? markdown.settings : {};
+        }
+
+        if (port) {
+          // eslint-disable-next-line max-depth
+          if (!Number.isInteger(port)) {
+            reject(`Error: greenwood.config.js port must be an integer.  Passed value was: ${port}`);
+          } else {
+            customConfig.port = port;
+          }
         }
 
         if (pagesDirectory && typeof pagesDirectory === 'string') {

--- a/packages/cli/test/cases/serve.default/greenwood.config.js
+++ b/packages/cli/test/cases/serve.default/greenwood.config.js
@@ -3,5 +3,6 @@ export default {
     proxy: {
       '/api': 'https://www.analogstudios.net'
     }
-  }
+  },
+  port: 8181
 };

--- a/packages/cli/test/cases/serve.default/serve.default.spec.js
+++ b/packages/cli/test/cases/serve.default/serve.default.spec.js
@@ -9,7 +9,14 @@
  * greenwood serve
  *
  * User Config
- * None (Greenwood Default)
+ * {
+ *   devServer: {
+ *    proxy: {
+        '/api': 'https://www.analogstudios.net'
+      }
+ *   },
+ *   port: 8181
+ * }
  *
  * User Workspace
  * Greenwood default (src/)
@@ -28,7 +35,7 @@ describe('Serve Greenwood With: ', function() {
   const LABEL = 'Default Greenwood Configuration and Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
-  const hostname = 'http://127.0.0.1:8080';
+  const hostname = 'http://127.0.0.1:8181';
   let runner;
 
   before(function() {

--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -18,6 +18,7 @@ export default {
     port: 1984,
     host: 'localhost'
   },
+  port: 8080,
   markdown: {
     plugins: [],
     settings: {}
@@ -45,7 +46,7 @@ Configuration for Greenwood's development server is available using the `devServ
 export default {
   devServer: {
     extensions: ['.txt', '.rtf'],
-    port: 8181,
+    port: 3000,
     proxy: {
       '/api': 'https://stage.myapp.com',
       '/api/foo': 'https://foo.otherdomain.net'
@@ -152,6 +153,16 @@ By default the directory Greenwood will use to look for your local content is _p
 ```js
 export default {
   pagesDirectory: 'docs' // Greenwood will look for pages at src/docs/
+}
+```
+
+### Port
+Unlike the port option for `devServer` configuration, this option allows you to configure the port that your production server will run on when running `greenwood serve`.
+
+#### Example
+```js
+export default {
+  port: 8181
 }
 ```
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#708 

_**Question**: Should we make develop default port something more familiar like `3000`?_ - leaving it at `1984` 😄 

## Summary of Changes
1. Added the ability to customize server port
1. Added docs and serve spec