### PR TITLE
underline and darken all links on the site

### DIFF
--- a/www/styles/theme.css
+++ b/www/styles/theme.css
@@ -42,9 +42,8 @@ ul > li {
 }
 
 a {
-  & .title {
-    text-decoration: underline;
-  }
+  color: #504b65;
+  text-decoration: underline;
 
   & .step {
     margin: 2px;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Still a little hard to read the links on the website, so make links a bit darker and underlined them all.  Open to other suggestions!

_Before_
<img width="1184" alt="Screen Shot 2022-02-20 at 12 31 00 PM" src="https://user-images.githubusercontent.com/895923/154855826-66d7db86-7489-4733-b710-63e4636dc07d.png">

_After_
<img width="1247" alt="Screen Shot 2022-02-20 at 12 30 50 PM" src="https://user-images.githubusercontent.com/895923/154855825-150222dd-6385-4162-9891-8532dacb837e.png">


## Summary of Changes
1. Matched color and added underline to all links on the site