### PR TITLE
revert home page banner fading back to `setTimeout`

### DIFF
--- a/www/components/banner/banner.js
+++ b/www/components/banner/banner.js
@@ -39,12 +39,12 @@ class Banner extends LitElement {
       this.animateState = 'off';
       this.update();
 
-      requestAnimationFrame(() => {
+      setTimeout(() => {
         this.cycleProjectTypes();
         this.animateState = 'on';
         this.update();
-      });
-    }, 4000);
+      }, 500);
+    }, 5000);
   }
 
   render() {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #947 

LOL, so I upgraded my version of Chrome last night and noticed the banner isn't doing any fading in / out now, though it still seems to operate fine in Safari using `rAF`?  IDK, maybe I am using it wrong so reverted back to `setTimeout` for the fade out signal for now and seems to rotate well now in all browsers.  🤷 

> Update: also looks like this happens on FF too, so this implementation is the only one that seems consistent then.

https://user-images.githubusercontent.com/895923/176895811-22fba30a-9617-479a-ae83-ef614f47d17c.mov

## Summary of Changes
1. Revert back to `setTimeout` and tweaked timer values