### PR TITLE
ensure SPA does not prerender by default

### DIFF
--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -218,6 +218,11 @@ const readAndMergeConfig = async() => {
             reject(`Error: greenwood.config.js staticRouter must be a boolean; true or false.  Passed value was typeof: ${typeof staticRouter}`);
           }
         }
+      } else {
+        // SPA should not prerender by default
+        if (fs.existsSync(path.join(customConfig.workspace, 'index.html'))) {
+          customConfig.prerender = false;
+        }
       }
 
       resolve({ ...defaultConfig, ...customConfig });

--- a/packages/cli/test/cases/build.default.spa/greenwood.config.js
+++ b/packages/cli/test/cases/build.default.spa/greenwood.config.js
@@ -1,3 +1,0 @@
-export default {
-  title: 'this is the wrong title'
-};


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #890 

## Summary of Changes
1. Handle SPA `prerender` setting when no _greenwood.config.js_ is present