### PR TITLE
add cloud IDE caveat to puppeteer renderer plugin readme

### DIFF
--- a/packages/plugin-renderer-puppeteer/README.md
+++ b/packages/plugin-renderer-puppeteer/README.md
@@ -9,6 +9,9 @@ A Greenwood plugin for using [**Puppeteer**](https://pptr.dev) as a custom [_pre
 #### Limitations
 Given this plugin instruments an entire browser, this plugin _only_ supports Greenwood's [`prerender` configuration](/docs/configuration/#prerender) option and so will NOT be viable for any [SSR](/docs/server-rendering/) or [Serverless and Edge](https://github.com/ProjectEvergreen/greenwood/discussions/626) features.  Instead, Greenwood will be focusing on making [**WCC**](https://github.com/ProjectEvergreen/wcc) the default and recommended first-party solution.
 
+In addition, **puppeteer** also leverages npm `postinstall` scripts which in some environments, like [Stackblitz](https://github.com/ProjectEvergreen/greenwood/discussions/639), would be disabled and so [YMMV](https://dictionary.cambridge.org/us/dictionary/english/ymmv).
+
+
 #### Dependencies
 
 You may need to install additional Operating System level libraries and dependencies depending on the system you are running on to support headless Chrome. For example, for a Docker based environment like [GitHub Actions](https://github.com/ProjectEvergreen/greenwood/blob/master/.github/workflows/master.yml#L19), you would need to add [this below setup script (or similar)](https://github.com/ProjectEvergreen/greenwood/blob/master/.github/workflows/chromium-lib-install.sh) to your runner


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
https://github.com/ProjectEvergreen/greenwood/discussions/639

## Summary of Changes
1. Add caveat regarding `postintall` and constrained environments like on IDEs, e.g. Stackblitz