### PR TITLE
async `import()` browser.js only if used when default prerendering

### DIFF
--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -1,4 +1,3 @@
-import { BrowserRunner } from '../lib/browser.js';
 import fs from 'fs';
 import htmlparser from 'node-html-parser';
 import path from 'path';
@@ -125,6 +124,7 @@ async function preRenderCompilationCustom(compilation, customPrerender) {
 }
 
 async function preRenderCompilationDefault(compilation) {
+  const BrowserRunner = (await import('../lib/browser.js')).BrowserRunner;
   const browserRunner = new BrowserRunner();
 
   const runBrowser = async (serverUrl, pages, outputDir) => {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#916 

Realized, due to having **puppeteer** as a `devDependency` in the monorepo, and other projects I tested having it as a transitive dependency, i wasn't shielding puppeteer away enough.  Basically, even if running `build` for a static compilation, _lifecycles/prerender.js_ is still getting loaded and so is still going load **puppeteer**.  🤦 

Seeing this behavior in https://github.com/thescientist13/greenwood-starter-presentation/pull/56

## Summary of Changes
1. Only load _lib/browser.js_ when we run `preRenderCompilationDefault`