### PR TITLE
rename chai assert method for readability

### DIFF
--- a/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
@@ -94,7 +94,7 @@ describe('Build Greenwood With: ', function() {
           
           expect(scriptTag.type).to.be.equal('module');
           // eslint-disable-next-line max-len
-          expect(scriptTag.textContent).to.be.contain('class e extends HTMLElement{constructor(){super(),this.root=this.attachShadow({mode:"open"}),this.root.innerHTML="\\n      <header>This is the header component.</header>\\n    "}}customElements.define("app-header",e);');
+          expect(scriptTag.textContent).to.contain('class e extends HTMLElement{constructor(){super(),this.root=this.attachShadow({mode:"open"}),this.root.innerHTML="\\n      <header>This is the header component.</header>\\n    "}}customElements.define("app-header",e);');
         });
       });
 
@@ -106,7 +106,7 @@ describe('Build Greenwood With: ', function() {
 
           expect(scriptTag.type).to.be.equal('module');
           // eslint-disable-next-line max-len
-          expect(scriptTag.textContent).to.be.contain('class t extends HTMLElement{constructor(){super(),this.list=[]}find(t){this.list.findIndex(e=>new RegExp(`^${t}$`).test(e.route))}}export{t as Foobar};');
+          expect(scriptTag.textContent).to.contain('class t extends HTMLElement{constructor(){super(),this.list=[]}find(t){this.list.findIndex(e=>new RegExp(`^${t}$`).test(e.route))}}export{t as Foobar};');
         });
       });
 
@@ -118,7 +118,7 @@ describe('Build Greenwood With: ', function() {
 
           expect(scriptTag.type).to.be.equal('module');
           // eslint-disable-next-line max-len
-          expect(scriptTag.textContent).to.be.contain('class t extends HTMLElement{constructor(){super(),this.list=[]}find(t){this.list.findIndex(e=>new RegExp(`^${t}$`).test(e.route))}}export{t as Baz};');
+          expect(scriptTag.textContent).to.contain('class t extends HTMLElement{constructor(){super(),this.list=[]}find(t){this.list.findIndex(e=>new RegExp(`^${t}$`).test(e.route))}}export{t as Baz};');
         });
       });
 
@@ -138,13 +138,13 @@ describe('Build Greenwood With: ', function() {
         it('should contain the expected CSS content inlined for theme.css', function() {
           const styleTags = dom.window.document.querySelectorAll('head style');
 
-          expect(styleTags[0].textContent).to.be.contain('*{font-family:Comic Sans,sans-serif;margin:0;padding:0}');
+          expect(styleTags[0].textContent).to.contain('*{font-family:Comic Sans,sans-serif;margin:0;padding:0}');
         });
 
         it('should contain the expected CSS content inlined for page.css', function() {
           const styleTags = dom.window.document.querySelectorAll('head style');
 
-          expect(styleTags[1].textContent).to.be.contain('body{color:red}');
+          expect(styleTags[1].textContent).to.contain('body{color:red}');
         });
       });
     });

