### PR TITLE
Enhancement/issue 919 node modules location lookup fallback

### DIFF
--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -42,7 +42,7 @@ async function getNodeModulesLocationForPackage(packageName) {
 
     if (!nodeModulesUrl) {
       console.debug(`Unable to look up ${packageName} using NodeJS require.resolve.  Falling back to process.cwd()`);
-      nodeModulesUrl = path.join(process.cwd(), 'node_modules', packageName);
+      nodeModulesUrl = path.join(process.cwd(), 'node_modules', packageName.replace(/\\/g, '/')); // force / for consistency and path matching);
     }
   }
 

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -42,7 +42,7 @@ async function getNodeModulesLocationForPackage(packageName) {
 
     if (!nodeModulesUrl) {
       console.debug(`Unable to look up ${packageName} using NodeJS require.resolve.  Falling back to process.cwd()`);
-      nodeModulesUrl = path.join(process.cwd(), 'node_modules', packageName.replace(/\\/g, '/')); // force / for consistency and path matching);
+      nodeModulesUrl = path.join(process.cwd(), 'node_modules', packageName); // force / for consistency and path matching);
     }
   }
 

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -1,5 +1,6 @@
 import { createRequire } from 'module'; // https://stackoverflow.com/a/62499498/417806
 import fs from 'fs';
+import path from 'path';
 
 // defer to NodeJS to find where on disk a package is located using import.meta.resolve
 // and return the root absolute location
@@ -40,7 +41,8 @@ async function getNodeModulesLocationForPackage(packageName) {
     }
 
     if (!nodeModulesUrl) {
-      console.debug(`Unable to look up ${packageName} using NodeJS require.resolve.`);
+      console.debug(`Unable to look up ${packageName} using NodeJS require.resolve.  Falling back to process.cwd()`);
+      nodeModulesUrl = path.join(process.cwd(), 'node_modules', packageName);
     }
   }
 

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -3,7 +3,7 @@
  * Run Greenwood with and loading different references to node_module types to ensure proper support.
  * Sets prerender: true to validate the functionality.
  * 
- * Uaer Result
+ * User Result
  * Should generate a bare bones Greenwood build without erroring.
  *
  * User Command

--- a/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
+++ b/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
@@ -1,7 +1,6 @@
 // shared from another test
 import fs from 'fs';
 import { myThemePackPlugin } from '../build.plugins.context/theme-pack-context-plugin.js';
-import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import { URL } from 'url';
 
@@ -18,7 +17,7 @@ class MyThemePackDevelopmentResource extends ResourceInterface {
   }
 
   async resolve(url) {
-    return Promise.resolve(url.replace(`/node_modules/${packageName}/dist/`, path.join(process.cwd(), '/fixtures/')));
+    return Promise.resolve(url.replace(`/node_modules/${packageName}/dist/`, '/fixtures/'));
   }
 }
 

--- a/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
+++ b/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
@@ -1,5 +1,6 @@
 // shared from another test
 import fs from 'fs';
+import path from 'path';
 import { myThemePackPlugin } from '../build.plugins.context/theme-pack-context-plugin.js';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import { URL } from 'url';
@@ -13,11 +14,11 @@ class MyThemePackDevelopmentResource extends ResourceInterface {
   }
 
   async shouldResolve(url) {
-    return Promise.resolve(url.indexOf(`/node_modules/${packageName}/`) >= 0);
+    return Promise.resolve(url.indexOf(`node_modules${path.sep}${packageName}`) >= 0);
   }
 
   async resolve(url) {
-    return Promise.resolve(url.replace(`/node_modules/${packageName}/dist/`, '/fixtures/'));
+    return Promise.resolve(path.normalize(url).replace(`node_modules${path.sep}${packageName}${path.sep}dist`, 'fixtures'));
   }
 }
 

--- a/packages/cli/test/cases/theme-pack/greenwood.config.js
+++ b/packages/cli/test/cases/theme-pack/greenwood.config.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import { myThemePack } from './my-theme-pack.js';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import { URL } from 'url';
@@ -13,11 +14,11 @@ class MyThemePackDevelopmentResource extends ResourceInterface {
 
   async shouldResolve(url) {
     // eslint-disable-next-line no-underscore-dangle
-    return Promise.resolve(process.env.__GWD_COMMAND__ === 'develop' && url.indexOf(`/node_modules/${packageName}/`) >= 0);
+    return Promise.resolve(process.env.__GWD_COMMAND__ === 'develop' && url.indexOf(`node_modules${path.sep}${packageName}/`) >= 0);
   }
 
   async resolve(url) {
-    return Promise.resolve(this.getBareUrlPath(url).replace(`/node_modules/${packageName}/dist/`, '/src/'));
+    return Promise.resolve(path.normalize(this.getBareUrlPath(url)).replace(`node_modules${path.sep}${packageName}${path.sep}dist`, 'src'));
   }
 }
 

--- a/packages/cli/test/cases/theme-pack/greenwood.config.js
+++ b/packages/cli/test/cases/theme-pack/greenwood.config.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import { myThemePack } from './my-theme-pack.js';
-import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import { URL } from 'url';
 
@@ -18,7 +17,7 @@ class MyThemePackDevelopmentResource extends ResourceInterface {
   }
 
   async resolve(url) {
-    return Promise.resolve(this.getBareUrlPath(url).replace(`/node_modules/${packageName}/dist/`, path.join(process.cwd(), '/src/')));
+    return Promise.resolve(this.getBareUrlPath(url).replace(`/node_modules/${packageName}/dist/`, '/src/'));
   }
 }
 

--- a/packages/cli/test/cases/theme-pack/theme-pack.develop.spec.js
+++ b/packages/cli/test/cases/theme-pack/theme-pack.develop.spec.js
@@ -38,7 +38,7 @@ const expect = chai.expect;
 const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
 
 describe('Develop Greenwood With: ', function() {
-  const LABEL = 'Developement environment for a Theme Pack';
+  const LABEL = 'Development environment for a Theme Pack';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = 'http://localhost';


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #919 

## Summary of Changes
1. Add a fallback location for `getNodeModulesLocationForPackage`
1. Update theme pack specs (_could_ be a breaking change?)

## TODO
1. [x] Fix Windows specs
1. [x] Maybe pre-test in local _node_modules_ first as part of next alpha?
1. [ ] Update docs?  (windows URLs <> file paths interop and awareness)