### PR TITLE
Bug/issue 961 commonjs plugin named export spelled wrong

### DIFF
--- a/packages/cli/test/cases/build.config.default/build.config.default.spec.js
+++ b/packages/cli/test/cases/build.config.default/build.config.default.spec.js
@@ -2,7 +2,7 @@
  * Use Case
  * Run Greenwood with empty config object and default workspace.
  *
- * Uaer Result
+ * User Result
  * Should generate a bare bones Greenwood build.  (same as build.default.spec.js)
  *
  * User Command

--- a/packages/cli/test/cases/build.default.workspace-javascript-css-remote/build.default.workspace-javascript-css-remote.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css-remote/build.default.workspace-javascript-css-remote.spec.js
@@ -2,7 +2,7 @@
  * Use Case
  * Run Greenwood with various usages of JavaScript (<script>) and CSS (<style> / <link>) tags with remove links.
  * 
- * Uaer Result
+ * User Result
  * Should generate a bare bones Greenwood build without erroring.
  *
  * User Command

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -2,7 +2,7 @@
  * Use Case
  * Run Greenwood with various usages of JavaScript (<script>) and CSS (<style> / <link>) tags.
  * 
- * Uaer Result
+ * User Result
  * Should generate a bare bones Greenwood build without erroring.
  *
  * User Command

--- a/packages/cli/test/cases/build.plugins.resource/build.config.plugins-resource.spec.js
+++ b/packages/cli/test/cases/build.plugins.resource/build.config.plugins-resource.spec.js
@@ -2,7 +2,7 @@
  * Use Case
  * Run Greenwood with a custom resource plugin and default workspace.
  *
- * Uaer Result
+ * User Result
  * Should generate a bare bones Greenwood build with expected custom file (.foo) behavior.
  *
  * User Command

--- a/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
+++ b/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
@@ -2,7 +2,7 @@
  * Use Case
  * Run Greenwood and get external  custom resource plugin and default workspace.
  *
- * Uaer Result
+ * User Result
  * Should generate a bare bones Greenwood build with expected artists data as static files using a custom template.
  *
  * User Command

--- a/packages/plugin-babel/test/cases/default/default.spec.js
+++ b/packages/plugin-babel/test/cases/default/default.spec.js
@@ -9,7 +9,7 @@
  * greenwood build
  *
  * User Config
