### PR TITLE
Chore/ci windows increase network timeout

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: ${{ matrix.node }}
     - name: Installing project dependencies
       run: |
-        yarn install --frozen-lockfile && yarn lerna bootstrap
+        yarn install --frozen-lockfile --network-timeout 1000000 && yarn lerna bootstrap
     - name: Lint
       run: |
         yarn lint


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Noticed we get a lot of intermitted timeouts on `yarn install` on Windows
- https://github.com/ProjectEvergreen/greenwood/runs/5074493269?check_suite_focus=true
- https://github.com/ProjectEvergreen/greenwood/runs/4903665306?check_suite_focus=true


## Summary of Changes
1. Increased network timeout for `yarn install` on Windows per suggestions so hoping this will help, [1](https://github.community/t/yarn-esockettimedout-on-windows/118776/3), [2](https://github.com/yarnpkg/yarn/issues/8242), [3](https://github.com/yarnpkg/yarn/issues/4890#issuecomment-358179301)