### PR TITLE
fix incorrect HUD noopener implementation

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -86,7 +86,7 @@ const getAppTemplate = (contents, templatesDir, customImports = [], contextPlugi
       appTemplateContents = appTemplateContents.replace('<body>', `
         <body>
           <div style="position: absolute; width: auto; border: dotted 3px red; background-color: white; opacity: 0.75; padding: 1% 1% 0">
-            <p>Malformed HTML detected, please check your closing tags or an <a href="https://www.google.com/search?q=html+formatter" target="_blank" rel="nopener noreferrer">HTML formatter</a>.</p>
+            <p>Malformed HTML detected, please check your closing tags or an <a href="https://www.google.com/search?q=html+formatter" target="_blank" rel="noreferrer">HTML formatter</a>.</p>
             <details>
               <pre>
                 ${contents.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')}


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Noticed `noopener` was spelled wrong inside the `<a>` tag of the HUD.  But also did some reading and learned
1. In newer browsers (anything that would support WCs at least) [`noopener` is implied when using `target="_blank"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#security_and_privacy) ✅ 
1. If using `noreferrer`, [it basically behaves like `noopener` as well](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noreferrer) ✅ ✅ 

I guess we could do this anywhere else in the site?  🤔 

## Summary of Changes
1. Change HUD to just use `noreferrer`