### PR TITLE
Bug/issue 940 static router breaking hybrid workspaces

### DIFF
--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -22,7 +22,7 @@ document.addEventListener('click', function(e) {
       return outlet.getAttribute('data-route') === targetUrl.pathname;
     })[0];
 
-    // maintain the app shell if we are navigating between pages that are built from the page template
+    // maintain the app shell if we are navigating between pages that are built from the same page template
     // also, some routes may be SSR, so we may not always match on a static route
     if (routerOutlet && routerOutlet.getAttribute('data-template') === window.__greenwood.currentTemplate) {
       

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -23,7 +23,8 @@ document.addEventListener('click', function(e) {
     })[0];
 
     // maintain the app shell if we are navigating between pages that are built from the page template
-    if (routerOutlet.getAttribute('data-template') === window.__greenwood.currentTemplate) {
+    // also, some routes may be SSR, so we may not always match on a static route
+    if (routerOutlet && routerOutlet.getAttribute('data-template') === window.__greenwood.currentTemplate) {
       
       // only update the hash if it just the hash changing
       // else, request and load the partial for the page, and push page to the browser history stack

--- a/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
+++ b/packages/cli/src/plugins/resource/plugin-optimization-mpa.js
@@ -1,6 +1,7 @@
 /*
  *
- * Manages web standard resource related operations for JavaScript.
+ * 
+ * Manages SPA like client side routing for static pages.
  * This is a Greenwood default plugin.
  *
  */
@@ -40,6 +41,7 @@ class OptimizationMPAResource extends ResourceInterface {
   }
 
   async optimize(url, body) {
+    console.debug('optimize', url);
     return new Promise(async (resolve, reject) => {
       try {
         let currentTemplate;
@@ -47,7 +49,8 @@ class OptimizationMPAResource extends ResourceInterface {
         const bodyContents = body.match(/<body>(.*)<\/body>/s)[0].replace('<body>', '').replace('</body>', '');
         const outputBundlePath = path.normalize(`${outputDir}/_routes${url.replace(projectDirectory, '')}`)
           .replace(`.greenwood${path.sep}`, '');
-
+        const outputBundlePathDir = path.extname(outputBundlePath) === '.html' ? path.dirname(outputBundlePath) : outputBundlePath;
+        
         const routeTags = this.compilation.graph
           .filter(page => !page.isSSR)
           .filter(page => page.route !== '/404/')
@@ -67,13 +70,26 @@ class OptimizationMPAResource extends ResourceInterface {
             `;
           });
 
-        if (!fs.existsSync(path.dirname(outputBundlePath))) {
-          fs.mkdirSync(path.dirname(outputBundlePath), {
+        // console.debug({ routeTags });
+        console.debug({ outputBundlePath });
+        console.debug({ outputBundlePathDir });
+        if (!fs.existsSync(outputBundlePathDir)) {
+          fs.mkdirSync(outputBundlePathDir, {
             recursive: true
           });
         }
 
-        await fs.promises.writeFile(outputBundlePath, bodyContents);
+        console.debug('WRITE??????');
+
+        const writePath = path.extname(outputBundlePath) === '.html' 
+          ? outputBundlePath
+          : `${outputBundlePath}.html`;
+
+        console.debug({ writePath });
+
+        await fs.promises.writeFile(writePath, bodyContents);
+
+        console.debug('@#$#@$#@$@#$#@$@');
 
         body = body.replace('</head>', `
           <script type="module" src="/node_modules/@greenwood/cli/src/lib/router.js"></script>\n
@@ -93,6 +109,7 @@ class OptimizationMPAResource extends ResourceInterface {
           </body>
         `);
 
+        console.debug('SO FAR SO GOOD?????');
         resolve(body);
       } catch (e) {
         reject(e);

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -97,7 +97,6 @@ class StaticRouterResource extends ResourceInterface {
           </body>
         `);
 
-        console.debug('SO FAR SO GOOD?????');
         resolve(body);
       } catch (e) {
         reject(e);

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -10,7 +10,7 @@ import path from 'path';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 import { fileURLToPath, URL } from 'url';
 
-class OptimizationMPAResource extends ResourceInterface {
+class StaticRouterResource extends ResourceInterface {
   constructor(compilation, options) {
     super(compilation, options);
     this.extensions = ['.html'];
@@ -106,10 +106,10 @@ class OptimizationMPAResource extends ResourceInterface {
   }
 }
 
-const greenwoodPluginOptimzationMpa = {
+const greenwoodPluginStaticRouter = {
   type: 'resource',
-  name: 'plugin-optimization-mpa',
-  provider: (compilation, options) => new OptimizationMPAResource(compilation, options)
+  name: 'plugin-static-router',
+  provider: (compilation, options) => new StaticRouterResource(compilation, options)
 };
 
-export { greenwoodPluginOptimzationMpa };
+export { greenwoodPluginStaticRouter };

--- a/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
+++ b/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
@@ -1,6 +1,6 @@
 /*
  * Use Case
- * Run Greenwood with staticRouter setting in Greenwood to enable MPA like routing.
+ * Run Greenwood with staticRouter setting in Greenwood to enable SPA like routing.
  *
  * User Result
  * Should generate a bare bones Greenwood build with support for static router navigation.
@@ -33,7 +33,7 @@ import { fileURLToPath, URL } from 'url';
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
-  const LABEL = 'Static Router';
+  const LABEL = 'Static Router Configuration and Hybrid Workspace';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
@@ -62,7 +62,7 @@ describe('Build Greenwood With: ', function() {
 
     runSmokeTest(['public', 'index'], LABEL);
 
-    describe('MPA (Multi Page Application)', function() {
+    describe('Static content routes', function() {
       let dom;
       let aboutDom;
       let pages;
@@ -134,9 +134,6 @@ describe('Build Greenwood With: ', function() {
 
       // tests to make sure we filter out 404 page from _route partials
       it('should have the expected top level HTML files (index.html, 404.html) in the output', function() {
-        // const aboutPartial = fs.readFileSync(path.join(this.context.publicDir, '*.html'), 'utf-8');
-        // const aboutRouterOutlet = aboutDom.window.document.querySelectorAll('body > router-outlet')[0];
-
         expect(pages.length).to.equal(2);
       });
 

--- a/packages/cli/test/cases/build.config.static-router/src/pages/artists.js
+++ b/packages/cli/test/cases/build.config.static-router/src/pages/artists.js
@@ -1,0 +1,17 @@
+async function getBody() {
+  const artists = [{ name: 'Analog', imageUrl: '/assets/analog.png' }];
+  const html = artists.map(artist => {
+    return `
+      <wc-card>
+        <h2>${artist.name}</h2>
+        <img src="${artist.imageUrl}" alt="${artist.name}"/>
+      </wc-card>
+    `;
+  }).join('');
+  
+  return html;
+}
+
+export {
+  getBody
+};

--- a/packages/cli/test/cases/serve.config.static-router/greenwood.config.js
+++ b/packages/cli/test/cases/serve.config.static-router/greenwood.config.js
@@ -1,0 +1,3 @@
+export default {
+  staticRouter: true
+};

--- a/packages/cli/test/cases/serve.config.static-router/serve.config.static-router.spec.js
+++ b/packages/cli/test/cases/serve.config.static-router/serve.config.static-router.spec.js
@@ -1,0 +1,113 @@
+/*
+ * Use Case
+ * Run Greenwood with staticRouter setting in Greenwood to enable SPA like routing.
+ *
+ * User Result
+ * Should serve a bare bones Greenwood build with support for static router navigation and SSR routes
+ * to support hybrid workspaces.
+ *
+ * User Command
+ * greenwood serve
+ *
+ * User Config
+ * {
+ *   staticRouter: true
+ * }
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     about.md
+ *     artists.js
+ *     index.md
+ */
+import chai from 'chai';
+import path from 'path';
+import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import request from 'request';
+import { runSmokeTest } from '../../../../../test/smoke-test.js';
+import { Runner } from 'gallinago';
+import { fileURLToPath, URL } from 'url';
+
+const expect = chai.expect;
+
+describe('Serve Greenwood With: ', function() {
+  const LABEL = 'Static Router Configuration and Hybrid Workspace';
+  const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
+  const hostname = 'http://127.0.0.1:8080';
+  let runner;
+
+  before(function() {
+    this.context = {
+      hostname
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function() {
+
+    before(async function() {
+      const greenwoodRouterLibs = await getDependencyFiles(
+        `${process.cwd()}/packages/cli/src/lib/router.js`, 
+        `${outputPath}/node_modules/@greenwood/cli/src/lib`
+      );
+
+      await runner.setup(outputPath, [
+        ...getSetupFiles(outputPath),
+        ...greenwoodRouterLibs
+      ]);
+      
+      return new Promise(async (resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, 10000);
+
+        await runner.runCommand(cliPath, 'serve');
+      });
+    });
+
+    runSmokeTest(['serve'], LABEL);
+
+    describe('Serve command with SSR route with staticRouter config set', function() {
+      let response = {};
+
+      before(async function() {
+        return new Promise((resolve, reject) => {
+          request.get(`${hostname}/artists/`, (err, res, body) => {
+            if (err) {
+              reject();
+            }
+
+            response = res;
+            response.body = body;
+
+            resolve();
+          });
+        });
+      });
+
+      it('should return a 200 status', function(done) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
+
+      it('should return the correct content type', function(done) {
+        expect(response.headers['content-type']).to.contain('text/html');
+        done();
+      });
+
+      it('should return the correct response body', function(done) {
+        expect(response.body).to.contain('<h2>Analog</h2>');
+        expect(response.body).to.contain('<img src="/assets/analog.png" alt="Analog"/>');
+        done();
+      });
+    });
+
+  });
+
+  after(function() {
+    runner.teardown(getOutputTeardownFiles(outputPath));
+    runner.stopCommand();
+  });
+});

--- a/packages/cli/test/cases/serve.config.static-router/src/pages/about.md
+++ b/packages/cli/test/cases/serve.config.static-router/src/pages/about.md
@@ -1,0 +1,7 @@
+---
+template: test
+---
+
+### Greenwood
+
+This is the about page built by Greenwood.

--- a/packages/cli/test/cases/serve.config.static-router/src/pages/artists.js
+++ b/packages/cli/test/cases/serve.config.static-router/src/pages/artists.js
@@ -1,0 +1,17 @@
+async function getBody() {
+  const artists = [{ name: 'Analog', imageUrl: '/assets/analog.png' }];
+  const html = artists.map(artist => {
+    return `
+      <wc-card>
+        <h2>${artist.name}</h2>
+        <img src="${artist.imageUrl}" alt="${artist.name}"/>
+      </wc-card>
+    `;
+  }).join('');
+  
+  return html;
+}
+
+export {
+  getBody
+};

--- a/packages/cli/test/cases/serve.config.static-router/src/pages/index.md
+++ b/packages/cli/test/cases/serve.config.static-router/src/pages/index.md
@@ -1,0 +1,3 @@
+### Greenwood
+
+This is the home page built by Greenwood.


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #940 

## Summary of Changes
1. Fix route trying load a SSR route "statically"
1. Avoid and add specs to cover this
1. Rename resource plugin to accurately reflect behavior

## TODO
1. [x] should cross verify test with #936 / #937
1. [x] ~~Maybe support SSR routes by writing out a `<greenwood-router>`, e.g. if `isSSR`, load with `window.location.href`?~~ - will track as a future feature request
1. [ ] Should have this thrown a `500` instead of a `404`?