### PR TITLE
router refactor to better handle hash URL changes and history navigation events

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -11,7 +11,7 @@ export default {
   workspace: fileURLToPath(new URL('./www', import.meta.url)),
   prerender: true,
   optimization: 'inline',
-  // staticRouter: true,
+  staticRouter: true,
   interpolateFrontmatter: true,
   plugins: [
     ...greenwoodPluginGraphQL(),

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -2,9 +2,10 @@
 
 // ** THIS DOES NOT WORK ON SAFARI **
 // It will just load pages as if staticRouter was not enabled
-window.__greenwood.lastRoutes.push(new URL(window.location));
+// window.__greenwood.lastRoutes.push(new URL(window.location));
 
 document.addEventListener('click', function(e) {
+  console.debug(window.location);
   const href = (e.path && e.path[0]
     ? e.path[0].href // chrome + edge
     : e.originalTarget && e.originalTarget.href
@@ -19,110 +20,140 @@ document.addEventListener('click', function(e) {
   console.debug({ href });
   console.debug('can client side route', canClientSideRoute);
   if (canClientSideRoute) {
+    console.debug('STARTING FROM -> ', window.location.pathname);
+
     window.__greenwood.enableRouter = true;
     e.preventDefault();
 
-    const url = new URL(href, window.location.origin);
-    console.debug({ url });
+    const targetUrl = new URL(href, window.location.origin);
+    console.debug({ targetUrl });
+
+    console.debug('TARGET URL -> ', targetUrl.pathname);
 
     const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
-      return outlet.getAttribute('data-route') === url.pathname;
+      return outlet.getAttribute('data-route') === targetUrl.pathname;
     })[0];
     console.debug({ routerOutlet });
 
     if (routerOutlet.getAttribute('data-template') === window.__greenwood.currentTemplate) {
-      console.debug('routerOutlet.loadRoute', routerOutlet);
+      console.debug('same template, persist template');
+      console.debug('HASH ???????', targetUrl.hash);
       // if this is only a hash update, just update the hash itself
       // else, load the route
 
-      console.debug('pushing url', url);
-      window.__greenwood.lastRoutes.push(url);
+      // console.debug('pushing url', url);
+      // window.__greenwood.lastRoutes.push(url);
 
-      if (url.hash !== '') {
-        console.debug('has a hash :o!', url.hash);
-        console.debug(window.location);
-        if (window.location.pathname !== url.pathname) {
+      if (targetUrl.hash !== '') {
+        console.debug('targetUrl has a hash :o!');
+        if (window.location.pathname !== targetUrl.pathname) {
           console.debug('pathname is different, need to update entire location');
           // window.location = href;
         } else {
           console.debug('just a hash change');
-          location.hash = url.hash;
+          // location.hash = url.hash;
         }
       } else {
-        console.debug('else just load the new route');
+        console.debug('else use routerOutlet to load the new route');
         // window.location.pathname = href;
         routerOutlet.loadRoute();
-        history.pushState({}, null, url.pathname);
+        history.pushState({}, '', targetUrl.pathname);
       }
       console.debug('*******************');
     } else {
-      console.debug('hard load href', href);
+      console.debug('different template, hard load href', href);
       window.location.href = href;
     }
   }
 });
 
 window.addEventListener('popstate', (e) => {
-  console.debug('!!!!!!! POP STATE', window.__greenwood.lastRoutes);
-  console.debug(window.location);
+  console.debug('!!!!!!! POP STATE <MOVING << OR >>', window.location);
   console.debug(e);
 
-  if (window.__greenwood.enableRouter) {
-    try {
-      console.debug('BROWSER MOVING TO....', window.location.pathname);
-      if (window.__greenwood.lastRoutes.length > 1) {
-        console.debug('lastRoutes exists.  DOING SOMETHING....');
-        const lastRoute = window.__greenwood.lastRoutes[window.__greenwood.lastRoutes.length - 1];
-        const targetRoute = window.__greenwood.lastRoutes[window.__greenwood.lastRoutes.length - 2];
-        console.debug('TARGET MOVING TO....', targetRoute.pathname);
-        // const targetRoute = window.location;
+  // TODO
+  // if (window.__greenwood.enableRouter) {
+  try {
+    const targetRoute = window.location;
+    console.debug('BROWSER MOVING TO....', targetRoute.pathname);
+    console.debug('WITH HASH ???', targetRoute.hash);
+    const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
+      return outlet.getAttribute('data-route') === targetRoute.pathname;
+    })[0];
 
-        console.debug({ lastRoute });
-        console.debug({ targetRoute });
-
-        if (window.location.hash === lastRoute.hash && lastRoute.hash !== '') {
-          console.debug('this was a forward hash navigation, do nothing????');
-        } else if (targetRoute.pathname !== lastRoute.pathname) {
-          console.debug('pathnames are different, something to see here; loadRoute()');
-          const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
-            return outlet.getAttribute('data-route') === targetRoute.pathname;
-          })[0];
-
-          console.debug('load this routerOutlet ===> ', routerOutlet.getAttribute('data-route'));
-          routerOutlet.loadRoute();
-          
-          console.debug('pop!');
-          window.__greenwood.lastRoutes.pop();
-
-          console.debug('has hash???', targetRoute.hash);
-          // eslint-disable-next-line max-depth
-          if (targetRoute.hash) {
-            console.debug('hash it up!!!!!');
-            location.hash = targetRoute.hash;
-          }
-        } else if (lastRoute.pathname === targetRoute.pathname) {
-          console.debug('else if some other scenario, like a hash change. nothing to see here??');
-          console.debug('should pop?');
-          window.__greenwood.lastRoutes.pop();
-        } else {
-          console.debug('something else entirely different just happened????');
-          console.debug('should pop?');
-        }
-      } else if (window.__greenwood.lastRoutes.length === 1) {
-        console.debug('Last in the stack, pop and go(-1)');
-        window.__greenwood.lastRoutes.pop();
-        history.go(-1);
-      } else {
-        console.debug('NOTHING IN LAST ROUTES.  DO SOMETHING like history.go(-1)???');
-        history.go(-1);
-      }
-    } catch (err) {
-      console.debug('Unexpected error trying to go back.');
-      console.error(err);
+    console.debug({ routerOutlet });
+    if (routerOutlet) {
+      routerOutlet.loadRoute();
     }
-    console.debug('=================================');
+  } catch (err) {
+    console.debug('Unexpected error trying to go back.');
+    console.error(err);
   }
+  console.debug('=================================');
+  //  }
 });
+
+// window.addEventListener('popstate', (e) => {
+//   console.debug('!!!!!!! POP STATE', window.__greenwood.lastRoutes);
+//   console.debug(window.location);
+//   console.debug(e);
+
+//   if (window.__greenwood.enableRouter) {
+//     try {
+//       console.debug('BROWSER MOVING TO....', window.location.pathname);
+//       if (window.__greenwood.lastRoutes.length > 1) {
+//         console.debug('lastRoutes exists.  DOING SOMETHING....');
+//         const lastRoute = window.__greenwood.lastRoutes[window.__greenwood.lastRoutes.length - 1];
+//         const targetRoute = window.__greenwood.lastRoutes[window.__greenwood.lastRoutes.length - 2];
+//         console.debug('TARGET MOVING TO....', targetRoute.pathname);
+//         // const targetRoute = window.location;
+
+//         console.debug({ lastRoute });
+//         console.debug({ targetRoute });
+
+//         if (window.location.hash === lastRoute.hash && lastRoute.hash !== '') {
+//           console.debug('this was a forward hash navigation, do nothing????');
+//         } else if (targetRoute.pathname !== lastRoute.pathname) {
+//           console.debug('pathnames are different, something to see here; loadRoute()');
+//           const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
+//             return outlet.getAttribute('data-route') === targetRoute.pathname;
+//           })[0];
+
+//           console.debug('load this routerOutlet ===> ', routerOutlet.getAttribute('data-route'));
+//           routerOutlet.loadRoute();
+          
+//           console.debug('pop!');
+//           window.__greenwood.lastRoutes.pop();
+
+//           console.debug('has hash???', targetRoute.hash);
+//           // eslint-disable-next-line max-depth
+//           if (targetRoute.hash) {
+//             console.debug('hash it up!!!!!');
+//             location.hash = targetRoute.hash;
+//           }
+//         } else if (lastRoute.pathname === targetRoute.pathname) {
+//           console.debug('else if some other scenario, like a hash change. nothing to see here??');
+//           console.debug('should pop?');
+//           window.__greenwood.lastRoutes.pop();
+//         } else {
+//           console.debug('something else entirely different just happened????');
+//           console.debug('should pop?');
+//         }
+//       } else if (window.__greenwood.lastRoutes.length === 1) {
+//         console.debug('Last in the stack, pop and go(-1)');
+//         window.__greenwood.lastRoutes.pop();
+//         history.go(-1);
+//       } else {
+//         console.debug('NOTHING IN LAST ROUTES.  DO SOMETHING like history.go(-1)???');
+//         history.go(-1);
+//       }
+//     } catch (err) {
+//       console.debug('Unexpected error trying to go back.');
+//       console.error(err);
+//     }
+//     console.debug('=================================');
+//   }
+// });
 
 class RouteComponent extends HTMLElement {
   loadRoute() {

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -20,8 +20,6 @@ document.addEventListener('click', function(e) {
   console.debug('can client side route', canClientSideRoute);
   if (canClientSideRoute) {
     console.debug('STARTING FROM -> ', window.location.pathname);
-
-    window.__greenwood.enableRouter = true;
     e.preventDefault();
 
     const targetUrl = new URL(href, window.location.origin);
@@ -58,8 +56,6 @@ window.addEventListener('popstate', (e) => {
   console.debug('!!!!!!! POP STATE <MOVING << OR >>', window.location);
   console.debug(e);
 
-  // TODO
-  // if (window.__greenwood.enableRouter) {
   try {
     const targetRoute = window.location;
     console.debug('BROWSER MOVING TO....', targetRoute.pathname);
@@ -77,7 +73,6 @@ window.addEventListener('popstate', (e) => {
     console.error(err);
   }
   console.debug('=================================');
-  //  }
 });
 
 class RouteComponent extends HTMLElement {

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -45,14 +45,8 @@ document.addEventListener('click', function(e) {
       // window.__greenwood.lastRoutes.push(url);
 
       if (targetUrl.hash !== '') {
-        console.debug('targetUrl has a hash :o!');
-        if (window.location.pathname !== targetUrl.pathname) {
-          console.debug('pathname is different, need to update entire location');
-          // window.location = href;
-        } else {
-          console.debug('just a hash change');
-          location = targetUrl.hash;
-        }
+        console.debug('just a hash change');
+        location = targetUrl.hash;
       } else {
         console.debug('else use routerOutlet to load the new route');
         routerOutlet.loadRoute();

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -1,5 +1,9 @@
 /* eslint-disable no-underscore-dangle */
 
+// ** THIS DOES NOT WORK ON SAFARI **
+// It will just load pages as if staticRouter was not enabled
+window.__greenwood.lastRoutes.push(new URL(window.location));
+
 document.addEventListener('click', function(e) {
   const href = (e.path && e.path[0]
     ? e.path[0].href // chrome + edge
@@ -12,40 +16,101 @@ document.addEventListener('click', function(e) {
   const isOnCurrentDomain = href.indexOf(window.location.hostname) >= 0 || href.indexOf('localhost') >= 0;
   const canClientSideRoute = href !== '' && isOnCurrentDomain;
 
+  console.debug({ href });
+  console.debug('can client side route', canClientSideRoute);
   if (canClientSideRoute) {
     e.preventDefault();
 
-    const route = href.replace(window.location.origin, '');
+    const url = new URL(href, window.location.origin);
+    console.debug({ url });
+
     const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
-      return outlet.getAttribute('data-route') === route;
+      return outlet.getAttribute('data-route') === url.pathname;
     })[0];
+    console.debug({ routerOutlet });
 
     if (routerOutlet.getAttribute('data-template') === window.__greenwood.currentTemplate) {
-      window.__greenwood.lastRoutes.push(window.location.pathname);
+      console.debug('routerOutlet.loadRoute', routerOutlet);
+      // if this is only a hash update, just update the hash itself
+      // else, load the route
 
-      routerOutlet.loadRoute();
+      console.debug('pushing url', url);
+      window.__greenwood.lastRoutes.push(url);
+
+      if (url.hash !== '') {
+        console.debug('has a hash :o!', url.hash);
+        console.debug(window.location);
+        if (window.location.pathname !== url.pathname) {
+          console.debug('pathname is different, need to update entire location');
+          window.location = href;
+        } else {
+          console.debug('just a hash change');
+          location.hash = url.hash;
+        }
+      } else {
+        console.debug('else just load the new route');
+        routerOutlet.loadRoute();
+      }
+      console.debug('*******************');
     } else {
+      console.debug('hard load href', href);
       window.location.href = href;
     }
   }
 });
 
-window.addEventListener('popstate', () => {
-  try {
-    if (window.__greenwood.lastRoutes.length > 0) {
-      const lastRoute = window.__greenwood.lastRoutes.pop();
-      const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
-        return outlet.getAttribute('data-route') === lastRoute;
-      })[0];
+window.addEventListener('popstate', (e) => {
+  console.debug('!!!!!!! POP STATE', window.__greenwood.lastRoutes);
+  console.debug(window.location);
+  console.debug(e);
 
-      routerOutlet.loadRoute();
+  try {
+    console.debug('BROWSER MOVING TO....', window.location.pathname);
+    if (window.__greenwood.lastRoutes.length > 1) {
+      console.debug('lastRoutes exists.  DOING SOMETHING....');
+      const lastRoute = window.__greenwood.lastRoutes[window.__greenwood.lastRoutes.length - 1];
+      const targetRoute = window.__greenwood.lastRoutes[window.__greenwood.lastRoutes.length - 2];
+      console.debug('TARGET MOVING TO....', targetRoute.pathname);
+      // const targetRoute = window.location;
+
+      console.debug({ lastRoute });
+      console.debug({ targetRoute });
+
+      if (window.location.hash === lastRoute.hash && lastRoute.hash !== '') {
+        console.debug('this was a forward hash navigation, do nothing????');
+      } else if (targetRoute.pathname !== lastRoute.pathname) {
+        console.debug('pathnames are different, something to see here; loadRoute()');
+        const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
+          return outlet.getAttribute('data-route') === targetRoute.pathname;
+        })[0];
+
+        console.debug('load this routerOutlet ===> ', routerOutlet.getAttribute('data-route'));
+
+        routerOutlet.loadRoute();
+
+        console.debug('pop!');
+        window.__greenwood.lastRoutes.pop();
+      } else if (lastRoute.pathname === targetRoute.pathname) {
+        console.debug('else if some other scenario, like a hash change. nothing to see here??');
+        console.debug('should pop?');
+        window.__greenwood.lastRoutes.pop();
+      } else {
+        console.debug('something else entirely different just happened????');
+        console.debug('should pop?');
+      }
+    } else if (window.__greenwood.lastRoutes.length === 1) {
+      console.debug('Last in the stack, pop and go(-1)');
+      window.__greenwood.lastRoutes.pop();
+      history.go(-1);
     } else {
+      console.debug('NOTHING IN LAST ROUTES.  DO SOMETHING like history.go(-1)???');
       history.go(-1);
     }
-  } catch (e) {
+  } catch (err) {
     console.debug('Unexpected error trying to go back.');
-    console.error(e);
+    console.error(err);
   }
+  console.debug('=================================');
 });
 
 class RouteComponent extends HTMLElement {

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -19,6 +19,7 @@ document.addEventListener('click', function(e) {
   console.debug({ href });
   console.debug('can client side route', canClientSideRoute);
   if (canClientSideRoute) {
+    window.__greenwood.enableRouter = true;
     e.preventDefault();
 
     const url = new URL(href, window.location.origin);
@@ -64,53 +65,55 @@ window.addEventListener('popstate', (e) => {
   console.debug(window.location);
   console.debug(e);
 
-  try {
-    console.debug('BROWSER MOVING TO....', window.location.pathname);
-    if (window.__greenwood.lastRoutes.length > 1) {
-      console.debug('lastRoutes exists.  DOING SOMETHING....');
-      const lastRoute = window.__greenwood.lastRoutes[window.__greenwood.lastRoutes.length - 1];
-      const targetRoute = window.__greenwood.lastRoutes[window.__greenwood.lastRoutes.length - 2];
-      console.debug('TARGET MOVING TO....', targetRoute.pathname);
-      // const targetRoute = window.location;
+  if (window.__greenwood.enableRouter) {
+    try {
+      console.debug('BROWSER MOVING TO....', window.location.pathname);
+      if (window.__greenwood.lastRoutes.length > 1) {
+        console.debug('lastRoutes exists.  DOING SOMETHING....');
+        const lastRoute = window.__greenwood.lastRoutes[window.__greenwood.lastRoutes.length - 1];
+        const targetRoute = window.__greenwood.lastRoutes[window.__greenwood.lastRoutes.length - 2];
+        console.debug('TARGET MOVING TO....', targetRoute.pathname);
+        // const targetRoute = window.location;
 
-      console.debug({ lastRoute });
-      console.debug({ targetRoute });
+        console.debug({ lastRoute });
+        console.debug({ targetRoute });
 
-      if (window.location.hash === lastRoute.hash && lastRoute.hash !== '') {
-        console.debug('this was a forward hash navigation, do nothing????');
-      } else if (targetRoute.pathname !== lastRoute.pathname) {
-        console.debug('pathnames are different, something to see here; loadRoute()');
-        const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
-          return outlet.getAttribute('data-route') === targetRoute.pathname;
-        })[0];
+        if (window.location.hash === lastRoute.hash && lastRoute.hash !== '') {
+          console.debug('this was a forward hash navigation, do nothing????');
+        } else if (targetRoute.pathname !== lastRoute.pathname) {
+          console.debug('pathnames are different, something to see here; loadRoute()');
+          const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
+            return outlet.getAttribute('data-route') === targetRoute.pathname;
+          })[0];
 
-        console.debug('load this routerOutlet ===> ', routerOutlet.getAttribute('data-route'));
+          console.debug('load this routerOutlet ===> ', routerOutlet.getAttribute('data-route'));
 
-        routerOutlet.loadRoute();
+          routerOutlet.loadRoute();
 
-        console.debug('pop!');
+          console.debug('pop!');
+          window.__greenwood.lastRoutes.pop();
+        } else if (lastRoute.pathname === targetRoute.pathname) {
+          console.debug('else if some other scenario, like a hash change. nothing to see here??');
+          console.debug('should pop?');
+          window.__greenwood.lastRoutes.pop();
+        } else {
+          console.debug('something else entirely different just happened????');
+          console.debug('should pop?');
+        }
+      } else if (window.__greenwood.lastRoutes.length === 1) {
+        console.debug('Last in the stack, pop and go(-1)');
         window.__greenwood.lastRoutes.pop();
-      } else if (lastRoute.pathname === targetRoute.pathname) {
-        console.debug('else if some other scenario, like a hash change. nothing to see here??');
-        console.debug('should pop?');
-        window.__greenwood.lastRoutes.pop();
+        history.go(-1);
       } else {
-        console.debug('something else entirely different just happened????');
-        console.debug('should pop?');
+        console.debug('NOTHING IN LAST ROUTES.  DO SOMETHING like history.go(-1)???');
+        history.go(-1);
       }
-    } else if (window.__greenwood.lastRoutes.length === 1) {
-      console.debug('Last in the stack, pop and go(-1)');
-      window.__greenwood.lastRoutes.pop();
-      history.go(-1);
-    } else {
-      console.debug('NOTHING IN LAST ROUTES.  DO SOMETHING like history.go(-1)???');
-      history.go(-1);
+    } catch (err) {
+      console.debug('Unexpected error trying to go back.');
+      console.error(err);
     }
-  } catch (err) {
-    console.debug('Unexpected error trying to go back.');
-    console.error(err);
+    console.debug('=================================');
   }
-  console.debug('=================================');
 });
 
 class RouteComponent extends HTMLElement {

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -2,7 +2,6 @@
 
 // ** THIS DOES NOT WORK ON SAFARI **
 // It will just load pages as if staticRouter was not enabled
-// window.__greenwood.lastRoutes.push(new URL(window.location));
 
 document.addEventListener('click', function(e) {
   console.debug(window.location);
@@ -38,11 +37,6 @@ document.addEventListener('click', function(e) {
     if (routerOutlet.getAttribute('data-template') === window.__greenwood.currentTemplate) {
       console.debug('same template, persist template');
       console.debug('HASH ???????', targetUrl.hash);
-      // if this is only a hash update, just update the hash itself
-      // else, load the route
-
-      // console.debug('pushing url', url);
-      // window.__greenwood.lastRoutes.push(url);
 
       if (targetUrl.hash !== '') {
         console.debug('just a hash change');
@@ -85,68 +79,6 @@ window.addEventListener('popstate', (e) => {
   console.debug('=================================');
   //  }
 });
-
-// window.addEventListener('popstate', (e) => {
-//   console.debug('!!!!!!! POP STATE', window.__greenwood.lastRoutes);
-//   console.debug(window.location);
-//   console.debug(e);
-
-//   if (window.__greenwood.enableRouter) {
-//     try {
-//       console.debug('BROWSER MOVING TO....', window.location.pathname);
-//       if (window.__greenwood.lastRoutes.length > 1) {
-//         console.debug('lastRoutes exists.  DOING SOMETHING....');
-//         const lastRoute = window.__greenwood.lastRoutes[window.__greenwood.lastRoutes.length - 1];
-//         const targetRoute = window.__greenwood.lastRoutes[window.__greenwood.lastRoutes.length - 2];
-//         console.debug('TARGET MOVING TO....', targetRoute.pathname);
-//         // const targetRoute = window.location;
-
-//         console.debug({ lastRoute });
-//         console.debug({ targetRoute });
-
-//         if (window.location.hash === lastRoute.hash && lastRoute.hash !== '') {
-//           console.debug('this was a forward hash navigation, do nothing????');
-//         } else if (targetRoute.pathname !== lastRoute.pathname) {
-//           console.debug('pathnames are different, something to see here; loadRoute()');
-//           const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
-//             return outlet.getAttribute('data-route') === targetRoute.pathname;
-//           })[0];
-
-//           console.debug('load this routerOutlet ===> ', routerOutlet.getAttribute('data-route'));
-//           routerOutlet.loadRoute();
-          
-//           console.debug('pop!');
-//           window.__greenwood.lastRoutes.pop();
-
-//           console.debug('has hash???', targetRoute.hash);
-//           // eslint-disable-next-line max-depth
-//           if (targetRoute.hash) {
-//             console.debug('hash it up!!!!!');
-//             location.hash = targetRoute.hash;
-//           }
-//         } else if (lastRoute.pathname === targetRoute.pathname) {
-//           console.debug('else if some other scenario, like a hash change. nothing to see here??');
-//           console.debug('should pop?');
-//           window.__greenwood.lastRoutes.pop();
-//         } else {
-//           console.debug('something else entirely different just happened????');
-//           console.debug('should pop?');
-//         }
-//       } else if (window.__greenwood.lastRoutes.length === 1) {
-//         console.debug('Last in the stack, pop and go(-1)');
-//         window.__greenwood.lastRoutes.pop();
-//         history.go(-1);
-//       } else {
-//         console.debug('NOTHING IN LAST ROUTES.  DO SOMETHING like history.go(-1)???');
-//         history.go(-1);
-//       }
-//     } catch (err) {
-//       console.debug('Unexpected error trying to go back.');
-//       console.error(err);
-//     }
-//     console.debug('=================================');
-//   }
-// });
 
 class RouteComponent extends HTMLElement {
   loadRoute() {

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -51,11 +51,10 @@ document.addEventListener('click', function(e) {
           // window.location = href;
         } else {
           console.debug('just a hash change');
-          // location.hash = url.hash;
+          location = targetUrl.hash;
         }
       } else {
         console.debug('else use routerOutlet to load the new route');
-        // window.location.pathname = href;
         routerOutlet.loadRoute();
         history.pushState({}, '', targetUrl.pathname);
       }

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -43,14 +43,16 @@ document.addEventListener('click', function(e) {
         console.debug(window.location);
         if (window.location.pathname !== url.pathname) {
           console.debug('pathname is different, need to update entire location');
-          window.location = href;
+          // window.location = href;
         } else {
           console.debug('just a hash change');
           location.hash = url.hash;
         }
       } else {
         console.debug('else just load the new route');
+        // window.location.pathname = href;
         routerOutlet.loadRoute();
+        history.pushState({}, null, url.pathname);
       }
       console.debug('*******************');
     } else {
@@ -87,15 +89,17 @@ window.addEventListener('popstate', (e) => {
           })[0];
 
           console.debug('load this routerOutlet ===> ', routerOutlet.getAttribute('data-route'));
-
           routerOutlet.loadRoute();
-
-          if (targetRoute.hash) {
-            location.hash = targetRoute.hash;
-          }
-
+          
           console.debug('pop!');
           window.__greenwood.lastRoutes.pop();
+
+          console.debug('has hash???', targetRoute.hash);
+          // eslint-disable-next-line max-depth
+          if (targetRoute.hash) {
+            console.debug('hash it up!!!!!');
+            location.hash = targetRoute.hash;
+          }
         } else if (lastRoute.pathname === targetRoute.pathname) {
           console.debug('else if some other scenario, like a hash change. nothing to see here??');
           console.debug('should pop?');
@@ -122,13 +126,11 @@ window.addEventListener('popstate', (e) => {
 
 class RouteComponent extends HTMLElement {
   loadRoute() {
-    const route = this.getAttribute('data-route');
     const key = this.getAttribute('data-key');
 
     fetch(key)
       .then(res => res.text())
       .then((response) => {
-        history.pushState(response, route, route);
         document.getElementsByTagName('router-outlet')[0].innerHTML = response;
       });
   }

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -90,6 +90,10 @@ window.addEventListener('popstate', (e) => {
 
           routerOutlet.loadRoute();
 
+          if (targetRoute.hash) {
+            location.hash = targetRoute.hash;
+          }
+
           console.debug('pop!');
           window.__greenwood.lastRoutes.pop();
         } else if (lastRoute.pathname === targetRoute.pathname) {

--- a/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
+++ b/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
@@ -80,7 +80,6 @@ class OptimizationMPAResource extends ResourceInterface {
           <script>
             window.__greenwood = window.__greenwood || {};
 
-            window.__greenwood.lastRoutes = [];
             window.__greenwood.enableRouter = false;
             window.__greenwood.currentTemplate = "${currentTemplate}";
           </script>

--- a/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
+++ b/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
@@ -1,5 +1,5 @@
 /*
- * 
+ *
  * Manages web standard resource related operations for JavaScript.
  * This is a Greenwood default plugin.
  *
@@ -79,18 +79,19 @@ class OptimizationMPAResource extends ResourceInterface {
           <script type="module" src="/node_modules/@greenwood/cli/src/lib/router.js"></script>\n
           <script>
             window.__greenwood = window.__greenwood || {};
-            
+
             window.__greenwood.lastRoutes = [];
+            window.__greenwood.enableRouter = false;
             window.__greenwood.currentTemplate = "${currentTemplate}";
-          </script> 
+          </script>
           </head>
         `).replace(/<body>(.*)<\/body>/s, `
           <body>\n
-            
+
             <router-outlet>
               ${bodyContents.replace(/\$/g, '$$$')}\n
             </router-outlet>
-            
+
             ${routeTags.join('\n')}
           </body>
         `);

--- a/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
+++ b/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
@@ -79,8 +79,6 @@ class OptimizationMPAResource extends ResourceInterface {
           <script type="module" src="/node_modules/@greenwood/cli/src/lib/router.js"></script>\n
           <script>
             window.__greenwood = window.__greenwood || {};
-
-            window.__greenwood.enableRouter = false;
             window.__greenwood.currentTemplate = "${currentTemplate}";
           </script>
           </head>

--- a/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
+++ b/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
@@ -95,7 +95,6 @@ describe('Build Greenwood With: ', function() {
 
         expect(inlineScriptTags.length).to.be.equal(1);
         expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood = window.__greenwood || {};');
-        expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood.enableRouter = false;');
         expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood.currentTemplate = "page"');
       });
 

--- a/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
+++ b/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
@@ -39,8 +39,8 @@ describe('Build Greenwood With: ', function() {
   let runner;
 
   before(async function() {
-    this.context = { 
-      publicDir: path.join(outputPath, 'public') 
+    this.context = {
+      publicDir: path.join(outputPath, 'public')
     };
     runner = new Runner();
   });
@@ -49,7 +49,7 @@ describe('Build Greenwood With: ', function() {
 
     before(async function() {
       const greenwoodRouterLibs = await getDependencyFiles(
-        `${process.cwd()}/packages/cli/src/lib/router.js`, 
+        `${process.cwd()}/packages/cli/src/lib/router.js`,
         `${outputPath}/node_modules/@greenwood/cli/src/lib`
       );
 
@@ -76,7 +76,7 @@ describe('Build Greenwood With: ', function() {
         partials = await glob(`${this.context.publicDir}/_routes/**/*.html`);
         routerFiles = await glob(`${this.context.publicDir}/router.*.js`);
       });
-      
+
       it('should have one <script> tag in the <head> for the router', function() {
         const scriptTags = dom.window.document.querySelectorAll('head > script[type]');
 
@@ -96,6 +96,7 @@ describe('Build Greenwood With: ', function() {
         expect(inlineScriptTags.length).to.be.equal(1);
         expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood = window.__greenwood || {};');
         expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood.lastRoutes = [];');
+        expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood.enableRouter = false;');
         expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood.currentTemplate = "page"');
       });
 
@@ -110,7 +111,7 @@ describe('Build Greenwood With: ', function() {
 
         expect(routeTags.length).to.be.equal(3);
       });
-                  
+
       it('should have the expected properties for each <greenwood-route> tag for the about page', function() {
         const aboutRouteTag = Array
           .from(dom.window.document.querySelectorAll('body > greenwood-route'))
@@ -155,10 +156,10 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected partial output to match the contents of the about page in the <router-outlet> tag in the <body>', function() {
         const homePartial = fs.readFileSync(path.join(this.context.publicDir, '_routes/index.html'), 'utf-8');
         const homeRouterOutlet = dom.window.document.querySelectorAll('body > router-outlet')[0];
-        
+
         expect(homeRouterOutlet.innerHTML).to.contain(homePartial);
       });
-      
+
     });
 
     // https://github.com/ProjectEvergreen/greenwood/pull/743
@@ -168,7 +169,7 @@ describe('Build Greenwood With: ', function() {
       before(async function() {
         dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, 'regex-test/index.html'));
       });
-      
+
       it('should not have duplicate <app-footer> custom elements', function() {
         const footer = dom.window.document.querySelectorAll('body footer');
 

--- a/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
+++ b/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
@@ -95,7 +95,6 @@ describe('Build Greenwood With: ', function() {
 
         expect(inlineScriptTags.length).to.be.equal(1);
         expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood = window.__greenwood || {};');
-        expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood.lastRoutes = [];');
         expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood.enableRouter = false;');
         expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood.currentTemplate = "page"');
       });

--- a/www/components/shelf/shelf.js
+++ b/www/components/shelf/shelf.js
@@ -33,11 +33,6 @@ class Shelf extends LitElement {
     this.collapseAll();
   }
 
-  goTo(path) {
-    location.hash = path;
-    // window.history.pushState({}, '', path);
-  }
-
   expandRoute(path) {
     let routeShelfListIndex = this.shelfList.findIndex(item => {
       let expRoute = new RegExp(`^${path}$`);
@@ -113,15 +108,6 @@ class Shelf extends LitElement {
     }
   }
 
-  handleSubItemSelect(mainRoute, itemRoute) {
-    // check if we're on the same page as subitem anchor
-    if (window.location.pathname.substr(0, window.location.pathname.length - 1) !== mainRoute) {
-      window.location.href = mainRoute + itemRoute;
-    } else {
-      this.goTo(`${item.route}`);
-    }
-  }
-
   renderList() {
     /* eslint-disable indent */
     const renderListItems = (mainRoute, children, selected) => {
@@ -133,7 +119,7 @@ class Shelf extends LitElement {
             ${children.map((child) => {
               return html`
                 <li class="${selected ? '' : 'hidden'}">
-                  <a @click=${() => this.handleSubItemSelect(mainRoute, child.item.route)}>${child.item.label}</a>
+                  <a href="${mainRoute}${child.item.route}">${child.item.label}</a>
                 </li>
               `;
             })}

--- a/www/components/shelf/shelf.js
+++ b/www/components/shelf/shelf.js
@@ -35,7 +35,7 @@ class Shelf extends LitElement {
 
   goTo(path) {
     location.hash = path;
-    window.history.pushState({}, '', path);
+    // window.history.pushState({}, '', path);
   }
 
   expandRoute(path) {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #936

I believe the issue here is that even [updating a hash will trigger a `pop state` event](https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event#when_popstate_is_sent), even if that means we are navigating "forward", eg.
1. Getting Started
1. Creating Content
1. -> Home Page Template

Opted to refactor the shelf a little bit so it only needs to use `<a>` tags for all navigation, and concentrated all the routing logic into the `staticRouter` to handle these various states of hash vs non hash.  So even without `staticRouter`, Shelf `<a>` + browser default behavior should still work fine.

## Summary of Changes
1. Re-enable `staticRouter` in _greenwood.config.js_ for the website
1. Refactor Shelf to just use standard `<a>` tag behavior for navigating
1. Refactor Router to better accommodate various modes of navigation, with and without hash changes, backwards AND forwards
1. Refactor Router to handle browser's we can support with `staticRouter` and just avoid trying to do any routing at all, so at least it still works instead of failing

### Testing Scenarios
Tested the following scenarios in Chrome and Firefox (currently `staticRouter` is not supported for Safari).  In all scenarios was able to click Back all the way to the starting page.  _Please test forwards and backwards navigation_.  🙏 

#### _Home -> Plugins + side nav_
```
1. Home
2. Plugins
3.   -> Copy
4.   -> Resource
5.   -> Renderer
6.   -> Rollup
```

#### _Home -> Getting Started + side nav + nested items_
```
1. Home
2. Getting Started
3.   -> Project Setup
3a.   -> Key Concepts
4.   -> Creating Content
4a.     -> Home Page Template
4b.     -> Blog Posts Template
4c.     -> App Template
4d.     -> Creating Pages
5.   -> Optimizing
5a.     -> Prerendering
```

#### _Home -> Getting Started + side nav + nested items_ -> Blog
```
1. Home
2. Getting Started
3.   -> Project Setup
3a.   -> Key Concepts
4.   -> Creating Content
4a.     -> Home Page Template
4b.     -> Blog Posts Template
4c.     -> App Template
4d.     -> Creating Pages
5.   -> Optimizing
5a.     -> Prerendering
6.  Blog
7.   -> State of Greenwood 2022
```

#### _Docs -> About + side nav_
```
1. Home
2. Docs
2a.   -> Configuration
2b.   -> Front Matter
3. About
4.   -> Goals
```

## TODO
1. [x] Validate with more testing
    - still an issue with Safari (need to validate post second refactor)
    - _forwards_ navigation testing 🤦 
1. [x] Clean up console logging