### PR TITLE
update `init` spec to reflect latest state of blog starter for content over configuration

### DIFF
--- a/packages/init/test/cases/init.template/init.template.spec.js
+++ b/packages/init/test/cases/init.template/init.template.spec.js
@@ -44,10 +44,6 @@ describe('Scaffold Greenwood From a (Blog) Template: ', function() {
         expect(fs.existsSync(path.join(outputPath, 'src', 'pages'))).to.be.true;
       });
 
-      it('should generate a greenwood.config.js file', function() {
-        expect(fs.existsSync(path.join(outputPath, 'greenwood.config.js'))).to.be.true;
-      });
-
       it('should generate a .gitignore file', function() {
         expect(fs.existsSync(path.join(outputPath, '.gitignore'))).to.be.true;
       });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#881 

## Summary of Changes
1. Per the above PR, merged the changes into **greenwood-template-blog** (https://github.com/ProjectEvergreen/greenwood-template-blog/pull/3) and needed to update the specs here