### PR TITLE
short circuit depth check if current URL is already sufficient for `ResourceInterface.resolveRelativeUrl`

### DIFF
--- a/packages/cli/src/lib/resource-interface.js
+++ b/packages/cli/src/lib/resource-interface.js
@@ -18,6 +18,10 @@ class ResourceInterface {
   // turn relative paths into relatively absolute based on a known root directory
   // e.g. "../styles/theme.css" -> `${userWorkspace}/styles/theme.css`
   resolveRelativeUrl(root, url) {
+    if (fs.existsSync(path.join(root, url))) {
+      return url;
+    }
+
     let reducedUrl;
 
     url.split('/')


### PR DESCRIPTION
…race resolveRelativeUrl

<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

As part of https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/72, noticed that if I had a deep route like
`/albums/some-album-name/`

Deeply nested paths and relative directories were causing issues, lead to file being loaded like this from the browser
```sh
../albums/styles/theme.css
```

> This is more or less what #691 is an open discussion about

This of course can be solved in userland already but requires a conditional with the current `ResourceInterface.resolveRelativeUrl` because we start slicing and return `undefined`
```js
const location = this.resolveRelativeUrl(nodeModulesLocation, barePath) || barePath;
```

However, since the routing will always be dynamic, it would just a bit more ergonomic if `resolveRelativeUrl` could just help us out regardless of the scenario
```js
const location = this.resolveRelativeUrl(nodeModulesLocation, barePath)
```

## Summary of Changes
1. Make `ResourceInterface.resolveRelativeUrl` a little more ergonomic by just return the URL if it actually doesn't need to be resolved