### PR TITLE
set rollup context option to window

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -550,6 +550,7 @@ const getRollupConfig = async (compilation) => {
       chunkFileNames: '[name].[hash].js',
       sourcemap: true
     },
+    context: 'window',
     onwarn: (errorObj) => {
       const { code, message } = errorObj;
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #904 (tested on a handful of Greenwood projects)

## Summary of Changes
1. Set Rollup `context` to `'window'`