### PR TITLE
specify styles so production build doesn't break header logo render

### DIFF
--- a/www/pages/blog/release/v0-26-0.md
+++ b/www/pages/blog/release/v0-26-0.md
@@ -13,7 +13,7 @@ template: blog
 After a lot of hard work, the Greenwood team is eager to share our first round of enhancements related to our [SSR work](/blog/release/v0-24-0/).  By fully leaning into Web Components as a standard API for server rendered pages, we have finally realized something we've been chasing since the early days of the project; all made possible through a new library we've started developing called [**Web Components Compiler (WCC)**](https://github.com/ProjectEvergreen/wcc)!  📣 
 
 <style>
-  img {
+  .gwd-content img {
     width: 60%!important;
     margin-left: 20%;
   }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Blog post `<img>` style breaking header logo in production build (due to inline puppeteer rendering / Shady DOM)
![Screen Shot 2022-08-01 at 8 26 56 PM](https://user-images.githubusercontent.com/895923/182266621-260526d2-ad5a-49c3-bdab-bc4db3937ac2.png)

## Summary of Changes
1. Applied greater CSS specificity to blog post image