- * const pluginBabel = require('@greenwod/plugin-babel');
+ * const pluginBabel = require('@greenwood/plugin-babel');
  *
  * {
  *   plugins: [

--- a/packages/plugin-babel/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-babel/test/cases/options.extend-config/options.extend-config.spec.js
@@ -10,7 +10,7 @@
  * greenwood build
  *
  * User Config
- * const pluginBabel = require('@greenwod/plugin-babel');
+ * const pluginBabel = require('@greenwood/plugin-babel');
  *
  * {
  *   plugins: [

--- a/packages/plugin-google-analytics/test/cases/default/default.spec.js
+++ b/packages/plugin-google-analytics/test/cases/default/default.spec.js
@@ -2,14 +2,14 @@
  * Use Case
  * Run Greenwood with Google Analytics composite plugin with default options.
  *
- * Uaer Result
+ * User Result
  * Should generate a bare bones Greenwood build with Google Analytics tracking snippet injected into index.html.
  *
  * User Command
  * greenwood build
  *
  * User Config
- * import { greenwoodPluginGoogleAnalytics } from '@greenwod/plugin-google-analytics';
+ * import { greenwoodPluginGoogleAnalytics } from '@greenwood/plugin-google-analytics';
  *
  * {
  *   plugins: [{

--- a/packages/plugin-google-analytics/test/cases/error-analytics-id/error-analytics-id.spec.js
+++ b/packages/plugin-google-analytics/test/cases/error-analytics-id/error-analytics-id.spec.js
@@ -2,14 +2,14 @@
  * Use Case
  * Run Greenwood with Google Analytics composite plugin.
  *
- * Uaer Result
+ * User Result
  * Should generate an error when not passing in a valid analyticsId.
  *
  * User Command
  * greenwood build
  *
  * User Config
- * import { greenwoodPluginGoogleAnalytics } from '@greenwod/plugin-google-analytics';
+ * import { greenwoodPluginGoogleAnalytics } from '@greenwood/plugin-google-analytics';
  *
  * {
  *   plugins: [{

--- a/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
+++ b/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
@@ -2,14 +2,14 @@
  * Use Case
  * Run Greenwood with Google Analytics composite plugin with IP anonymization set to false.
  *
- * Uaer Result
+ * User Result
  * Should generate a bare bones Greenwood build with Google Analytics tracking snippet injected into index.html.
  *
  * User Command
  * greenwood build
  *
  * User Config
- * import { greenwoodPluginGoogleAnalytics } from '@greenwod/plugin-google-analytics';
+ * import { greenwoodPluginGoogleAnalytics } from '@greenwood/plugin-google-analytics';
  *
  * {
  *   plugins: [{

--- a/packages/plugin-graphql/test/cases/query-children/query-children.spec.js
+++ b/packages/plugin-graphql/test/cases/query-children/query-children.spec.js
@@ -1,6 +1,6 @@
 /*
  * Use Case
- * Run Greenwood build command with GraphQL calls to get data about the projects graph using ChildrenQuaery.
+ * Run Greenwood build command with GraphQL calls to get data about the projects graph using ChildrenQuery.
  *
  * Needs prerender to be true to get SSR and client side GQL fetching.
  * 

--- a/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
+++ b/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
@@ -1,6 +1,6 @@
 /*
  * Use Case
- * Run Greenwood build command with GraphQL calls to get data about the projects graph using GraphQuaery.
+ * Run Greenwood build command with GraphQL calls to get data about the projects graph using GraphQuery.
  *
  * Needs prerender to be true to get SSR and client side GQL fetching.
  * 

--- a/packages/plugin-import-commonjs/src/index.js
+++ b/packages/plugin-import-commonjs/src/index.js
@@ -82,7 +82,7 @@ class ImportCommonJsResource extends ResourceInterface {
   }
 }
 
-const greenwodPluginImportCommonJs = (options = {}) => {
+const greenwoodPluginImportCommonJs = (options = {}) => {
   return [{
     type: 'resource',
     name: 'plugin-import-commonjs:resource',
@@ -97,5 +97,5 @@ const greenwodPluginImportCommonJs = (options = {}) => {
 };
 
 export {
-  greenwodPluginImportCommonJs
+  greenwoodPluginImportCommonJs
 };

--- a/packages/plugin-import-commonjs/test/cases/default/default.spec.js
+++ b/packages/plugin-import-commonjs/test/cases/default/default.spec.js
@@ -10,11 +10,11 @@
  * greenwood build
  *
  * User Config
- * import { greenwodPluginImportCommonJs } from '@greenwod/plugin-import-commonjs';
+ * import { greenwoodPluginImportCommonJs } from '@greenwod/plugin-import-commonjs';
  *
  * {
  *   plugins: [{
- *     ...greenwodPluginImportCommonJs()
+ *     ...greenwoodPluginImportCommonJs()
  *  }]
  * }
  *

--- a/packages/plugin-import-commonjs/test/cases/default/default.spec.js
+++ b/packages/plugin-import-commonjs/test/cases/default/default.spec.js
@@ -3,14 +3,14 @@
  * Run Greenwood with pluginImportCommonjs plugin with default options.
  * Sets prerender: true to validate the functionality.
  * 
- * Uaer Result
+ * User Result
  * Should generate a bare bones Greenwood build without erroring on a CommonJS module.
  *
  * User Command
  * greenwood build
  *
  * User Config
- * import { greenwoodPluginImportCommonJs } from '@greenwod/plugin-import-commonjs';
+ * import { greenwoodPluginImportCommonJs } from '@greenwood/plugin-import-commonjs';
  *
  * {
  *   plugins: [{

--- a/packages/plugin-import-commonjs/test/cases/default/greenwood.config.js
+++ b/packages/plugin-import-commonjs/test/cases/default/greenwood.config.js
@@ -1,8 +1,8 @@
-import { greenwodPluginImportCommonJs } from '../../../src/index.js';
+import { greenwoodPluginImportCommonJs } from '../../../src/index.js';
 
 export default {
 
   plugins: [
-    ...greenwodPluginImportCommonJs()
+    ...greenwoodPluginImportCommonJs()
   ]
 };

--- a/packages/plugin-import-css/test/cases/default/default.spec.js
+++ b/packages/plugin-import-css/test/cases/default/default.spec.js
@@ -2,14 +2,14 @@
  * Use Case
  * Run Greenwood with pluginImportCss plugin with default options.
  * 
- * Uaer Result
+ * User Result
  * Should generate a bare bones Greenwood build without erroring when using ESM (import) with CSS.
  *
  * User Command
  * greenwood build
  *
  * User Config
- * import { greenwoodPluginImportCss } from '@greenwod/plugin-import-css';
+ * import { greenwoodPluginImportCss } from '@greenwood/plugin-import-css';
  *
  * {
  *   plugins: [{

--- a/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
@@ -9,7 +9,7 @@
  * greenwood develop
  *
  * User Config
- * import { greenwoodPluginImportCss } from '@greenwod/plugin-import-css';
+ * import { greenwoodPluginImportCss } from '@greenwood/plugin-import-css';
  *
  * {
  *   plugins: [{

--- a/packages/plugin-import-json/test/cases/default/default.spec.js
+++ b/packages/plugin-import-json/test/cases/default/default.spec.js
@@ -2,14 +2,14 @@
  * Use Case
  * Run Greenwood with pluginImportCss plugin with default options.
  * 
- * Uaer Result
+ * User Result
  * Should generate a bare bones Greenwood build without erroring when using ESM (import) with CSS.
  *
  * User Command
  * greenwood build
  *
  * User Config
- * const { greenwoodPluginImportJson } from '@greenwod/plugin-import-json';
+ * const { greenwoodPluginImportJson } from '@greenwood/plugin-import-json';
  *
  * {
  *   plugins: [{

--- a/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
@@ -9,7 +9,7 @@
  * greenwood develop
  *
  * User Config
- * const { greenwoodPluginImportJson } from '@greenwod/plugin-import-json';
+ * const { greenwoodPluginImportJson } from '@greenwood/plugin-import-json';
  *
  * {
  *   plugins: [{

--- a/packages/plugin-include-html/test/cases/build.default-custom-element/build.default.custom-element.spec.js
+++ b/packages/plugin-include-html/test/cases/build.default-custom-element/build.default.custom-element.spec.js
@@ -9,7 +9,7 @@
  * greenwood build
  *
  * User Config
- * import { greenwoodPluginIncludeHTML } from '@greenwod/plugin-include-html';
+ * import { greenwoodPluginIncludeHTML } from '@greenwood/plugin-include-html';
  *
  * {
  *   plugins: [{

--- a/packages/plugin-include-html/test/cases/build.default-link-tag/build.default.link-tag.spec.js
+++ b/packages/plugin-include-html/test/cases/build.default-link-tag/build.default.link-tag.spec.js
@@ -9,7 +9,7 @@
  * greenwood build
  *
  * User Config
- * import { greenwoodPluginIncludeHTML } from '@greenwod/plugin-include-html';
+ * import { greenwoodPluginIncludeHTML } from '@greenwood/plugin-include-html';
  *
  * {
  *   plugins: [{

--- a/packages/plugin-polyfills/test/cases/default/default.spec.js
+++ b/packages/plugin-polyfills/test/cases/default/default.spec.js
@@ -2,14 +2,14 @@
  * Use Case
  * Run Greenwood with Polyfills composite plugin with default options.
  *
- * Uaer Result
+ * User Result
  * Should generate a bare bones Greenwood build with polyfills injected into index.html.
  *
  * User Command
  * greenwood build
  *
  * User Config
- * import { greenwoodPluginPolyfills } from '@greenwod/plugin-polyfills';
+ * import { greenwoodPluginPolyfills } from '@greenwood/plugin-polyfills';
  *
  * {
  *   plugins: [{

--- a/packages/plugin-polyfills/test/cases/lit/lit.spec.js
+++ b/packages/plugin-polyfills/test/cases/lit/lit.spec.js
@@ -9,7 +9,7 @@
  * greenwood build
  *
  * User Config
- * import { greenwoodPluginPolyfills } from '@greenwod/plugin-polyfills';
+ * import { greenwoodPluginPolyfills } from '@greenwood/plugin-polyfills';
  *
  * {
  *   plugins: [

--- a/packages/plugin-postcss/test/cases/default/default.spec.js
+++ b/packages/plugin-postcss/test/cases/default/default.spec.js
@@ -9,7 +9,7 @@
  * greenwood build
  *
  * User Config
- * const pluginPostCss = require('@greenwod/plugin-postcss');
+ * const pluginPostCss = require('@greenwood/plugin-postcss');
  *
  * {
  *   plugins: [

--- a/packages/plugin-postcss/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-postcss/test/cases/options.extend-config/options.extend-config.spec.js
@@ -9,7 +9,7 @@
  * greenwood build
  *
  * User Config
- * const pluginPostCss = require('@greenwod/plugin-postcss');
+ * const pluginPostCss = require('@greenwood/plugin-postcss');
  *
  * {
  *   plugins: [

--- a/packages/plugin-renderer-lit/test/cases/build.prerender.getting-started/build.prerender.getting-started.spec.js
+++ b/packages/plugin-renderer-lit/test/cases/build.prerender.getting-started/build.prerender.getting-started.spec.js
@@ -10,7 +10,7 @@
  * greenwood build
  *
  * User Config
- * import { greenwoodPluginIncludeHTML } from '@greenwod/plugin-include-html';
+ * import { greenwoodPluginIncludeHTML } from '@greenwood/plugin-include-html';
  *
  * {
  *   plugins: [{

--- a/packages/plugin-typescript/test/cases/default/default.spec.js
+++ b/packages/plugin-typescript/test/cases/default/default.spec.js
@@ -9,7 +9,7 @@
  * greenwood build
  *
  * User Config
- * const pluginTypeScript = require('@greenwod/plugin-typescript);
+ * const pluginTypeScript = require('@greenwood/plugin-typescript);
  *
  * {
  *   plugins: [

--- a/packages/plugin-typescript/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-typescript/test/cases/options.extend-config/options.extend-config.spec.js
@@ -9,7 +9,7 @@
  * greenwood build
  *
  * User Config
- * const pluginTypeScript = require('@greenwod/plugin-typescript');
+ * const pluginTypeScript = require('@greenwood/plugin-typescript');
  *
  * {
  *   plugins: [


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #961 

## Summary of Changes
1. Fixed the spelling of Import CommonJS named `export`
1. Fix misc spelling mistakes in comments