--- a/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
@@ -79,7 +79,7 @@ describe('Build Greenwood With: ', function() {
           const js = fs.readFileSync(jsFiles[0], 'utf-8');
 
           // eslint-disable-next-line max-len
-          expect(js).to.be.contain('class HeaderComponent extends HTMLElement {\n  constructor() {\n    super();\n\n    this.root = this.attachShadow({ mode: \'open\' });\n    this.root.innerHTML = `\n      <header>This is the header component.</header>\n    `;\n  }\n}\n\ncustomElements.define(\'app-header\', HeaderComponent);\n');
+          expect(js).to.contain('class HeaderComponent extends HTMLElement {\n  constructor() {\n    super();\n\n    this.root = this.attachShadow({ mode: \'open\' });\n    this.root.innerHTML = `\n      <header>This is the header component.</header>\n    `;\n  }\n}\n\ncustomElements.define(\'app-header\', HeaderComponent);\n');
         });
 
         it('should have the expected <script> tag in the <head>', function() {
@@ -103,7 +103,7 @@ describe('Build Greenwood With: ', function() {
         it('should output the contents of the CSS file unminified', function() {
           const css = fs.readFileSync(cssFiles[0], 'utf-8');
           
-          expect(css).to.be.contain('{\n  margin: 0;\n  padding: 0;\n  font-family: \'Comic Sans\', sans-serif;\n}');
+          expect(css).to.contain('{\n  margin: 0;\n  padding: 0;\n  font-family: \'Comic Sans\', sans-serif;\n}');
         });
 
         it('should have only one expected <link> tag in the <head>', function() {

--- a/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
+++ b/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
@@ -81,7 +81,7 @@ describe('Build Greenwood With: ', function() {
         const scriptTags = dom.window.document.querySelectorAll('head > script[type]');
 
         expect(scriptTags.length).to.be.equal(1);
-        expect(scriptTags[0].href).to.be.contain(/router.*.js/);
+        expect(scriptTags[0].href).to.contain(/router.*.js/);
         expect(scriptTags[0].type).to.be.equal('module');
       });
 

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -84,19 +84,19 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected inline content from inline <script> tag one in index.html', async function() {
         const scriptTagSrcOne = dom.window.document.querySelectorAll('head > script:not([src])')[0];
 
-        expect(scriptTagSrcOne.textContent).to.be.contain('document.getElementsByClassName("output-script-inline-one")[0].innerHTML="script tag module inline one"');
+        expect(scriptTagSrcOne.textContent).to.contain('document.getElementsByClassName("output-script-inline-one")[0].innerHTML="script tag module inline one"');
       });
 
       it('should have the expected inline content from inline <script> tag two in index.html', async function() {
         const scriptTagSrcTwo = dom.window.document.querySelectorAll('head > script:not([src])')[1];
 
-        expect(scriptTagSrcTwo.textContent).to.be.contain('document.getElementsByClassName("output-script-inline-two")[0].innerHTML="script tag module inline two"');
+        expect(scriptTagSrcTwo.textContent).to.contain('document.getElementsByClassName("output-script-inline-two")[0].innerHTML="script tag module inline two"');
       });
 
       it('should have the expected inline content from inline <script> tag three in index.html', async function() {
         const scriptTagSrcTwo = dom.window.document.querySelectorAll('head > script:not([src])')[2];
 
-        expect(scriptTagSrcTwo.textContent).to.be.contain('document.getElementsByClassName(\'output-script-inline-three\')[0].innerHTML = three');
+        expect(scriptTagSrcTwo.textContent).to.contain('document.getElementsByClassName(\'output-script-inline-three\')[0].innerHTML = three');
       });
 
     });
@@ -126,13 +126,13 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected output from the first inline <style> tag in index.html', async function() {
         const styleTags = dom.window.document.querySelectorAll('head > style');
 
-        expect(styleTags[0].textContent.replace(/\n/g, '').trim().replace(' ', '')).to.be.contain('p.output-style{        color: green;      }');
+        expect(styleTags[0].textContent.replace(/\n/g, '').trim().replace(' ', '')).to.contain('p.output-style{        color: green;      }');
       });
 
       it('should have the expected output from the second inline <style> tag in index.html', async function() {
         const styleTags = dom.window.document.querySelectorAll('head > style');
 
-        expect(styleTags[1].textContent.replace(/\n/g, '').trim().replace(' ', '')).to.be.contain('span.output-style{        color: red;      }');
+        expect(styleTags[1].textContent.replace(/\n/g, '').trim().replace(' ', '')).to.contain('span.output-style{        color: red;      }');
       });
 
       it('should have the color style for the output element', function() {

--- a/packages/plugin-graphql/test/cases/query-children/query-children.spec.js
+++ b/packages/plugin-graphql/test/cases/query-children/query-children.spec.js
@@ -187,8 +187,8 @@ describe('Build Greenwood With: ', function() {
 
         expect(listItems.length).to.be.equal(2);        
         
-        expect(listItems[0].innerHTML).to.be.contain('First Post');
-        expect(listItems[1].innerHTML).to.be.contain('Second Post');
+        expect(listItems[0].innerHTML).to.contain('First Post');
+        expect(listItems[1].innerHTML).to.contain('Second Post');
       });
     });
   });

--- a/packages/plugin-graphql/test/cases/query-custom-schema/query-custom-schema.spec.js
+++ b/packages/plugin-graphql/test/cases/query-custom-schema/query-custom-schema.spec.js
@@ -111,14 +111,14 @@ describe('Build Greenwood With: ', function() {
         it('should have a expected src attribute value for all three <img> tags', function() {
           images.forEach((image, i) => {
             const count = i += 1;
-            expect(image.src).to.be.contain(`/assets/logo${count}.png`);
+            expect(image.src).to.contain(`/assets/logo${count}.png`);
           });
         });
 
         it('should have a expected title attribute value for all three <img> tags', function() {
           images.forEach((image, i) => {
             const count = i += 1;
-            expect(image.title).to.be.contain(`${title} - Logo #${count}`);
+            expect(image.title).to.contain(`${title} - Logo #${count}`);
           });
         });
 

--- a/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
+++ b/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
@@ -185,10 +185,10 @@ describe('Build Greenwood With: ', function() {
 
         expect(listItems.length).to.be.equal(4);
         
-        expect(listItems[0].innerHTML).to.be.contain('First Post');
-        expect(listItems[1].innerHTML).to.be.contain('Second Post');
-        expect(listItems[2].innerHTML).to.be.contain('Index');
-        expect(listItems[3].innerHTML).to.be.contain('Not Found');
+        expect(listItems[0].innerHTML).to.contain('First Post');
+        expect(listItems[1].innerHTML).to.contain('Second Post');
+        expect(listItems[2].innerHTML).to.contain('Index');
+        expect(listItems[3].innerHTML).to.contain('Not Found');
       });
     });
   });

--- a/packages/plugin-import-css/test/cases/default/default.spec.js
+++ b/packages/plugin-import-css/test/cases/default/default.spec.js
@@ -70,7 +70,7 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected output from importing styles.css in main.js', function() {
         const contents = fs.readFileSync(scripts[0], 'utf-8');
 
-        expect(contents).to.be.contain('import from styles.css: p{color:red}"');
+        expect(contents).to.contain('import from styles.css: p{color:red}"');
       });
     });
   });

--- a/packages/plugin-import-json/test/cases/default/default.spec.js
+++ b/packages/plugin-import-json/test/cases/default/default.spec.js
@@ -72,7 +72,7 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected output from importing data.json in main.js', function() {
         const contents = fs.readFileSync(scripts[0], 'utf-8');
 
-        expect(contents).to.be.contain('const t=`${"got json"} via import, status is - ${200}`');
+        expect(contents).to.contain('const t=`${"got json"} via import, status is - ${200}`');
       });
     });
   });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Although it still worked the old way, `.to.contain` reads a lot better than `to.be.contain` (IMO)