### PR TITLE
Feature/issue 916 auto install puppeteer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 .vscode/
 coverage/
 node_modules/
+packages/**/test/**/yarn.lock
+packages/**/test/**/package-lock.json
 public/

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "optionalDependency": {
+  "peerDependencies": {
     "puppeteer": "^10.2.0"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "puppeteer": "^10.2.0"
+  },
   "dependencies": {
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-replace": "^2.3.4",
@@ -62,6 +65,7 @@
     "lit-redux-router": "~0.20.0",
     "lodash-es": "^4.17.20",
     "postcss-nested": "^4.1.2",
+    "puppeteer": "^10.2.0",
     "pwa-helpers": "^0.9.1",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "peerDependencies": {
+  "optionalDependency": {
     "puppeteer": "^10.2.0"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,11 @@
   "peerDependencies": {
     "puppeteer": "^10.2.0"
   },
+  "peerDependenciesMeta": {
+    "puppeteer": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-replace": "^2.3.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,6 @@
     "node-html-parser": "^1.2.21",
     "postcss": "^8.3.11",
     "postcss-import": "^13.0.0",
-    "puppeteer": "^10.2.0",
     "rehype-raw": "^5.0.0",
     "rehype-stringify": "^8.0.0",
     "remark-frontmatter": "^2.0.0",

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -2,16 +2,14 @@ import { bundleCompilation } from '../lifecycles/bundle.js';
 import { copyAssets } from '../lifecycles/copy.js';
 import { getDevServer } from '../lifecycles/serve.js';
 import fs from 'fs';
-import { generateCompilation } from '../lifecycles/compile.js';
 import { preRenderCompilationCustom, preRenderCompilationDefault, staticRenderCompilation } from '../lifecycles/prerender.js';
 import { ServerInterface } from '../lib/server-interface.js';
 
-const runProductionBuild = async () => {
+const runProductionBuild = async (compilation) => {
 
   return new Promise(async (resolve, reject) => {
 
     try {
-      const compilation = await generateCompilation();
       const { prerender } = compilation.config;
       const port = compilation.config.devServer.port;
       const outputDir = compilation.context.outputDir;

--- a/packages/cli/src/commands/develop.js
+++ b/packages/cli/src/commands/develop.js
@@ -1,13 +1,11 @@
-import { generateCompilation } from '../lifecycles/compile.js';
 import { ServerInterface } from '../lib/server-interface.js';
 import { getDevServer } from '../lifecycles/serve.js';
 
-const runDevServer = async () => {
+const runDevServer = async (compilation) => {
 
   return new Promise(async (resolve, reject) => {
 
     try {
-      const compilation = await generateCompilation();
       const { port } = compilation.config.devServer;
       
       (await getDevServer(compilation)).listen(port, () => {

--- a/packages/cli/src/commands/eject.js
+++ b/packages/cli/src/commands/eject.js
@@ -1,12 +1,10 @@
 import fs from 'fs';
-import { generateCompilation } from '../lifecycles/compile.js';
 import path from 'path';
 import { fileURLToPath, URL } from 'url';
 
-const ejectConfiguration = async () => {
+const ejectConfiguration = async (compilation) => {
   return new Promise(async (resolve, reject) => {
     try {
-      const compilation = await generateCompilation();
       const configFilePath = fileURLToPath(new URL('../config', import.meta.url));
       const configFiles = fs.readdirSync(configFilePath);
       

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -1,12 +1,10 @@
-import { generateCompilation } from '../lifecycles/compile.js';
 import { getStaticServer, getHybridServer } from '../lifecycles/serve.js';
 
-const runProdServer = async () => {
+const runProdServer = async (compilation) => {
 
   return new Promise(async (resolve, reject) => {
 
     try {
-      const compilation = await generateCompilation();
       const port = compilation.config.port;
       const hasRoutes = compilation.graph.find(page => page.isSSR);
       const server = hasRoutes ? getHybridServer : getStaticServer;

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -69,7 +69,7 @@ const run = async() => {
     
     // auto install puppeteer if user has enabled prerendering and not installed it already
     console.debug('@@@@@@@@@@@@@@', path.join(process.cwd(), '/node_modules/puppeteer'));
-    console.debug('PUP UP', fs.existsSync(path.join(process.cwd(), '/node_modules/puppeteer')));
+    console.debug('PUP EXISTS', fs.existsSync(path.join(process.cwd(), '/node_modules/puppeteer')));
     if (compilation.config.prerender && !fs.existsSync(path.join(process.cwd(), '/node_modules/puppeteer'))) {
       console.log('prerender configuration detected but puppeteer is not installed');
       console.log('attempting to auto-install puppeteer...');
@@ -98,7 +98,7 @@ const run = async() => {
           });
         });
       } catch (err) {
-        console.error('not able to handle installing puppeteer', err); // TODO provide manual step
+        console.error('not able to handle installing puppeteer', err); // TODO provide manual steps
       }
     }
 
@@ -115,7 +115,7 @@ const run = async() => {
       case 'serve':
         process.env.__GWD_COMMAND__ = 'build';
 
-        await (await import('./commands/build.js')).runProductionBuild(compilation);
+        await (await import('./commands/build.js')).runProductionBuild(Object.assign({}, compilation));
         await (await import('./commands/serve.js')).runProdServer(compilation);
 
         break;

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -68,29 +68,25 @@ const run = async() => {
     process.env.__GWD_COMMAND__ = command;
     
     // auto install puppeteer if user has enabled prerendering and not installed it already
-    console.debug('@@@@@@@@@@@@@@', path.join(process.cwd(), '/node_modules/puppeteer'));
-    console.debug('PUP EXISTS', fs.existsSync(path.join(process.cwd(), '/node_modules/puppeteer')));
     if (compilation.config.prerender && !fs.existsSync(path.join(process.cwd(), '/node_modules/puppeteer'))) {
       console.log('prerender configuration detected but puppeteer is not installed');
       console.log('attempting to auto-install puppeteer...');
       const os = await import('os');
       const spawn = (await import('child_process')).spawn;
-      const pkgMng = 'yarn'; // TODO program.yarn ? 'yarn' : 'npm'; // default to npm
-      const command = pkgMng === 'yarn' ? 'add' : 'install --dev';
-      const suffix = pkgMng === 'yarn' ? '--save-dev' : '--save-dev'; // TODO
+      const pkgMng = fs.existsSync(path.join(process.cwd(), 'yarn.lock')) ? 'yarn' : 'npm';
+      const command = pkgMng === 'yarn' ? 'add' : 'install';
+      const suffix = pkgMng === 'yarn' ? '--dev' : '--save-dev';
       const pkgCommand = os.platform() === 'win32' ? `${pkgMng}.cmd` : pkgMng;
-      const args = [command, `puppeteer@^10.2.0 ${suffix}`]; // TODO pull version from Greenwood
+      const args = [command, 'puppeteer@^10.2.0', suffix]; // TODO pull version from Greenwood
 
       try {
         await new Promise((resolve, reject) => {
 
-          const process = spawn(pkgCommand, args, { stdio: 'ignore' });
+          const childProcess = spawn(pkgCommand, args, { stdio: 'ignore' });
 
-          process.on('close', code => {
+          childProcess.on('close', code => {
             if (code !== 0) {
-              reject({
-                command: `${pkgCommand} ${args.join(' ')}`
-              });
+              reject();
               return;
             }
             console.log('auto installation successful!');
@@ -98,7 +94,7 @@ const run = async() => {
           });
         });
       } catch (err) {
-        console.error('not able to handle installing puppeteer', err); // TODO provide manual steps
+        console.error('not able to handle installing puppeteer'); // TODO provide manual steps
       }
     }
 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -71,17 +71,17 @@ const run = async() => {
     if (compilation.config.prerender && !fs.existsSync(path.join(process.cwd(), '/node_modules/puppeteer'))) {
       console.log('prerender configuration detected but puppeteer is not installed.');
       console.log('attempting to auto-install puppeteer...');
-      const os = await import('os');
-      const spawn = (await import('child_process')).spawn;
-      const pkgMng = fs.existsSync(path.join(process.cwd(), 'yarn.lock')) ? 'yarn' : 'npm';
-      const command = pkgMng === 'yarn' ? 'add' : 'install';
-      const suffix = pkgMng === 'yarn' ? '--dev' : '--save-dev';
-      const pkgCommand = os.platform() === 'win32' ? `${pkgMng}.cmd` : pkgMng;
-      const args = [command, 'puppeteer@^10.2.0', suffix]; // TODO pull version from Greenwood
 
       try {
-        await new Promise((resolve, reject) => {
-
+        await new Promise(async (resolve, reject) => {
+          const os = await import('os');
+          const spawn = (await import('child_process')).spawn;
+          const pkgMng = fs.existsSync(path.join(process.cwd(), 'yarn.lock')) ? 'yarn' : 'npm';
+          const command = pkgMng === 'yarn' ? 'add' : 'install';
+          const commandFlags = pkgMng === 'yarn' ? '--dev' : '--save-dev';
+          const pkgCommand = os.platform() === 'win32' ? `${pkgMng}.cmd` : pkgMng;
+          const puppeteerVersion = greenwoodPackageJson.peerDependencies.puppeteer;
+          const args = [command, `puppeteer@${puppeteerVersion}`, commandFlags];
           const childProcess = spawn(pkgCommand, args, { stdio: 'ignore' });
 
           childProcess.on('close', code => {
@@ -93,7 +93,7 @@ const run = async() => {
             resolve();
           });
         });
-      } catch (err) {
+      } catch (e) {
         console.error('Sorry, we were not able to handle auto-installing puppeteer.');
         console.log('Please visit our website for more information on self-installation: https://www.greenwoodjs.io/docs/configuration/#prerender');
       }

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -7,6 +7,7 @@ process.setMaxListeners(0);
 
 import { generateCompilation } from './lifecycles/compile.js';
 import fs from 'fs';
+import path from 'path';
 import program from 'commander';
 import { URL } from 'url';
 
@@ -67,13 +68,18 @@ const run = async() => {
     process.env.__GWD_COMMAND__ = command;
     
     // auto install puppeteer if user has enabled prerendering and not installed it already
-    if (compilation.config.prerender && !fs.existsSync(new URL('./node_modules/puppeteer', import.meta.url))) {
+    console.debug('@@@@@@@@@@@@@@', path.join(process.cwd(), '/node_modules/puppeteer'));
+    console.debug('PUP UP', fs.existsSync(path.join(process.cwd(), '/node_modules/puppeteer')));
+    if (compilation.config.prerender && !fs.existsSync(path.join(process.cwd(), '/node_modules/puppeteer'))) {
+      console.log('prerender configuration detected but puppeteer is not installed');
+      console.log('attempting to auto-install puppeteer...');
       const os = await import('os');
       const spawn = (await import('child_process')).spawn;
       const pkgMng = 'yarn'; // TODO program.yarn ? 'yarn' : 'npm'; // default to npm
-      const command = pkgMng === 'yarn' ? 'add' : 'install';
+      const command = pkgMng === 'yarn' ? 'add' : 'install --dev';
+      const suffix = pkgMng === 'yarn' ? '--save-dev' : '--save-dev'; // TODO
       const pkgCommand = os.platform() === 'win32' ? `${pkgMng}.cmd` : pkgMng;
-      const args = [command, 'puppeteer@^10.2.0']; // TODO pull version from Greenwood
+      const args = [command, `puppeteer@^10.2.0 ${suffix}`]; // TODO pull version from Greenwood
 
       try {
         await new Promise((resolve, reject) => {
@@ -87,7 +93,7 @@ const run = async() => {
               });
               return;
             }
-            console.debug('auto installation successful!');
+            console.log('auto installation successful!');
             resolve();
           });
         });

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -69,7 +69,7 @@ const run = async() => {
     
     // auto install puppeteer if user has enabled prerendering and not installed it already
     if (compilation.config.prerender && !fs.existsSync(path.join(process.cwd(), '/node_modules/puppeteer'))) {
-      console.log('prerender configuration detected but puppeteer is not installed');
+      console.log('prerender configuration detected but puppeteer is not installed.');
       console.log('attempting to auto-install puppeteer...');
       const os = await import('os');
       const spawn = (await import('child_process')).spawn;
@@ -94,7 +94,8 @@ const run = async() => {
           });
         });
       } catch (err) {
-        console.error('not able to handle installing puppeteer'); // TODO provide manual steps
+        console.error('Sorry, we were not able to handle auto-installing puppeteer.');
+        console.log('Please visit our website for more information on self-installation: https://www.greenwoodjs.io/docs/configuration/#prerender');
       }
     }
 

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -40,8 +40,7 @@ async function getNodeModulesLocationForPackage(packageName) {
     }
 
     if (!nodeModulesUrl) {
-      console.debug(`Unable to look up ${packageName} using NodeJS require.resolve.  Falling back to process.cwd()`);
-      // TODO nodeModulesUrl = path.join(process.cwd(), 'node_modules', packageName);
+      console.debug(`Unable to look up ${packageName} using NodeJS require.resolve.`);
     }
   }
 

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -1,5 +1,6 @@
 import { createRequire } from 'module'; // https://stackoverflow.com/a/62499498/417806
 import fs from 'fs';
+import path from 'path';
 
 // defer to NodeJS to find where on disk a package is located using import.meta.resolve
 // and return the root absolute location
@@ -40,7 +41,8 @@ async function getNodeModulesLocationForPackage(packageName) {
     }
 
     if (!nodeModulesUrl) {
-      console.debug(`Unable to look up ${packageName} using NodeJS require.resolve.`);
+      console.debug(`Unable to look up ${packageName} using NodeJS require.resolve.  Falling back to process.cwd()`);
+      nodeModulesUrl = path.join(process.cwd(), 'node_modules', packageName);
     }
   }
 

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -1,6 +1,5 @@
 import { createRequire } from 'module'; // https://stackoverflow.com/a/62499498/417806
 import fs from 'fs';
-import path from 'path';
 
 // defer to NodeJS to find where on disk a package is located using import.meta.resolve
 // and return the root absolute location
@@ -42,7 +41,7 @@ async function getNodeModulesLocationForPackage(packageName) {
 
     if (!nodeModulesUrl) {
       console.debug(`Unable to look up ${packageName} using NodeJS require.resolve.  Falling back to process.cwd()`);
-      nodeModulesUrl = path.join(process.cwd(), 'node_modules', packageName);
+      // TODO nodeModulesUrl = path.join(process.cwd(), 'node_modules', packageName);
     }
   }
 

--- a/packages/cli/src/lib/walker-package-ranger.js
+++ b/packages/cli/src/lib/walker-package-ranger.js
@@ -199,6 +199,8 @@ async function walkPackageJson(packageJson = {}) {
 
         await walkPackageJson(dependencyPackageJson);
       } else {
+        console.debug({ absoluteNodeModulesLocation });
+        console.debug({ entry });
         const packageEntryPointPath = path.join(absoluteNodeModulesLocation, entry);
 
         // sometimes a main file is actually just an empty string... :/

--- a/packages/cli/src/lib/walker-package-ranger.js
+++ b/packages/cli/src/lib/walker-package-ranger.js
@@ -199,8 +199,6 @@ async function walkPackageJson(packageJson = {}) {
 
         await walkPackageJson(dependencyPackageJson);
       } else {
-        console.debug({ absoluteNodeModulesLocation });
-        console.debug({ entry });
         const packageEntryPointPath = path.join(absoluteNodeModulesLocation, entry);
 
         // sometimes a main file is actually just an empty string... :/

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -1,4 +1,3 @@
-import { BrowserRunner } from '../lib/browser.js';
 import fs from 'fs';
 import { hashString } from '../lib/hashing-utils.js';
 import path from 'path';
@@ -256,14 +255,6 @@ async function getStaticServer(compilation, composable) {
 
 async function getHybridServer(compilation) {
   const app = await getStaticServer(compilation, true);
-  const { prerender } = compilation.config;
-  let browserRunner;
-
-  if (prerender) {
-    browserRunner = new BrowserRunner();
-
-    await browserRunner.init();
-  }
 
   app.use(async (ctx) => {
     const url = ctx.request.url.replace(/\?(.*)/, ''); // get rid of things like query string parameters

--- a/packages/cli/test/cases/build.config.optimization-static/build.config-optimization-static.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-static/build.config-optimization-static.spec.js
@@ -25,7 +25,7 @@ import chai from 'chai';
 import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
-import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -47,6 +47,9 @@ describe('Build Greenwood With: ', function() {
   describe(LABEL, function() {
 
     before(async function() {
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
+
       await runner.setup(outputPath, getSetupFiles(outputPath));
       await runner.runCommand(cliPath, 'build');
     });

--- a/packages/cli/test/cases/build.config.prerender/build.config.prerender.spec.js
+++ b/packages/cli/test/cases/build.config.prerender/build.config.prerender.spec.js
@@ -24,7 +24,7 @@ import chai from 'chai';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -46,6 +46,11 @@ describe('Build Greenwood With: ', function() {
   describe(LABEL, function() {
 
     before(async function() {
+      // TODO would like to actually have puppeteer auto install happen as part of the test, but gallinago cleanup does not seem to run
+      // and then tests fail the next time because of no type="module" in package.json
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
+
       await runner.setup(outputPath, getSetupFiles(outputPath));
       await runner.runCommand(cliPath, 'build');
     });

--- a/packages/cli/test/cases/build.config.prerender/build.config.prerender.spec.js
+++ b/packages/cli/test/cases/build.config.prerender/build.config.prerender.spec.js
@@ -21,10 +21,11 @@
  *     index.html
  */
 import chai from 'chai';
+import fs from 'fs/promises';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { copyDirectory, getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { getSetupFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -46,11 +47,6 @@ describe('Build Greenwood With: ', function() {
   describe(LABEL, function() {
 
     before(async function() {
-      // TODO would like to actually have puppeteer auto install happen as part of the test, but gallinago cleanup does not seem to run
-      // and then tests fail the next time because of no type="module" in package.json
-      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
-      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
-
       await runner.setup(outputPath, getSetupFiles(outputPath));
       await runner.runCommand(cliPath, 'build');
     });
@@ -118,9 +114,15 @@ describe('Build Greenwood With: ', function() {
         expect(header[0].textContent).to.equal('This is the header component.');
       });
     });
-  });
 
-  after(function() {
-    runner.teardown(getOutputTeardownFiles(outputPath));
+    after(async function() {
+      // using unlink instead of runner.teardown since when auto-install puppeteer
+      // our spawned process of a spawned process does not clean up as expected
+      await fs.unlink(path.join(outputPath, 'package.json'));
+      await fs.unlink(path.join(outputPath, 'package-lock.json'));
+      await fs.rm(path.join(outputPath, '.greenwood'), { recursive: true, force: true });
+      await fs.rm(path.join(outputPath, 'node_modules'), { recursive: true, force: true });
+      await fs.rm(path.join(outputPath, 'public'), { recursive: true, force: true });
+    });
   });
 });

--- a/packages/cli/test/cases/build.config.prerender/build.config.prerender.spec.js
+++ b/packages/cli/test/cases/build.config.prerender/build.config.prerender.spec.js
@@ -118,8 +118,8 @@ describe('Build Greenwood With: ', function() {
     after(async function() {
       // using unlink instead of runner.teardown since when auto-install puppeteer
       // our spawned process of a spawned process does not clean up as expected
-      await fs.unlink(path.join(outputPath, 'package.json'));
-      await fs.unlink(path.join(outputPath, 'package-lock.json'));
+      await fs.rm(path.join(outputPath, 'package.json'), { recursive: true, force: true });
+      await fs.rm(path.join(outputPath, 'package-lock.json'), { recursive: true, force: true });
       await fs.rm(path.join(outputPath, '.greenwood'), { recursive: true, force: true });
       await fs.rm(path.join(outputPath, 'node_modules'), { recursive: true, force: true });
       await fs.rm(path.join(outputPath, 'public'), { recursive: true, force: true });

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -267,7 +267,7 @@ describe('Build Greenwood With: ', function() {
         expect(await glob.promise(path.join(this.context.publicDir, 'lit-element.*.js'))).to.have.lengthOf(1);
       });
 
-      it('should have the expected inline node_modules content in the first inline script', async function() {
+      xit('should have the expected inline node_modules content in the first inline script', async function() {
         const inlineScriptTag = dom.window.document.querySelectorAll('head > script:not([src])')[0];
         
         expect(inlineScriptTag.textContent.replace('\n', '')).to
@@ -275,7 +275,7 @@ describe('Build Greenwood With: ', function() {
           .equal('import"/lit-element.ae169679.js";import"/lit-html.7f7a9139.js";document.getElementsByClassName("output-script-inline")[0].innerHTML="script tag module inline"//# sourceMappingURL=1807818843-scratch.ee52d4f0.js.map');
       });
 
-      it('should have the expected inline node_modules content in the second inline script tag which should include extra code from rollup', async function() {
+      xit('should have the expected inline node_modules content in the second inline script tag which should include extra code from rollup', async function() {
         const inlineScriptTag = dom.window.document.querySelectorAll('head > script:not([src])')[1];
 
         expect(inlineScriptTag.textContent.replace('\n', '')).to.equal('import"/lit-element.ae169679.js";import"/lit-html.7f7a9139.js";//# sourceMappingURL=2012376258-scratch.0a6fc17c.js.map');

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -23,7 +23,7 @@ import chai from 'chai';
 import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
-import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -161,9 +161,15 @@ describe('Build Greenwood With: ', function() {
         `${outputPath}/node_modules/simpledotcss/`
       );
       const prismCss = await getDependencyFiles(
-        `${process.cwd()}/node_modules/prismjs/themes/prism-tomorrow.css`, 
+        `${process.cwd()}/node_modules/prismjs/themes/prism-tomorrow.css`,
         `${outputPath}/node_modules/prismjs/themes/`
       );
+      const prismPackageJson = await getDependencyFiles(
+        `${process.cwd()}/node_modules/prismjs/package.json`, 
+        `${outputPath}/node_modules/prismjs/`
+      );
+
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
 
       await runner.setup(outputPath, [
         ...getSetupFiles(outputPath),
@@ -194,6 +200,7 @@ describe('Build Greenwood With: ', function() {
         ...pwaHelpersPackageJson,    
         ...pwaHelpersLibs,
         ...prismCss,
+        ...prismPackageJson,
         ...simpleCss,
         ...simpleCssPackageJson
       ]);
@@ -267,7 +274,7 @@ describe('Build Greenwood With: ', function() {
         expect(await glob.promise(path.join(this.context.publicDir, 'lit-element.*.js'))).to.have.lengthOf(1);
       });
 
-      xit('should have the expected inline node_modules content in the first inline script', async function() {
+      it('should have the expected inline node_modules content in the first inline script', async function() {
         const inlineScriptTag = dom.window.document.querySelectorAll('head > script:not([src])')[0];
         
         expect(inlineScriptTag.textContent.replace('\n', '')).to
@@ -275,7 +282,7 @@ describe('Build Greenwood With: ', function() {
           .equal('import"/lit-element.ae169679.js";import"/lit-html.7f7a9139.js";document.getElementsByClassName("output-script-inline")[0].innerHTML="script tag module inline"//# sourceMappingURL=1807818843-scratch.ee52d4f0.js.map');
       });
 
-      xit('should have the expected inline node_modules content in the second inline script tag which should include extra code from rollup', async function() {
+      it('should have the expected inline node_modules content in the second inline script tag which should include extra code from rollup', async function() {
         const inlineScriptTag = dom.window.document.querySelectorAll('head > script:not([src])')[1];
 
         expect(inlineScriptTag.textContent.replace('\n', '')).to.equal('import"/lit-element.ae169679.js";import"/lit-html.7f7a9139.js";//# sourceMappingURL=2012376258-scratch.0a6fc17c.js.map');

--- a/packages/cli/test/cases/build.default.import-node-modules/package.json
+++ b/packages/cli/test/cases/build.default.import-node-modules/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "lit": "^2.0.0",
     "lodash-es": "^4.17.20",
+    "prismjs": "^1.21.0",
     "pwa-helpers": "^0.9.1",
     "redux": "^4.0.5",
     "simpledotcss": "^1.0.0"

--- a/packages/cli/test/cases/build.default.workspace-frontmatter-imports/build.default.workspace-frontmatter-imports.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-frontmatter-imports/build.default.workspace-frontmatter-imports.spec.js
@@ -30,7 +30,7 @@ import fs from 'fs';
 import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
-import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
@@ -53,6 +53,9 @@ describe('Build Greenwood With: ', function() {
   describe(LABEL, function() {
 
     before(async function() {
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
+
       await runner.setup(outputPath, getSetupFiles(outputPath));
       await runner.runCommand(cliPath, 'build');
     });

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -28,7 +28,7 @@ import chai from 'chai';
 import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
-import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -51,6 +51,9 @@ describe('Build Greenwood With: ', function() {
     let dom;
 
     before(async function() {
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
+
       await runner.setup(outputPath, getSetupFiles(outputPath));
       await runner.runCommand(cliPath, 'build');
 

--- a/packages/cli/test/cases/build.plugins.resource/build.config.plugins-resource.spec.js
+++ b/packages/cli/test/cases/build.plugins.resource/build.config.plugins-resource.spec.js
@@ -33,7 +33,7 @@
 import chai from 'chai';
 import { JSDOM } from 'jsdom';
 import path from 'path';
-import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -54,6 +54,9 @@ describe('Build Greenwood With: ', function() {
 
   describe(LABEL, function() {
     before(async function() {
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
+
       await runner.setup(outputPath, getSetupFiles(outputPath));
       await runner.runCommand(cliPath, 'build');
     });

--- a/packages/plugin-graphql/test/cases/query-children/query-children.spec.js
+++ b/packages/plugin-graphql/test/cases/query-children/query-children.spec.js
@@ -30,7 +30,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -119,6 +119,9 @@ describe('Build Greenwood With: ', function() {
         `${process.cwd()}/node_modules/@lit/reactive-element/package.json`, 
         `${outputPath}/node_modules/@lit/reactive-element/`
       );
+
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
 
       await runner.setup(outputPath, [
         ...getSetupFiles(outputPath),

--- a/packages/plugin-graphql/test/cases/query-config/query-config.spec.js
+++ b/packages/plugin-graphql/test/cases/query-config/query-config.spec.js
@@ -26,7 +26,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -57,6 +57,9 @@ describe('Build Greenwood With: ', function() {
         `${process.cwd()}/packages/plugin-graphql/src/queries/*.gql`, 
         `${outputPath}/node_modules/@greenwood/plugin-graphql/src/queries/`
       );
+
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
 
       await runner.setup(outputPath, [ 
         ...getSetupFiles(outputPath),

--- a/packages/plugin-graphql/test/cases/query-custom-frontmatter/query-custom-frontmatter.spec.js
+++ b/packages/plugin-graphql/test/cases/query-custom-frontmatter/query-custom-frontmatter.spec.js
@@ -32,7 +32,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -121,6 +121,9 @@ describe('Build Greenwood With: ', function() {
         `${process.cwd()}/node_modules/@lit/reactive-element/package.json`, 
         `${outputPath}/node_modules/@lit/reactive-element/`
       );
+
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
 
       await runner.setup(outputPath, [
         ...getSetupFiles(outputPath),

--- a/packages/plugin-graphql/test/cases/query-custom-schema/query-custom-schema.spec.js
+++ b/packages/plugin-graphql/test/cases/query-custom-schema/query-custom-schema.spec.js
@@ -27,7 +27,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -54,6 +54,9 @@ describe('Build Greenwood With: ', function() {
         `${process.cwd()}/packages/plugin-graphql/src/core/*.js`, 
         `${outputPath}/node_modules/@greenwood/plugin-graphql/src/core/`
       );
+
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
 
       await runner.setup(outputPath, [
         ...getSetupFiles(outputPath),

--- a/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
+++ b/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
@@ -28,7 +28,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -118,6 +118,7 @@ describe('Build Greenwood With: ', function() {
         `${outputPath}/node_modules/@lit/reactive-element/`
       );
 
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
       await runner.setup(outputPath, [
         ...getSetupFiles(outputPath),
         ...greenwoodGraphqlCoreLibs,

--- a/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
+++ b/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
@@ -118,7 +118,9 @@ describe('Build Greenwood With: ', function() {
         `${outputPath}/node_modules/@lit/reactive-element/`
       );
 
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
       await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
+
       await runner.setup(outputPath, [
         ...getSetupFiles(outputPath),
         ...greenwoodGraphqlCoreLibs,

--- a/packages/plugin-graphql/test/cases/query-menu/query-menu.spec.js
+++ b/packages/plugin-graphql/test/cases/query-menu/query-menu.spec.js
@@ -30,7 +30,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -119,6 +119,9 @@ describe('Build Greenwood With: ', async function() {
         `${process.cwd()}/node_modules/@lit/reactive-element/package.json`, 
         `${outputPath}/node_modules/@lit/reactive-element/`
       );
+
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
 
       await runner.setup(outputPath, [
         ...getSetupFiles(outputPath),

--- a/packages/plugin-import-commonjs/test/cases/default/default.spec.js
+++ b/packages/plugin-import-commonjs/test/cases/default/default.spec.js
@@ -30,7 +30,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -59,6 +59,9 @@ describe('Build Greenwood With: ', function() {
         `${process.cwd()}/node_modules/lodash/package.json`, 
         `${outputPath}/node_modules/lodash/`
       );
+
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
 
       await runner.setup(outputPath, [
         ...getSetupFiles(outputPath),

--- a/packages/plugin-import-css/test/cases/default/default.spec.js
+++ b/packages/plugin-import-css/test/cases/default/default.spec.js
@@ -29,7 +29,7 @@ import chai from 'chai';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -50,6 +50,9 @@ describe('Build Greenwood With: ', function() {
 
   describe(LABEL, function() {
     before(async function() {
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
+
       await runner.setup(outputPath, getSetupFiles(outputPath));
       await runner.runCommand(cliPath, 'build');
     });

--- a/packages/plugin-import-json/test/cases/default/default.spec.js
+++ b/packages/plugin-import-json/test/cases/default/default.spec.js
@@ -31,7 +31,7 @@ import chai from 'chai';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { copyDirectory, getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath, URL } from 'url';
 
@@ -52,6 +52,9 @@ describe('Build Greenwood With: ', function() {
 
   describe(LABEL, function() {
     before(async function() {
+      // stub puppeteer dependency to avoid package manager installation when running specs that need prerendering
+      await copyDirectory(`${process.cwd()}/node_modules/puppeteer`, `${outputPath}node_modules/puppeteer`);
+
       await runner.setup(outputPath, getSetupFiles(outputPath));
       await runner.runCommand(cliPath, 'build');
     });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,37 @@
+import fs from 'fs';
 import glob from 'glob-promise';
 import path from 'path';
+
+async function rreaddir (dir, allFiles = []) {
+  const files = (await fs.promises.readdir(dir)).map(f => path.join(dir, f));
+
+  allFiles.push(...files);
+
+  await Promise.all(files.map(async f => (
+    await fs.promises.stat(f)).isDirectory() && rreaddir(f, allFiles
+  )));
+
+  return allFiles;
+}
+
+// https://stackoverflow.com/a/30405105/417806
+async function copyFile(source, target) {
+  const rd = fs.createReadStream(source);
+  const wr = fs.createWriteStream(target);
+
+  try {
+    return await new Promise((resolve, reject) => {
+      rd.on('error', reject);
+      wr.on('error', reject);
+      wr.on('finish', resolve);
+      rd.pipe(wr);
+    });
+  } catch (error) {
+    console.error('ERROR', error);
+    rd.destroy();
+    wr.end();
+  }
+}
 
 function tagsMatch(tagName, html, expected = null) {
   const openTagRegex = new RegExp(`<${tagName}`, 'g');
@@ -40,9 +72,33 @@ async function getDependencyFiles(sourcePath, outputPath) {
   });
 }
 
+async function copyDirectory(sourcePath, outputPath) {
+  const sourceContents = await rreaddir(sourcePath);
+
+  console.debug({ sourcePath });
+  console.debug({ outputPath });
+
+  await fs.promises.mkdir(outputPath, { recursive: true });
+
+  sourceContents.forEach((filepath) => {
+    const target = decodeURIComponent(path.normalize(filepath.replace(sourcePath, outputPath)));
+    const stats = fs.lstatSync(filepath);
+
+    console.debug({ filepath });
+    console.debug({ target });
+    if (stats.isDirectory() && (!filepath.endsWith('Contents') || !filepath.endsWith('LICENSE')) && !fs.existsSync(target)) {
+      console.debug('mkdir', target);
+      fs.mkdirSync(target);
+    } else if (stats.isFile()) {
+      copyFile(filepath, target);
+    }
+  });
+}
+
 export {
   getDependencyFiles,
   getOutputTeardownFiles,
   getSetupFiles,
+  copyDirectory,
   tagsMatch
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -78,7 +78,7 @@ async function copyDirectory(sourcePath, outputPath) {
   await fs.promises.mkdir(outputPath, { recursive: true });
 
   for (const filepath of sourceRootFiles) {
-    const target = filepath.replace(sourcePath, outputPath);
+    const target = filepath.replace(path.normalize(sourcePath), path.normalize(outputPath));
     const stats = fs.lstatSync(filepath);
 
     // TODO possible race condition?

--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -186,7 +186,7 @@ export default {
 }
 ```
 
-_You will need to install puppeteer to use this feature_, as given how heavy the dependency of a full browser is, Greenwood does not install puppeteer by default.  Greenwood will try and install it for you automatically if you set this to `true` and have not installed it yourself, but if that fails or there are any issues with auto-installation, you can just install it with your favorite preferred manager.
+Given how heavy the dependency of a full browser is, _you will need to have puppeteer installed to use this feature_,as Greenwood does not include puppeteer by default.  Greenwood _will_ try and install it for you automatically if you set this to `true` and have not installed it already, but if that fails for any reason, you can just install it with your preferred manager.
 ```shell
 # npm
 $ npm install puppeteer --save-dev

--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -175,7 +175,7 @@ export default {
 
 ### Prerender
 
-Though `false` by default, when this feature is enabled, [Greenwood will pre-render](/about/how-it-works/) your application using a browser, including your _runtime_ JavaScript (Web Components, GraphQL calls, etc) across all your pages and capture the output as part of the final static HTML build output.
+Though `false` by default, when this feature is enabled, [Greenwood will pre-render](/about/how-it-works/) your application using a browser (**puppeteer**), including your _runtime_ JavaScript (Web Components, GraphQL calls, etc) across all your pages and capture the output as part of the final static HTML build output.
 
 You can combine this with ["static" components](/docs/configuration/#optimization) so that you can just do single pass rendering of your Web Components and get their output as static HTML and CSS at build time without having to ship any runtime JavaScript!
 
@@ -186,7 +186,16 @@ export default {
 }
 ```
 
-> _**As of now, if you are using [plugin-graphql](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-graphql) you cannot change this setting.**  We are working on improving support for server [side rendering and templating](https://github.com/ProjectEvergreen/greenwood/discussions/576) (with Web Components) as part of our [1.0 release](https://github.com/ProjectEvergreen/greenwood/milestone/3)._
+_You will need to install puppeteer to use this feature_, as given how heavy the dependency of a full browser is, Greenwood does not install puppeteer by default.  Greenwood will try and install it for you automatically if you set this to `true` and have not installed it yourself, but if that fails or there are any issues with auto-installation, you can just install it with your favorite preferred manager.
+```sh
+# npm
+$ npm install puppeteer --save-dev
+
+# yarn
+$ yarn add puppeteer --dev
+```
+
+> _**As of now, if you are using [plugin-graphql](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-graphql) you must set this to `true`.**  We are working on improving support for server [side rendering and templating](https://github.com/ProjectEvergreen/greenwood/discussions/576) (with Web Components) as part of our [1.0 release](https://github.com/ProjectEvergreen/greenwood/milestone/3)._
 
 ### Static Router
 

--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -187,7 +187,7 @@ export default {
 ```
 
 _You will need to install puppeteer to use this feature_, as given how heavy the dependency of a full browser is, Greenwood does not install puppeteer by default.  Greenwood will try and install it for you automatically if you set this to `true` and have not installed it yourself, but if that fails or there are any issues with auto-installation, you can just install it with your favorite preferred manager.
-```sh
+```shell
 # npm
 $ npm install puppeteer --save-dev
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #916  (alternative to #860 )

> _Assuming all this works, like `init`, this will be very coupled to package manager solutions (npm, yarn, pnpm, etc), so how many will we need to detect and support?  As opposed to just providing a simple documentation step?_

## Summary of Changes
1. Made **puppeteer** an `peerDependency` using [`peerDependencyMeta`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta), since package managers will still try and install `optionalDependencies` from what I can tell
1. Implemented basic detection solution and auto install solution (refactored _cli/index.js_ to lazily load command scripts)

## TODO
1. [x] All `prerender` config dependent tests needs to get scaffolded accordingly
1. [x] save puppeteer as `devDependency` (and test)
1. [x] Fix windows specs
1. [x] Finalize best way to track **puppeteer** as a dependency ([`peerDeps`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependencies) will raise errors in npm and require flags and isn't required as such, [`optionalDeps`](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#optionaldependencies) will still try and be installed too...???)
1. [x] Get version of puppeteer from Greenwood _package.json_
1. [x] Detect `yarn` vs `npm`
1. [x] Provide / link to manual instructions if can't auto install in error message
1. [x] Documentation
1. [x] Found an issue with `buffer` package not working with `require.resolve` and had to use a fallback (will make its own issue / PR and will break theme pack specs) - https://github.com/ProjectEvergreen/greenwood/issues/919
1. [x] (nice to have) See if preprender spec can actually run auto-install feature
1. [ ] (nice to have) intermittent race condition in `copyDirectory`, at least when using with puppeteer for specs