### PR TITLE
Enhancement/issue 763 parcel css bundling

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -15,11 +15,11 @@ export default {
   staticRouter: true,
   interpolateFrontmatter: true,
   plugins: [
-    ...greenwoodPluginGraphQL(),
-    ...greenwoodPluginPolyfills(),
+    greenwoodPluginGraphQL(),
+    greenwoodPluginPolyfills(),
     greenwoodPluginPostCss(),
-    ...greenwoodPluginImportJson(),
-    ...greenwoodPluginImportCss(),
+    greenwoodPluginImportJson(),
+    greenwoodPluginImportCss(),
     {
       type: 'rollup',
       name: 'rollup-plugin-analyzer',
@@ -34,8 +34,8 @@ export default {
         ];
       }
     },
-    ...greenwoodPluginIncludeHTML(),
-    ...greenwoodPluginRendererPuppeteer()
+    greenwoodPluginIncludeHTML(),
+    greenwoodPluginRendererPuppeteer()
   ],
   markdown: {
     plugins: [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,12 +24,12 @@
     "access": "public"
   },
   "dependencies": {
+    "@parcel/css": "^1.13.1",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@rollup/plugin-replace": "^2.3.4",
     "acorn": "^8.0.1",
     "acorn-walk": "^8.0.0",
     "commander": "^2.20.0",
-    "cssnano": "^5.0.11",
     "es-module-shims": "^1.2.0",
     "front-matter": "^4.0.2",
     "koa": "^2.13.0",
@@ -37,8 +37,6 @@
     "markdown-toc": "^1.2.0",
     "node-fetch": "^2.6.1",
     "node-html-parser": "^1.2.21",
-    "postcss": "^8.3.11",
-    "postcss-import": "^13.0.0",
     "rehype-raw": "^5.0.0",
     "rehype-stringify": "^8.0.0",
     "remark-frontmatter": "^2.0.0",

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -1,555 +1,139 @@
-/* eslint-disable max-depth, no-loop-func */
 import fs from 'fs';
-import htmlparser from 'node-html-parser';
 import path from 'path';
-import postcss from 'postcss';
-import postcssImport from 'postcss-import';
+import { terser } from 'rollup-plugin-terser';
 
-const tokenSuffix = 'scratch';
-const tokenNodeModules = 'node_modules';
-
-const hashString = (queryKeysString) => {
-  let h = 0;
-
-  for (let i = 0; i < queryKeysString.length; i += 1) {
-    h = Math.imul(31, h) + queryKeysString.charCodeAt(i) | 0; // eslint-disable-line no-bitwise
-  }
-
-  return Math.abs(h).toString();
-};
-
-const parseTagForAttributes = (tag) => {
-  return tag.rawAttrs.split(' ').map((attribute) => {
-    if (attribute.indexOf('=') > 0) {
-      const attributePieces = attribute.split('=');
-      return {
-        [attributePieces[0]]: attributePieces[1].replace(/"/g, '').replace(/'/g, '')
-      };
-    } else {
-      return undefined;
-    }
-  }).filter(attribute => attribute)
-    .reduce((accum, attribute) => {
-      return Object.assign(accum, {
-        ...attribute
-      });
-    }, {});
-};
-
-async function getOptimizedSource(url, plugins, compilation) {
-  const initSoure = fs.readFileSync(url, 'utf-8');
-  let optimizedSource = await plugins.reduce(async (bodyPromise, resource) => {
-    const body = await bodyPromise;
-    const shouldOptimize = await resource.shouldOptimize(url, body);
-
-    if (shouldOptimize) {
-      const optimizedBody = await resource.optimize(url, body);
-      
-      return Promise.resolve(optimizedBody);
-    } else {
-      return Promise.resolve(body);
-    }
-  }, Promise.resolve(initSoure));
-
-  // if no custom user optimization found, fallback to standard Greenwood default optimization
-  if (optimizedSource === initSoure) {
-    const standardResourcePlugins = compilation.config.plugins
-      .filter((plugin) => {
-        return plugin.type === 'resource'
-          && plugin.name.indexOf('plugin-standard') === 0;
-      }).map((plugin) => {
-        return plugin.provider(compilation);
-      });
-
-    optimizedSource = await standardResourcePlugins.reduce(async (sourcePromise, resource) => {
-      const source = await sourcePromise;
-      const shouldOptimize = await resource.shouldOptimize(url, source);
-  
-      if (shouldOptimize) {
-        const defaultOptimizedSource = await resource.optimize(url, source);
-        
-        return Promise.resolve(defaultOptimizedSource);
-      } else {
-        return Promise.resolve(source);
-      }
-    }, Promise.resolve(optimizedSource));
-  }
-
-  return Promise.resolve(optimizedSource);
-}
-
-function greenwoodWorkspaceResolver (compilation) {
-  const { userWorkspace, scratchDir } = compilation.context;
-
-  return {
-    name: 'greenwood-workspace-resolver',
-    resolveId(source) {
-      if ((source.indexOf('./') === 0 || source.indexOf('/') === 0) && path.extname(source) !== '.html' && fs.existsSync(path.join(userWorkspace, source))) {        
-        return source.replace(source, path.join(userWorkspace, source));
-      }
-
-      // handle inline script / style bundling
-      if (source.indexOf(`-${tokenSuffix}`) > 0 && fs.existsSync(path.join(scratchDir, source))) {        
-        return source.replace(source, path.join(scratchDir, source));
-      }
-
-      return null;
-    }
-  };
-}
-
-// https://github.com/rollup/rollup/issues/2873
-function greenwoodHtmlPlugin(compilation) {
-  const { projectDirectory, userWorkspace, outputDir, scratchDir } = compilation.context;
-  const { optimization } = compilation.config;
-  const isRemoteUrl = (url = undefined) => url && (url.indexOf('http') === 0 || url.indexOf('//') === 0);
-  const customResources = compilation.config.plugins.filter((plugin) => {
-    return plugin.type === 'resource' && !plugin.isGreenwoodDefaultPlugin;
+function greenwoodResourceLoader (compilation) {
+  const resourcePlugins = compilation.config.plugins.filter((plugin) => {
+    return plugin.type === 'resource';
   }).map((plugin) => {
     return plugin.provider(compilation);
   });
 
   return {
-    name: 'greenwood-html-plugin',
-    // tell Rollup how to handle HTML entry points 
-    // and other custom user resource types like .ts, .gql, etc
+    name: 'greenwood-resource-loader',
+    resolveId(id) {
+      const { userWorkspace } = compilation.context;
+
+      if ((id.indexOf('./') === 0 || id.indexOf('/') === 0) && fs.existsSync(path.join(userWorkspace, id))) {
+        return path.join(userWorkspace, id.replace(/\?type=(.*)/, ''));
+      }
+
+      return null;
+    },
     async load(id) {
-      const extension = path.extname(id);
-      const importAsRegex = /\?type=(.*)/;
+      const importAsIdAsUrl = id.replace(/\?type=(.*)/, '');
+      const extension = path.extname(importAsIdAsUrl);
 
-      // bit of a hack to get these two bugs to play well together
-      // https://github.com/ProjectEvergreen/greenwood/issues/598
-      // https://github.com/ProjectEvergreen/greenwood/issues/604
-      if (importAsRegex.test(id)) {
-        const match = id.match(importAsRegex);
-        const importee = id
-          .replace(match[0], '')
-          .replace(/\\/g, '/');
-        
-        return `export {default} from '${importee}';`;
-      }
+      if (extension !== '.js') {
+        let contents;
 
-      switch (extension) {
+        for (const plugin of resourcePlugins) {
+          const headers = {
+            request: {
+              originalUrl: id
+            },
+            response: {
+              'content-type': plugin.contentType
+            }
+          };
 
-        case '.html':
-          return Promise.resolve('');
-        default:
-          const resourceHandler = (await Promise.all(customResources.map(async (resource) => {
-            const shouldServe = await resource.shouldServe(id);
+          contents = await plugin.shouldServe(importAsIdAsUrl)
+            ? (await plugin.serve(importAsIdAsUrl)).body
+            : contents;
 
-            return shouldServe
-              ? resource
-              : null;
-          }))).filter(resource => resource);
-
-          if (resourceHandler.length) {
-            const response = await resourceHandler[0].serve(id);
-
-            return Promise.resolve(response.body);
+          if (await plugin.shouldIntercept(importAsIdAsUrl, contents, headers)) {
+            contents = (await plugin.intercept(importAsIdAsUrl, contents, headers)).body;
           }
-          break;
+        }
 
+        return contents;
       }
-    },
+    }
+  };
+}
 
-    // crawl through all entry HTML files and emit JavaScript chunks and CSS assets along the way
-    // for bundling with Rollup
-    buildStart(options) {
-      const mappedStyles = [];
-      const mappedScripts = new Map();
+function greenwoodSyncPageResourceBundlesPlugin(compilation) {
+  return {
+    name: 'greenwood-sync-page-resource-bundles-plugin',
+    writeBundle(outputOptions, bundles) {
+      const { outputDir } = compilation.context;
 
-      for (const input in options.input) {
-        try {
-          const inputHtml = options.input[input];
-          const html = fs.readFileSync(inputHtml, 'utf-8');
-          const root = htmlparser.parse(html, {
-            script: true,
-            style: true
-          });
-          const headScripts = root.querySelectorAll('script');
-          const headLinks = root.querySelectorAll('link');
+      for (const resource of compilation.resources.values()) {
+        const resourceKey = resource.sourcePathURL.pathname;
 
-          headScripts.forEach((scriptTag) => {
-            const parsedAttributes = parseTagForAttributes(scriptTag);
-            // handle <script [type="module"] src="some/path.js"></script>
-            if (!isRemoteUrl(parsedAttributes.src) && parsedAttributes.src && !mappedScripts.get(parsedAttributes.src)) {
-              if (optimization === 'static' || parsedAttributes['data-gwd-opt'] === 'static') {
-                // dont need to bundle / emit this one
-              } else {
-                const { src } = parsedAttributes;
-                const absoluteSrc = `${path.normalize(src.replace(/\.\.\//g, '').replace('./', ''))}`;
-                const basePath = absoluteSrc.indexOf(tokenNodeModules) >= 0
-                  ? projectDirectory
-                  : userWorkspace;
-                const id = path.join(basePath, absoluteSrc);
-                const source = fs.readFileSync(id, 'utf-8');
-                
-                mappedScripts.set(absoluteSrc, true);
+        for (const bundle in bundles) {
+          let facadeModuleId = (bundles[bundle].facadeModuleId || '').replace(/\\/g, '/');
 
-                this.emitFile({
-                  type: 'chunk',
-                  id,
-                  name: absoluteSrc.split(`${path.sep}`)[absoluteSrc.split(`${path.sep}`).length - 1].replace('.js', ''),
-                  source
-                });
-              }
+          /*
+           * this is an odd issue related to symlinking in our Greenwood monorepo when building the website
+           * and managing packages that we create as "virtual" modules, like for the mpa router
+           *
+           * ex. import @greenwood/router/router.js -> /node_modules/@greenwood/cli/src/lib/router.js
+           *
+           * when running our tests, which better emulates a real user
+           * facadeModuleId will be in node_modules, which is like how it would be for a user:
+           * /node_modules/@greenwood/cli/src/lib/router.js
+           *
+           * however, when building our website, where symlinking points back to our packages/ directory
+           * facadeModuleId will look like this:
+           * /<workspace>/greenwood/packages/cli/src/lib/router.js
+           *
+           * so we need to massage facadeModuleId a bit for Rollup for our internal development
+           * pathToMatch (before): /node_modules/@greenwood/cli/src/lib/router.js
+           * pathToMatch (after): /cli/src/lib/router.js
+           */
+          if (facadeModuleId && resourceKey.indexOf('/node_modules/@greenwood/cli') > 0 && facadeModuleId.indexOf('/packages/cli') > 0 && fs.existsSync(facadeModuleId)) {
+            facadeModuleId = facadeModuleId.replace('/packages/cli', '/node_modules/@greenwood/cli');
+          }
+
+          if (resourceKey === facadeModuleId) {
+            const { fileName } = bundles[bundle];
+            const { rawAttributes, contents } = resource;
+            const noop = rawAttributes && rawAttributes.indexOf('data-gwd-opt="none"') >= 0 || compilation.config.optimization === 'none';
+            const outputPath = path.join(outputDir, fileName);
+
+            compilation.resources.set(resourceKey, {
+              ...compilation.resources.get(resourceKey),
+              optimizedFileName: fileName,
+              optimizedFileContents: fs.readFileSync(outputPath, 'utf-8'),
+              contents: contents.replace(/\.\//g, '/')
+            });
+
+            if (noop) {
+              fs.writeFileSync(outputPath, contents);
             }
-
-            // handle <script type="module">/* some inline JavaScript code */</script>
-            if (parsedAttributes.type === 'module' && scriptTag.rawText !== '') {
-              const id = hashString(scriptTag.rawText);
-
-              if (!mappedScripts.get(id)) {
-                // using console.log avoids having rollup strip out our internal marker if we used a commnent
-                const marker = `${id}-${tokenSuffix}`;
-                const filename = `${marker}.js`;
-                const source = `${scriptTag.rawText}console.log("${marker}");`.trim();
-
-                fs.writeFileSync(path.join(scratchDir, filename), source);
-                mappedScripts.set(id, true);
-
-                this.emitFile({
-                  type: 'chunk',
-                  id: filename,
-                  name: filename.replace('.js', ''),
-                  source
-                });
-              }
-            }
-          });
-      
-          headLinks.forEach((linkTag) => {
-            const parsedAttributes = parseTagForAttributes(linkTag);
-
-            // handle <link rel="stylesheet" href="./some/path.css"></link>
-            if (!isRemoteUrl(parsedAttributes.href) && parsedAttributes.rel === 'stylesheet' && !mappedStyles[parsedAttributes.href]) {
-              let { href } = parsedAttributes;
-
-              if (href.charAt(0) === '/') {
-                href = href.slice(1);
-              }
-
-              const basePath = href.indexOf(tokenNodeModules) >= 0
-                ? projectDirectory
-                : userWorkspace;
-              const absoluteHref = href.replace(/\.\.\//g, '').replace('./', '');
-              const filePath = path.join(basePath, absoluteHref);
-              const source = fs.readFileSync(filePath, 'utf-8');
-              const to = `${outputDir}/${absoluteHref}`;
-              const hash = hashString(source);
-              const fileName = absoluteHref.replace('.css', `.${hash.slice(0, 8)}.css`);
-
-              if (!fs.existsSync(path.dirname(to)) && href.indexOf(tokenNodeModules) < 0) {
-                fs.mkdirSync(path.dirname(to), {
-                  recursive: true
-                });
-              }
-
-              mappedStyles[fileName] = {
-                type: 'asset',
-                fileName: fileName.indexOf(tokenNodeModules) >= 0
-                  ? path.basename(fileName)
-                  : fileName,
-                name: href,
-                source
-              };
-            }
-          });
-        } catch (e) {
-          console.error(e);
+          }
         }
       }
-
-      // this is a giant work around because PostCSS and some plugins can only be run async
-      // and so have to use with await but _outside_ sync code, like parser / rollup
-      // https://github.com/cssnano/cssnano/issues/68
-      // https://github.com/postcss/postcss/issues/595
-      Promise.all(Object.keys(mappedStyles).map(async (assetKey) => {
-        const asset = mappedStyles[assetKey];
-        const source = mappedStyles[assetKey].source;
-        const basePath = asset.name.indexOf(tokenNodeModules) >= 0
-          ? projectDirectory
-          : userWorkspace;
-        const result = await postcss()
-          .use(postcssImport())
-          .process(source, {
-            from: path.join(basePath, asset.name.replace(/\.\.\//g, ''))
-          });
-
-        asset.source = result.css;
-
-        return new Promise((resolve, reject) => {
-          try {
-            this.emitFile(asset);
-            resolve();
-          } catch (e) {
-            reject(e);
-          }
-        });
-      }));
-    },
-
-    // crawl through all entry HTML files and map Rollup bundled JavaScript and CSS filenames
-    // back to their original <script> / <link> tags, and update the HTML to their new bundled filenames
-    generateBundle(outputOptions, bundles) {      
-      for (const bundleId of Object.keys(bundles)) {
-        try {
-          const bundle = bundles[bundleId];
-
-          if (bundle.isEntry && path.extname(bundle.facadeModuleId) === '.html') {
-            const html = fs.readFileSync(bundle.facadeModuleId, 'utf-8');
-            const root = htmlparser.parse(html, {
-              script: true,
-              style: true
-            });
-            const headScripts = root.querySelectorAll('script');
-            const headLinks = root.querySelectorAll('link');
-            let newHtml = html;
-
-            headScripts.forEach((scriptTag) => {
-              const parsedAttributes = parseTagForAttributes(scriptTag);
-    
-              // handle <script [type="module"] src="some/path.js"></script>
-              if (!isRemoteUrl(parsedAttributes.src) && parsedAttributes.src) {
-                for (const innerBundleId of Object.keys(bundles)) {
-                  const { src } = parsedAttributes;
-                  const facadeModuleId = bundles[innerBundleId].facadeModuleId
-                    ? bundles[innerBundleId].facadeModuleId.replace(/\\/g, '/')
-                    : bundles[innerBundleId].facadeModuleId;
-                  let pathToMatch = src.replace(/\.\.\//g, '').replace('./', '');
-
-                  /*
-                   * this is an odd issue related to symlinking in our Greenwood monorepo when building the website
-                   * and managing packages that we create as "virtaul" modules, like for the mpa router
-                   *
-                   * ex. import @greenwood/router/router.js -> /node_modules/@greenwood/cli/src/lib/router.js
-                   *
-                   * when running our tests, which better emulates a real user
-                   * facadeModuleId will be in node_modules, which is like how it would be for a user:
-                   * /node_modules/@greenwood/cli/src/lib/router.js
-                   *
-                   * however, when building our website, where symlinking points back to our packages/ directory
-                   * facadeModuleId will look like this:
-                   * /<workspace>/greenwood/packages/cli/src/lib/router.js
-                   *
-                   * so we need to massage pathToMatch a bit for Rollup for our internal development
-                   * pathToMatch (before): /node_modules/@greenwood/cli/src/lib/router.js
-                   * pathToMatch (after): /cli/src/lib/router.js
-                   */
-                  if (facadeModuleId && facadeModuleId.indexOf(tokenNodeModules) < 0 && fs.existsSync(path.join(projectDirectory, pathToMatch))) {
-                    pathToMatch = pathToMatch.replace(/\/node_modules\/@greenwood\//, '/');
-                  }
-
-                  if (facadeModuleId && facadeModuleId.indexOf(pathToMatch) > 0) {
-                    const newSrc = `/${innerBundleId}`;
-                    
-                    newHtml = newHtml.replace(src, newSrc);
-                    
-                    if (!parsedAttributes['data-gwd-opt'] && optimization === 'default') {
-                      newHtml = newHtml.replace('<head>', `
-                        <head>
-                        <link rel="modulepreload" href="${newSrc}" as="script">
-                      `);
-                    }
-                  } else if ((parsedAttributes['data-gwd-opt'] === 'static' || optimization === 'static') && newHtml.indexOf(pathToMatch) > 0) {
-                    newHtml = newHtml.replace(scriptTag, '');
-                  }
-                }
-              }
-            });
-        
-            headLinks.forEach((linkTag) => {
-              const parsedAttributes = parseTagForAttributes(linkTag);
-              const { href } = parsedAttributes;
-    
-              // handle <link rel="stylesheet" src="/some/path.css"></link>
-              if (parsedAttributes.rel === 'stylesheet') {
-                for (const bundleId2 of Object.keys(bundles)) {
-                  if (bundleId2.indexOf('.css') > 0) {
-                    const bundle2 = bundles[bundleId2];
-                    if (href.indexOf(bundle2.name) >= 0) {
-                      const newHref = `/${bundle2.fileName}`;
-                      
-                      newHtml = newHtml.replace(href, newHref);
-
-                      if (!parsedAttributes['data-gwd-opt'] && (optimization !== 'none' && optimization !== 'inline')) {
-                        newHtml = newHtml.replace('<head>', `
-                          <head>
-                          <link rel="preload" href="${newHref}" as="style" crossorigin="anonymous"></link>
-                        `);
-                      }
-                    }
-                  }
-                }
-              }
-            });
-
-            bundle.fileName = bundle.facadeModuleId.replace('.greenwood', 'public');
-            bundle.code = newHtml;
-          }
-        } catch (e) {
-          console.error('ERROR', e);
-        }
-      }
-    },
-
-    // crawl through all entry HTML files and map bundled JavaScript and CSS filenames
-    // back to their original _inline_ <script> / <link> tags
-    async writeBundle(outputOptions, bundles) {
-      const scratchFiles = {};
-
-      for (const bundleId of Object.keys(bundles)) {
-        const bundle = bundles[bundleId];
-
-        if (bundle.isEntry && path.extname(bundle.facadeModuleId) === '.html') {
-          const htmlPath = bundle.facadeModuleId.replace('.greenwood', 'public');
-          let html = fs.readFileSync(htmlPath, 'utf-8');
-          const root = htmlparser.parse(html, {
-            script: true,
-            style: true
-          });
-          const headScripts = root.querySelectorAll('script');
-          const headLinks = root.querySelectorAll('link');
-
-          headScripts.forEach((scriptTag) => {
-            const parsedAttributes = parseTagForAttributes(scriptTag);
-            const isScriptSrcTag = parsedAttributes.src && parsedAttributes.type === 'module';
-
-            // handle <script type="module" src="..."></script>
-            if ((parsedAttributes['data-gwd-opt'] === 'inline' || optimization === 'inline') && isScriptSrcTag && !isRemoteUrl(parsedAttributes.src)) {
-              const src = parsedAttributes.src;
-              const basePath = src.indexOf(tokenNodeModules) >= 0 
-                ? process.cwd()
-                : outputDir;
-              const outputPath = path.join(basePath, src);
-              const js = fs.readFileSync(outputPath, 'utf-8')
-                .replace(/\$/g, '$$$') // https://github.com/ProjectEvergreen/greenwood/issues/656
-                .replace(/\.\//g, '/'); // force absolute paths
-              scratchFiles[src] = true;
-
-              html = html.replace(`<script ${scriptTag.rawAttrs}></script>`, `
-                <script type="module">
-                  ${js}
-                </script>
-              `);
-            }
-
-            // handle <script type="module"> /* inline code */ </script>
-            if (parsedAttributes.type === 'module' && !parsedAttributes.src) {
-              const id = hashString(scriptTag.rawText);
-              const markerExp = `console.log\\("[0-9]+-${tokenSuffix}"\\)`;
-              const markerRegex = new RegExp(markerExp);
-
-              for (const innerBundleId of Object.keys(bundles)) {
-                if (innerBundleId.indexOf(`-${tokenSuffix}`) > 0 && path.extname(innerBundleId) === '.js') {
-                  const bundledSource = fs.readFileSync(path.join(outputDir, innerBundleId), 'utf-8')
-                    .replace(/\$/g, '$$$') // https://github.com/ProjectEvergreen/greenwood/issues/656
-                    .replace(/\.\//g, '/'); // force absolute paths
-                  
-                  if (markerRegex.test(bundledSource)) {
-                    const marker = bundledSource.match(new RegExp(`[0-9]+-${tokenSuffix}`))[0].split('-')[0];
-                    
-                    if (id === marker) {
-                      if (parsedAttributes['data-gwd-opt'] === 'static') {
-                        html = html.replace(scriptTag.rawText, '').replace(/<script .*data-gwd-opt="static".*><\/script>/, '');
-                      } else {
-                        const cleaned = bundledSource
-                          .replace(new RegExp(`,${markerExp};\n`), '')
-                          .replace(new RegExp(`${markerExp};\n`), '')
-                          .replace(new RegExp(`${markerExp};`), '');
-
-                        html = html.replace(scriptTag.rawText, cleaned);
-                      }
-
-                      scratchFiles[innerBundleId] = true;
-                    }
-                  }
-                }
-              }
-            }
-          });
-
-          headLinks
-            .forEach((linkTag) => {
-              const parsedAttributes = parseTagForAttributes(linkTag);
-              const isLocalLinkTag = parsedAttributes.rel === 'stylesheet'
-                && !isRemoteUrl(parsedAttributes.href);
-              
-              if (isLocalLinkTag && (parsedAttributes['data-gwd-opt'] === 'inline' || optimization === 'inline')) {
-                const href = parsedAttributes.href;
-                const outputPath = path.join(outputDir, href);
-                const css = fs.readFileSync(outputPath, 'utf-8');
-                scratchFiles[href] = true;
-
-                // https://github.com/ProjectEvergreen/greenwood/issues/810
-                // when preendering, puppeteer normalizes everything to <link .../>
-                // but if not using prerendering, then it could come out as <link ...></link>
-                // not great, but best we can do for now until #742
-                html = html.replace(`<link ${linkTag.rawAttrs}>`, `
-                  <style>
-                    ${css}
-                  </style>
-                `).replace(`<link ${linkTag.rawAttrs}/>`, `
-                  <style>
-                    ${css}
-                  </style>
-                `);
-              }
-            });
-
-          // mark each HTML's sourcemap file (generated by Rollup) to be cleaned up
-          // would be nice if we could just prevent Rollup from generating sourcemaps for just our input files in the first place (GFI)
-          // https://github.com/ProjectEvergreen/greenwood/issues/659
-          scratchFiles[`${htmlPath.replace(outputDir, '')}.map`] = true;
-          html = html.replace(/\/\/# sourceMappingURL=(.*)\.html\.map/, '');
-
-          await fs.promises.writeFile(htmlPath, html);
-        } else {
-          const sourcePath = `${outputDir}/${bundleId}`;
-          const optimizedSource = await getOptimizedSource(sourcePath, customResources, compilation);
-  
-          await fs.promises.writeFile(sourcePath, optimizedSource);
-        }
-      }
-
-      // cleanup any scratch files
-      return Promise.all(Object.keys(scratchFiles).map(async (file) => {
-        return await fs.promises.unlink(path.join(outputDir, file));
-      }));
     }
   };
 }
 
 const getRollupConfig = async (compilation) => {
-  const { scratchDir, outputDir } = compilation.context;
-  const inputs = compilation.graph.map((page) => {
-    return path.normalize(`${scratchDir}${page.outputPath}`);
-  });
-
-  // order matters but so far nodeModulesResource resolve plugin is the first in our list (so far)
-  const greenwoodRollupPlugins = compilation.config.plugins.filter((plugin) => {
-    return plugin.type === 'rollup' && plugin.isGreenwoodDefaultPlugin;
-  }).map((plugin) => {
-    return plugin.provider(compilation).flat();
-  }).concat([
-    greenwoodWorkspaceResolver(compilation),
-    greenwoodHtmlPlugin(compilation)
-  ]).flat();
-
-  const userRollupPlugins = compilation.config.plugins.filter((plugin) => {
-    return plugin.type === 'rollup' && !plugin.isGreenwoodDefaultPlugin;
-  }).map((plugin) => {
-    return plugin.provider(compilation).flat();
+  const { outputDir } = compilation.context;
+  const input = [...compilation.resources.values()]
+    .filter(resource => resource.type === 'script')
+    .map(resource => resource.sourcePathURL.pathname);
+  const customRollupPlugins = compilation.config.plugins.filter(plugin => {
+    return plugin.type === 'rollup';
+  }).map(plugin => {
+    return plugin.provider(compilation);
   }).flat();
 
   return [{
-    input: inputs,
+    input,
     output: { 
       dir: outputDir,
       entryFileNames: '[name].[hash].js',
       chunkFileNames: '[name].[hash].js',
       sourcemap: true
     },
+    plugins: [
+      greenwoodResourceLoader(compilation),
+      greenwoodSyncPageResourceBundlesPlugin(compilation),
+      ...customRollupPlugins,
+      terser()
+    ],
     context: 'window',
     onwarn: (errorObj) => {
       const { code, message } = errorObj;
@@ -578,13 +162,8 @@ const getRollupConfig = async (compilation) => {
           console.debug(message);
 
       }
-    },
-    plugins: [
-      ...greenwoodRollupPlugins,
-      ...userRollupPlugins
-    ]
+    }
   }];
-
 };
 
 export { getRollupConfig };

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -79,7 +79,7 @@ const run = async() => {
       case 'serve':
         process.env.__GWD_COMMAND__ = 'build';
 
-        await (await import('./commands/build.js')).runProductionBuild(Object.assign({}, compilation));
+        await (await import('./commands/build.js')).runProductionBuild(compilation);
         await (await import('./commands/serve.js')).runProdServer(compilation);
 
         break;

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import { hashString } from '../lib/hashing-utils.js';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+function modelResource(context, type, src = undefined, contents = undefined, optimizationAttr = undefined, rawAttributes = undefined) {
+  const { projectDirectory, scratchDir, userWorkspace } = context;
+  const extension = type === 'script' ? 'js' : 'css';
+  const windowsDriveRegex = /\/[a-zA-Z]{1}:\//;
+  let sourcePathURL;
+
+  if (src) {
+    sourcePathURL = src.indexOf('/node_modules') === 0
+      ? pathToFileURL(path.join(projectDirectory, src)) // TODO (good first issue) get "real" location of node modules
+      : pathToFileURL(path.join(userWorkspace, src.replace(/\.\.\//g, '').replace('./', '')));
+
+    contents = fs.readFileSync(sourcePathURL, 'utf-8');
+  } else {
+    const scratchFileName = hashString(contents);
+
+    sourcePathURL = pathToFileURL(path.join(scratchDir, `${scratchFileName}.${extension}`));
+    fs.writeFileSync(sourcePathURL, contents);
+  }
+
+  // TODO (good first issue) handle for Windows adding extra / in front of drive letter for whatever reason :(
+  // e.g. turn /C:/... -> C:/...
+  // and also URL is readonly in NodeJS??
+  if (windowsDriveRegex.test(sourcePathURL.pathname)) {
+    const driveMatch = sourcePathURL.pathname.match(windowsDriveRegex)[0];
+
+    sourcePathURL = {
+      ...sourcePathURL,
+      pathname: sourcePathURL.pathname.replace(driveMatch, driveMatch.replace('/', '')),
+      href: sourcePathURL.href.replace(driveMatch, driveMatch.replace('/', ''))
+    };
+  }
+
+  return {
+    src, // if <script src="..."></script> or <link href="..."></link>
+    sourcePathURL, // src as a URL
+    type,
+    contents,
+    optimizedFileName: undefined,
+    optimizedFileContents: undefined,
+    optimizationAttr,
+    rawAttributes
+  };
+}
+
+export { modelResource };

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -1,21 +1,151 @@
+import fs from 'fs';
 import { getRollupConfig } from '../config/rollup.config.js';
+import { hashString } from '../lib/hashing-utils.js';
+import path from 'path';
 import { rollup } from 'rollup';
+
+async function cleanUpResources(compilation) {
+  const { outputDir } = compilation.context;
+
+  for (const resource of compilation.resources.values()) {
+    const { src, optimizedFileName, optimizationAttr } = resource;
+    const optConfig = ['inline', 'static'].indexOf(compilation.config.optimization) >= 0;
+    const optAttr = ['inline', 'static'].indexOf(optimizationAttr) >= 0;
+
+    if (optimizedFileName && (!src || (optAttr || optConfig))) {
+      fs.unlinkSync(path.join(outputDir, optimizedFileName));
+    }
+  }
+}
+
+async function optimizeStaticPages(compilation, optimizeResources) {
+  const { scratchDir, outputDir } = compilation.context;
+
+  return Promise.all(compilation.graph
+    .filter(page => !page.isSSR || (page.isSSR && page.data.static))
+    .map(async (page) => {
+      const { route, outputPath } = page;
+      const html = await fs.promises.readFile(path.join(scratchDir, outputPath), 'utf-8');
+
+      if (route !== '/404/' && !fs.existsSync(path.join(outputDir, route))) {
+        fs.mkdirSync(path.join(outputDir, route), {
+          recursive: true
+        });
+      }
+
+      let htmlOptimized = await optimizeResources.reduce(async (htmlPromise, resource) => {
+        const contents = await htmlPromise;
+        const shouldOptimize = await resource.shouldOptimize(outputPath, contents);
+
+        return shouldOptimize
+          ? resource.optimize(outputPath, contents)
+          : Promise.resolve(contents);
+      }, Promise.resolve(html));
+
+      // clean up optimization markers
+      htmlOptimized = htmlOptimized.replace(/data-gwd-opt=".*[a-z]"/g, '');
+
+      await fs.promises.writeFile(path.join(outputDir, outputPath), htmlOptimized);
+    })
+  );
+}
+
+async function bundleStyleResources(compilation, optimizationPlugins) {
+  const { outputDir } = compilation.context;
+
+  for (const resource of compilation.resources.values()) {
+    const { contents, optimizationAttr, src = '', type } = resource;
+
+    if (['style', 'link'].includes(type)) {
+      const resourceKey = resource.sourcePathURL.pathname;
+      const srcPath = src && src.replace(/\.\.\//g, '').replace('./', '');
+      let optimizedFileName;
+      let optimizedFileContents;
+
+      if (src) {
+        const basename = path.basename(srcPath);
+        const basenamePieces = path.basename(srcPath).split('.');
+
+        optimizedFileName = srcPath.indexOf('/node_modules') >= 0
+          ? `${basenamePieces[0]}.${hashString(contents)}.css`
+          : srcPath.replace(basename, `${basenamePieces[0]}.${hashString(contents)}.css`);
+      } else {
+        optimizedFileName = `${hashString(contents)}.css`;
+      }
+
+      const outputPathRoot = path.join(outputDir, path.dirname(optimizedFileName));
+
+      if (!fs.existsSync(outputPathRoot)) {
+        fs.mkdirSync(outputPathRoot, {
+          recursive: true
+        });
+      }
+
+      if (compilation.config.optimization === 'none' || optimizationAttr === 'none') {
+        optimizedFileContents = contents;
+      } else {
+        const url = resource.sourcePathURL.pathname;
+        let optimizedStyles = await fs.promises.readFile(url, 'utf-8');
+
+        for (const plugin of optimizationPlugins) {
+          optimizedStyles = await plugin.shouldOptimize(url, optimizedStyles)
+            ? await plugin.optimize(url, optimizedStyles)
+            : optimizedStyles;
+        }
+
+        optimizedFileContents = optimizedStyles;
+      }
+
+      compilation.resources.set(resourceKey, {
+        ...compilation.resources.get(resourceKey),
+        optimizedFileName,
+        optimizedFileContents
+      });
+
+      await fs.promises.writeFile(path.join(outputDir, optimizedFileName), optimizedFileContents);
+    }
+  }
+}
+
+async function bundleScriptResources(compilation) {
+  // https://rollupjs.org/guide/en/#differences-to-the-javascript-api
+  const [rollupConfig] = await getRollupConfig(compilation);
+
+  if (rollupConfig.input.length !== 0) {
+    const bundle = await rollup(rollupConfig);
+    await bundle.write(rollupConfig.output);
+  }
+}
 
 const bundleCompilation = async (compilation) => {
 
   return new Promise(async (resolve, reject) => {
     try {
-      compilation.graph = compilation.graph.filter(page => !page.isSSR || (page.isSSR && page.data.static));
+      const optimizeResourcePlugins = compilation.config.plugins.filter((plugin) => {
+        return plugin.type === 'resource';
+      }).map((plugin) => {
+        return plugin.provider(compilation);
+      }).filter((provider) => {
+        return provider.shouldOptimize && provider.optimize;
+      });
+      // centrally register all static resources
+      compilation.graph.map((page) => {
+        return page.imports;
+      }).flat().forEach(resource => {
+        compilation.resources.set(resource.sourcePathURL.pathname, resource);
+      });
 
-      // https://rollupjs.org/guide/en/#differences-to-the-javascript-api
-      if (compilation.graph.length > 0) {
-        const rollupConfigs = await getRollupConfig({
-          ...compilation
-        });
-        const bundle = await rollup(rollupConfigs[0]);
+      console.info('bundling static assets...');
 
-        await bundle.write(rollupConfigs[0].output);
-      }
+      await Promise.all([
+        await bundleScriptResources(compilation),
+        await bundleStyleResources(compilation, optimizeResourcePlugins.filter(plugin => plugin.contentType.includes('text/css')))
+      ]);
+
+      console.info('optimizing static pages....');
+
+      await optimizeStaticPages(compilation, optimizeResourcePlugins.filter(plugin => plugin.contentType.includes('text/html')));
+      await cleanUpResources(compilation);
 
       resolve();
     } catch (err) {

--- a/packages/cli/src/lifecycles/compile.js
+++ b/packages/cli/src/lifecycles/compile.js
@@ -9,7 +9,8 @@ const generateCompilation = () => {
       let compilation = {
         graph: [],
         context: {},
-        config: {}
+        config: {},
+        resources: new Map()
       };
 
       console.info('Initializing project config');

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -5,6 +5,7 @@ import { fileURLToPath, pathToFileURL, URL } from 'url';
 // get and "tag" all plugins provided / maintained by the @greenwood/cli
 // and include as the default set, with all user plugins getting appended
 const greenwoodPluginsBasePath = fileURLToPath(new URL('../plugins', import.meta.url));
+const PLUGINS_FLATTENED_DEPTH = 2;
 
 const greenwoodPlugins = (await Promise.all([
   path.join(greenwoodPluginsBasePath, 'copy'),
@@ -14,7 +15,7 @@ const greenwoodPlugins = (await Promise.all([
 ].map(async (pluginDirectory) => {
   const files = await fs.promises.readdir(pluginDirectory);
 
-  return (await Promise.all(files.map(async(file) => {
+  return await Promise.all(files.map(async(file) => {
     const importPaTh = pathToFileURL(`${pluginDirectory}${path.sep}${file}`);
     const pluginImport = await import(importPaTh);
     const plugin = pluginImport[Object.keys(pluginImport)[0]];
@@ -22,8 +23,8 @@ const greenwoodPlugins = (await Promise.all([
     return Array.isArray(plugin)
       ? plugin
       : [plugin];
-  }))).flat();
-}).flat())).flat().map((plugin) => {
+  }));
+}))).flat(PLUGINS_FLATTENED_DEPTH).map((plugin) => {
   return {
     isGreenwoodDefaultPlugin: true,
     ...plugin
@@ -99,7 +100,9 @@ const readAndMergeConfig = async() => {
         }
 
         if (plugins && plugins.length > 0) {
-          plugins.forEach(plugin => {
+          const flattened = plugins.flat(PLUGINS_FLATTENED_DEPTH);
+
+          flattened.forEach(plugin => {
             if (!plugin.type || pluginTypes.indexOf(plugin.type) < 0) {
               reject(`Error: greenwood.config.js plugins must be one of type "${pluginTypes.join(', ')}". got "${plugin.type}" instead.`);
             }
@@ -117,14 +120,22 @@ const readAndMergeConfig = async() => {
             }
           });
 
-          // if user provides a custom renderer, replace ours with theirs
-          if (plugins.filter(plugin => plugin.type === 'renderer').length === 1) {
+          // if user provided a custom renderer, filter out Greenwood's default renderer
+          const customRendererPlugins = flattened.filter(plugin => plugin.type === 'renderer').length;
+
+          if (customRendererPlugins === 1) {
             customConfig.plugins = customConfig.plugins.filter((plugin) => {
               return plugin.type !== 'renderer';
             });
+          } else if (customRendererPlugins > 1) {
+            console.warn('More than one custom renderer plugin detected.  Please make sure you are only loading one.');
+            console.debug(plugins.filter(plugin => plugin.type === 'renderer'));
           }
 
-          customConfig.plugins = customConfig.plugins.concat(plugins);
+          customConfig.plugins = [
+            ...customConfig.plugins,
+            ...flattened
+          ];
         }
 
         if (devServer && Object.keys(devServer).length > 0) {

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -3,7 +3,7 @@ import path from 'path';
 import { fileURLToPath, URL } from 'url';
 
 const initContext = async({ config }) => {
-  const scratchDir = path.join(process.cwd(), './.greenwood/');
+  const scratchDir = path.join(process.cwd(), './.greenwood');
   const outputDir = path.join(process.cwd(), './public');
   const dataDir = fileURLToPath(new URL('../data', import.meta.url));
 

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -1,6 +1,7 @@
 /* eslint-disable complexity, max-depth */
 import fs from 'fs';
 import fm from 'front-matter';
+import { modelResource } from '../lib/resource-utils.js';
 import path from 'path';
 import toc from 'markdown-toc';
 import { Worker } from 'worker_threads';
@@ -123,7 +124,6 @@ const generateGraph = async (compilation) => {
               /* ---------End Menu Query-------------------- */
             } else {
               const routeWorkerUrl = compilation.config.plugins.filter(plugin => plugin.type === 'renderer')[0].provider().workerUrl;
-              // const relativePagePath = fullPath.substring(pagesDir.length - 1, fullPath.length);
               id = filename.split(path.sep)[filename.split(path.sep).length - 1].replace(extension, '');
               label = id.split('-')
                 .map((idPart) => {
@@ -147,6 +147,13 @@ const generateGraph = async (compilation) => {
                 });
                 worker.on('message', (result) => {
                   if (result.frontmatter) {
+                    const resources = (result.frontmatter.imports || []).map((resource) => {
+                      const type = path.extname(resource) === '.js' ? 'script' : 'link';
+
+                      return modelResource(compilation.context, type, resource);
+                    });
+
+                    result.frontmatter.imports = resources;
                     ssrFrontmatter = result.frontmatter;
                   }
                   resolve();

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -3,8 +3,6 @@ import { hashString } from '../lib/hashing-utils.js';
 import path from 'path';
 import Koa from 'koa';
 import { ResourceInterface } from '../lib/resource-interface.js';
-import { getRollupConfig } from '../config/rollup.config.js';
-import { rollup } from 'rollup';
 
 async function getDevServer(compilation) {
   const app = new Koa();
@@ -310,18 +308,6 @@ async function getHybridServer(compilation) {
           ? resource.optimize(url, html, headers)
           : Promise.resolve(html);
       }, Promise.resolve(body));
-
-      await fs.promises.mkdir(path.join(compilation.context.scratchDir, url), { recursive: true });
-      await fs.promises.writeFile(path.join(compilation.context.scratchDir, url, 'index.html'), body);
-
-      const rollupConfigs = await getRollupConfig({
-        ...compilation,
-        graph: [matchingRoute]
-      });
-      const bundle = await rollup(rollupConfigs[0]);
-      await bundle.write(rollupConfigs[0].output);
-
-      body = await fs.promises.readFile(path.join(compilation.context.outputDir, url, 'index.html'), 'utf-8');
 
       ctx.status = 200;
       ctx.set('content-type', 'text/html');

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -82,8 +82,7 @@ class NodeModulesResource extends ResourceInterface {
         const hasHead = body.match(/\<head>(.*)<\/head>/s);
 
         if (hasHead && hasHead.length > 0) {
-          const contents = hasHead[0]
-            .replace(/type="module"/g, 'type="module-shim"');
+          const contents = hasHead[0].replace(/type="module"/g, 'type="module-shim"');
 
           newContents = newContents.replace(/\<head>(.*)<\/head>/s, contents.replace(/\$/g, '$$$')); // https://github.com/ProjectEvergreen/greenwood/issues/656);
         }

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -8,6 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import cssnano from 'cssnano';
 import postcss from 'postcss';
+import postcssImport from 'postcss-import';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class StandardCssResource extends ResourceInterface {
@@ -43,7 +44,10 @@ class StandardCssResource extends ResourceInterface {
       try {  
         const { outputDir, userWorkspace } = this.compilation.context;
         const workspaceUrl = url.replace(outputDir, userWorkspace);
-        const css = (await postcss([cssnano]).process(body, { from: workspaceUrl })).css;
+        const contents = body || await fs.promises.readFile(url, 'utf-8');
+        const css = (await postcss([cssnano])
+          .use(postcssImport())
+          .process(contents, { from: workspaceUrl })).css;
 
         resolve(css);
       } catch (e) {

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -58,17 +58,17 @@ const getPageTemplate = (fullPath, templatesDir, template, contextPlugins = [], 
   return contents;
 };
 
-const getAppTemplate = (contents, templatesDir, customImports = [], contextPlugins, enableHud, frontmatterTitle) => {
+const getAppTemplate = (pageTemplateContents, templatesDir, customImports = [], contextPlugins, enableHud, frontmatterTitle) => {
   const userAppTemplatePath = `${templatesDir}app.html`;
   const customAppTemplates = getCustomPageTemplates(contextPlugins, 'app');
-
+  let mergedTemplateContents = '';
   let appTemplateContents = customAppTemplates.length > 0
     ? fs.readFileSync(`${customAppTemplates[0]}/app.html`, 'utf-8')
     : fs.existsSync(userAppTemplatePath)
       ? fs.readFileSync(userAppTemplatePath, 'utf-8')
       : fs.readFileSync(fileURLToPath(new URL('../../templates/app.html', import.meta.url)), 'utf-8');
 
-  const root = htmlparser.parse(contents, {
+  const pageRoot = htmlparser.parse(pageTemplateContents, {
     script: true,
     style: true,
     noscript: true,
@@ -79,8 +79,11 @@ const getAppTemplate = (contents, templatesDir, customImports = [], contextPlugi
     style: true
   });
 
-  if (!root.valid) {
+  if (!pageRoot.valid || !appRoot.valid) {
     console.debug('ERROR: Invalid HTML detected');
+    const invalidContents = !pageRoot.valid
+      ? pageTemplateContents
+      : appTemplateContents;
 
     if (enableHud) {
       appTemplateContents = appTemplateContents.replace('<body>', `
@@ -89,177 +92,81 @@ const getAppTemplate = (contents, templatesDir, customImports = [], contextPlugi
             <p>Malformed HTML detected, please check your closing tags or an <a href="https://www.google.com/search?q=html+formatter" target="_blank" rel="nopener noreferrer">HTML formatter</a>.</p>
             <details>
               <pre>
-                ${contents.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')}
+                ${invalidContents.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')}
               </pre>
             </details>
           </div>
       `);
     }
 
-    appTemplateContents = appTemplateContents.replace(/<page-outlet><\/page-outlet>/, '');
+    mergedTemplateContents = appTemplateContents.replace(/<page-outlet><\/page-outlet>/, '');
   } else {
     const appTitle = appRoot ? appRoot.querySelector('head title') : null;
-    const body = root.querySelector('body') ? root.querySelector('body').innerHTML : '';
-    const headScripts = root.querySelectorAll('head script');
-    const headLinks = root.querySelectorAll('head link');
-    const headMeta = root.querySelectorAll('head meta');
-    const headStyles = root.querySelectorAll('head style');
-    const headTitle = root.querySelector('head title');
-    const appTemplateHeadContents = appRoot.querySelector('head').innerHTML;
-    const hasInterpolatedFrontmatter = headTitle && headTitle.rawText.indexOf('${globalThis.page.title}') >= 0
+    const appBody = appRoot.querySelector('body') ? appRoot.querySelector('body').innerHTML : '';
+    const pageBody = pageRoot.querySelector('body') ? pageRoot.querySelector('body').innerHTML : '';
+    const pageTitle = pageRoot.querySelector('head title');
+    const hasInterpolatedFrontmatter = pageTitle && pageTitle.rawText.indexOf('${globalThis.page.title}') >= 0
      || appTitle && appTitle.rawText.indexOf('${globalThis.page.title}') >= 0;
 
     const title = hasInterpolatedFrontmatter // favor frontmatter interpolation first
-      ? headTitle && headTitle.rawText
-        ? headTitle.rawText
+      ? pageTitle && pageTitle.rawText
+        ? pageTitle.rawText
         : appTitle.rawText
       : frontmatterTitle // otherwise, work in order of specificity from page -> page template -> app template
         ? frontmatterTitle
-        : headTitle && headTitle.rawText
-          ? headTitle.rawText
+        : pageTitle && pageTitle.rawText
+          ? pageTitle.rawText
           : appTitle && appTitle.rawText
             ? appTitle.rawText
             : 'My App';
-    appTemplateContents = appTemplateContents.replace(/<page-outlet><\/page-outlet>/, body);
 
-    if (title) {
-      if (!appTitle) {
-        appTemplateContents = appTemplateContents.replace('<head>', '<head>\n <title></title>');
-      }
+    const mergedHtml = pageRoot.querySelector('html').rawAttrs !== ''
+      ? `<html ${pageRoot.querySelector('html').rawAttrs}>`
+      : appRoot.querySelector('html').rawAttrs !== ''
+        ? `<html ${appRoot.querySelector('html').rawAttrs}>`
+        : '<html>';
 
-      appTemplateContents = appTemplateContents.replace(/<title>(.*)<\/title>/, `<title>${title}</title>`);
-    }
+    const mergedMeta = [
+      ...appRoot.querySelectorAll('head meta'),
+      ...pageRoot.querySelectorAll('head meta')
+    ].join('\n');
 
-    // merge <script> tags
-    if (headScripts.length > 0) {
-      const matchNeedleScript = /<script .*<\/script>/g;
-      const appHeadScriptMatches = appTemplateHeadContents.match(matchNeedleScript);
-      const lastScript = appHeadScriptMatches && appHeadScriptMatches.length && appHeadScriptMatches.length > 0
-        ? appHeadScriptMatches[appHeadScriptMatches.length - 1]
-        : '</head>';
-      const pageBodyScripts = headScripts.map((script) => {
-        if (script.text === '') {
-          return `<script ${script.rawAttrs}></script>`;
-        } else {
-          const attributes = script.rawAttrs !== ''
-            ? ` ${script.rawAttrs}`
-            : '';
-          const source = script.text.replace(/\$/g, '$$$'); // https://github.com/ProjectEvergreen/greenwood/issues/656
+    const mergedLinks = [
+      ...appRoot.querySelectorAll('head link'),
+      ...pageRoot.querySelectorAll('head link')
+    ].join('\n');
 
-          return `
-            <script${attributes}>
-              ${source}
-            </script>
-          `;
-        }
-      });
+    const mergedStyles = [
+      ...appRoot.querySelectorAll('head style'),
+      ...pageRoot.querySelectorAll('head style'),
+      ...customImports.filter(resource => path.extname(resource) === '.css')
+        .map(resource => `<link rel="stylesheet" href="${resource}"></link>`)
+    ].join('\n');
 
-      if (lastScript === '</head>') {
-        appTemplateContents = appTemplateContents.replace(lastScript, `
-          ${pageBodyScripts.join('\n')}
-        ${lastScript}\n
-      `);
-      } else {
-        appTemplateContents = appTemplateContents.replace(lastScript, `${lastScript}\n
-          ${pageBodyScripts.join('\n')}
-        `);
-      }
-    }
+    const mergedScripts = [
+      ...appRoot.querySelectorAll('head script'),
+      ...pageRoot.querySelectorAll('head script'),
+      ...customImports.filter(resource => path.extname(resource) === '.js')
+        .map(resource => `<script src="${resource}" type="module"></script>`)
+    ].join('\n');
 
-    // merge <link> tags
-    if (headLinks.length > 0) {
-      const matchNeedleLink = /<link .*/g;
-      const appHeadLinkMatches = appTemplateHeadContents.match(matchNeedleLink);
-      const lastLink = appHeadLinkMatches && appHeadLinkMatches.length && appHeadLinkMatches.length > 0
-        ? appHeadLinkMatches[appHeadLinkMatches.length - 1]
-        : '</head>';
-      const pageHeadLinks = headLinks.map((link) => {
-        return `<link ${link.rawAttrs}/>`;
-      });
-
-      if (lastLink === '</head>') {
-        appTemplateContents = appTemplateContents.replace(lastLink, `
-          ${pageHeadLinks.join('\n')}
-        ${lastLink}\n
-      `);
-      } else {
-        appTemplateContents = appTemplateContents.replace(lastLink, `${lastLink}\n
-          ${pageHeadLinks.join('\n')}
-        `);
-      }
-    }
-
-    // merge <style> tags
-    if (headStyles.length > 0) {
-      const matchNeedleStyle = /<style .*/g;
-      const appHeadStyleMatches = appTemplateHeadContents.match(matchNeedleStyle);
-      const lastStyle = appHeadStyleMatches && appHeadStyleMatches.length && appHeadStyleMatches.length > 0
-        ? appHeadStyleMatches[appHeadStyleMatches.length - 1]
-        : '</head>';
-      const pageBodyStyles = headStyles.map((style) => {
-        const attributes = style.rawAttrs === '' ? '' : ` ${style.rawAttrs}`;
-
-        return `
-          <style${attributes}>
-            ${style.text}
-          </style>
-        `;
-      });
-
-      if (lastStyle === '</head>') {
-        appTemplateContents = appTemplateContents.replace(lastStyle, `
-          ${pageBodyStyles.join('\n')}
-        ${lastStyle}\n
-      `);
-      } else {
-        appTemplateContents = appTemplateContents.replace(lastStyle, `${lastStyle}\n
-          ${pageBodyStyles.join('\n')}
-        `);
-      }
-    }
-
-    // merge <meta>
-    if (headMeta.length > 0) {
-      const matchNeedleMeta = /<meta .*/g;
-      const appHeadMetaMatches = appTemplateHeadContents.match(matchNeedleMeta);
-      const lastMeta = appHeadMetaMatches && appHeadMetaMatches.length && appHeadMetaMatches.length > 0
-        ? appHeadMetaMatches[appHeadMetaMatches.length - 1]
-        : '</title>';
-      const pageMeta = headMeta.map((meta) => {
-        return `<meta ${meta.rawAttrs}/>`;
-      });
-
-      appTemplateContents = appTemplateContents.replace(lastMeta.replace('>', '/>'), `${lastMeta.replace('>', '/>')}
-        ${pageMeta.join('\n')}
-      `);
-    }
-
-    customImports.forEach((customImport) => {
-      const extension = path.extname(customImport);
-
-      switch (extension) {
-
-        case '.js':
-          appTemplateContents = appTemplateContents.replace('</head>', `
-              <script src="${customImport}" type="module"></script>
-            </head>
-          `);
-          break;
-        case '.css':
-          appTemplateContents = appTemplateContents.replace('</head>', `
-            <link rel="stylesheet" href="${customImport}"></link>
-            </head>
-          `);
-          break;
-
-        default:
-          break;
-
-      }
-    });
+    mergedTemplateContents = `<!DOCTYPE html>
+      ${mergedHtml}
+        <head>
+          <title>${title}</title>
+          ${mergedMeta}
+          ${mergedLinks}
+          ${mergedStyles}
+          ${mergedScripts}
+        </head>
+        <body>
+          ${appBody.replace(/<page-outlet><\/page-outlet>/, pageBody)}
+        </body>
+      </html>
+    `;
   }
 
-  return appTemplateContents;
+  return mergedTemplateContents;
 };
 
 const getUserScripts = (contents, context) => {
@@ -497,19 +404,85 @@ class StandardHtmlResource extends ResourceInterface {
   }
 
   async optimize(url, body) {
+    const { optimization } = this.compilation.config;
+    const pageResources = this.compilation.graph.find(page => page.outputPath === url || page.route === url).imports;
+
     return new Promise((resolve, reject) => {
       try {
         const hasHead = body.match(/\<head>(.*)<\/head>/s);
 
         if (hasHead && hasHead.length > 0) {
-          let contents = hasHead[0];
+          let headContents = hasHead[0];
 
-          contents = contents.replace(/<script src="(.*lit\/polyfill-support.js)"><\/script>/, '');
-          contents = contents.replace(/<script type="importmap-shim">.*?<\/script>/s, '');
-          contents = contents.replace(/<script defer="" src="(.*es-module-shims.js)"><\/script>/, '');
-          contents = contents.replace(/type="module-shim"/g, 'type="module"');
+          for (const pageResource of pageResources) {
+            const keyedResource = this.compilation.resources.get(pageResource.sourcePathURL.pathname);
+            const { contents, src, type, optimizationAttr, optimizedFileContents, optimizedFileName, rawAttributes } = keyedResource;
 
-          body = body.replace(/\<head>(.*)<\/head>/s, contents.replace(/\$/g, '$$$')); // https://github.com/ProjectEvergreen/greenwood/issues/656);
+            if (src) {
+              if (type === 'script') {
+                if (!optimizationAttr && optimization === 'default') {
+                  const optimizedFilePath = `/${optimizedFileName}`;
+
+                  headContents = headContents.replace(src, optimizedFilePath);
+                  headContents = headContents.replace('<head>', `
+                    <head>
+                    <link rel="modulepreload" href="${optimizedFilePath}" as="script">
+                  `);
+                } else if (optimizationAttr === 'inline' || optimization === 'inline') {
+                  const isModule = rawAttributes.indexOf('type="module') >= 0 ? ' type="module"' : '';
+
+                  headContents = headContents.replace(`<script ${rawAttributes}></script>`, `
+                    <script ${isModule}>
+                      ${optimizedFileContents.replace(/\.\//g, '/').replace(/\$/g, '$$$')}
+                    </script>
+                  `);
+                } else if (optimizationAttr === 'static' || optimization === 'static') {
+                  headContents = headContents.replace(`<script ${rawAttributes}></script>`, '');
+                }
+              } else if (type === 'link') {
+                if (!optimizationAttr && (optimization !== 'none' && optimization !== 'inline')) {
+                  const optimizedFilePath = `/${optimizedFileName}`;
+
+                  headContents = headContents.replace(src, optimizedFilePath);
+                  headContents = headContents.replace('<head>', `
+                    <head>
+                    <link rel="preload" href="${optimizedFilePath}" as="style" crossorigin="anonymous"></link>
+                  `);
+                } else if (optimizationAttr === 'inline' || optimization === 'inline') {
+                  // https://github.com/ProjectEvergreen/greenwood/issues/810
+                  // when pre-rendering, puppeteer normalizes everything to <link .../>
+                  // but if not using pre-rendering, then it could come out as <link ...></link>
+                  // not great, but best we can do for now until #742
+                  headContents = headContents.replace(`<link ${rawAttributes}>`, `
+                    <style>
+                      ${optimizedFileContents}
+                    </style>
+                  `).replace(`<link ${rawAttributes}/>`, `
+                    <style>
+                      ${optimizedFileContents}
+                    </style>
+                  `);
+                }
+              }
+            } else {
+              if (type === 'script') {
+                if (optimizationAttr === 'static' || optimization === 'static') {
+                  headContents = headContents.replace(`<script ${rawAttributes}>${contents.replace(/\.\//g, '/').replace(/\$/g, '$$$')}</script>`, '');
+                } else if (optimizationAttr === 'none') {
+                  headContents = headContents.replace(contents, contents.replace(/\.\//g, '/').replace(/\$/g, '$$$'));
+                } else {
+                  headContents = headContents.replace(contents, optimizedFileContents.replace(/\.\//g, '/').replace(/\$/g, '$$$'));
+                }
+              } else if (type === 'style') {
+                headContents = headContents.replace(contents, optimizedFileContents);
+              }
+            }
+          }
+
+          // TODO clean up lit-polyfill as part of https://github.com/ProjectEvergreen/greenwood/issues/728
+          headContents = headContents.replace(/<script src="(.*lit\/polyfill-support.js)"><\/script>/, '');
+
+          body = body.replace(/\<head>(.*)<\/head>/s, headContents.replace(/\$/g, '$$$')); // https://github.com/ProjectEvergreen/greenwood/issues/656);
         }
 
         resolve(body);

--- a/packages/cli/src/plugins/resource/plugin-standard-json.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-json.js
@@ -5,6 +5,7 @@
  *
  */
 import fs from 'fs';
+import path from 'path';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class StandardJsonResource extends ResourceInterface {
@@ -12,6 +13,13 @@ class StandardJsonResource extends ResourceInterface {
     super(compilation, options);
     this.extensions = ['.json'];
     this.contentType = 'application/json';
+  }
+
+  async shouldServe(url) {
+    return Promise.resolve(
+      url.indexOf('graph.json') >= 0 ||
+      path.extname(url) === '.json' && fs.existsSync(url)
+    );
   }
 
   async serve(url) {

--- a/packages/cli/test/cases/build.config.interpolate-frontmatter/build.config.interpolate-frontmatter.spec.js
+++ b/packages/cli/test/cases/build.config.interpolate-frontmatter/build.config.interpolate-frontmatter.spec.js
@@ -64,13 +64,13 @@ describe('Build Greenwood With: ', function() {
         expect(authorMeta).to.be.equal('Owen Buckley');
       });
 
-      it('should have the correct value for publised in the <h3> tag', function() {
+      it('should have the correct value for published in the <h3> tag', function() {
         const heading = dom.window.document.querySelector('body h3').textContent;
 
         expect(heading).to.be.equal('Published: 11/11/2022');
       });
 
-      it('should have the correct value for authro in the <h4> tag', function() {
+      it('should have the correct value for author in the <h4> tag', function() {
         const heading = dom.window.document.querySelector('body h4').textContent;
 
         expect(heading).to.be.equal('Author: Owen Buckley');

--- a/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
@@ -57,7 +57,7 @@ describe('Build Greenwood With: ', function() {
       });
 
       describe('<script> tag and preloading', function() {
-        it('should contain one javasccript file in the output directory', async function() {
+        it('should contain one javascript file in the output directory', async function() {
           expect(await glob.promise(path.join(this.context.publicDir, '*.js'))).to.have.lengthOf(1);
         });
 

--- a/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
@@ -138,7 +138,7 @@ describe('Build Greenwood With: ', function() {
         it('should contain the expected CSS content inlined for theme.css', function() {
           const styleTags = dom.window.document.querySelectorAll('head style');
 
-          expect(styleTags[0].textContent).to.contain('*{font-family:Comic Sans,sans-serif;margin:0;padding:0}');
+          expect(styleTags[0].textContent).to.contain('*{margin:0;padding:0;font-family:Comic Sans,sans-serif}');
         });
 
         it('should contain the expected CSS content inlined for page.css', function() {

--- a/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
@@ -71,15 +71,15 @@ describe('Build Greenwood With: ', function() {
       });
       
       describe('<script> tag and preloading', function() {
-        it('should contain one unminifed javascript file in the output directory', async function() {
+        it('should contain one un-minified javascript file in the output directory', async function() {
           expect(jsFiles).to.have.lengthOf(1);
         });
 
-        it('should output the contents of the JavaScript file unminified', function() {
+        it('should output the contents of the JavaScript file un-minified', function() {
           const js = fs.readFileSync(jsFiles[0], 'utf-8');
 
           // eslint-disable-next-line max-len
-          expect(js).to.contain('class HeaderComponent extends HTMLElement {\n  constructor() {\n    super();\n\n    this.root = this.attachShadow({ mode: \'open\' });\n    this.root.innerHTML = `\n      <header>This is the header component.</header>\n    `;\n  }\n}\n\ncustomElements.define(\'app-header\', HeaderComponent);\n');
+          expect(js).to.contain('class HeaderComponent extends HTMLElement {\n  constructor() {\n    super();\n\n    this.root = this.attachShadow({ mode: \'open\' });\n    this.root.innerHTML = `\n      <header>This is the header component.</header>\n    `;\n  }\n}\n\ncustomElements.define(\'app-header\', HeaderComponent);');
         });
 
         it('should have the expected <script> tag in the <head>', function() {
@@ -96,11 +96,11 @@ describe('Build Greenwood With: ', function() {
       });
 
       describe('<link> tags should not be preloaded', function() {
-        it('should contain one style.css in the output directory with unminifed content', async function() {
+        it('should contain one style.css in the output directory', async function() {
           expect(cssFiles).to.have.lengthOf(1);
         });
 
-        it('should output the contents of the CSS file unminified', function() {
+        it('should output the contents of the one CSS file', function() {
           const css = fs.readFileSync(cssFiles[0], 'utf-8');
           
           expect(css).to.contain('{\n  margin: 0;\n  padding: 0;\n  font-family: \'Comic Sans\', sans-serif;\n}');

--- a/packages/cli/test/cases/build.config.optimization-overrides/build.config-optimization-overrides.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-overrides/build.config-optimization-overrides.spec.js
@@ -153,7 +153,7 @@ describe('Build Greenwood With: ', function() {
       
       it('should have an inline <style> tag in the <head>', function() {
         const themeStyleTags = Array.from(dom.window.document.querySelectorAll('head style'))
-          .filter(style => style.textContent.indexOf('*{color:blue}') >= 0);
+          .filter(style => style.textContent.indexOf('*{color:#00f}') >= 0);
 
         expect(themeStyleTags.length).to.be.equal(1);
       });

--- a/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
+++ b/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
@@ -94,8 +94,7 @@ describe('Build Greenwood With: ', function() {
           .filter(tag => !tag.type);
 
         expect(inlineScriptTags.length).to.be.equal(1);
-        expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood = window.__greenwood || {};');
-        expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood.currentTemplate = "page"');
+        expect(inlineScriptTags[0].textContent).to.contain('window.__greenwood=window.__greenwood||{};window.__greenwood.currentTemplate="page"');
       });
 
       it('should have one <router-outlet> tag in the <body> for the content', function() {

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -217,8 +217,9 @@ describe('Build Greenwood With: ', function() {
         expect(mainScriptTags.length).to.be.equal(1);
       });
 
+      // TODO clean up lit-polyfill as part of https://github.com/ProjectEvergreen/greenwood/issues/728
       it('should have the total expected number of .js file in the output directory', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, '*.js'))).to.have.lengthOf(3);
+        expect(await glob.promise(path.join(this.context.publicDir, '*.js'))).to.have.lengthOf(4);
       });
 
       it('should have the expected main.js file in the output directory', async function() {
@@ -240,8 +241,8 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected inline node_modules content in the first inline script', async function() {
         const inlineScriptTag = dom.window.document.querySelectorAll('head > script:not([src])')[0];
         
-        expect(inlineScriptTag.textContent.replace('\n', '')).to
-          .equal('import"/lit-element.ae169679.js";import"/lit-html.7f7a9139.js";//# sourceMappingURL=2012376258-scratch.0a6fc17c.js.map');
+        expect(inlineScriptTag.textContent.replace(/\n/g, '')).to
+          .equal('import"/lit-element.ae169679.js";import"/lit-html.7f7a9139.js";//# sourceMappingURL=116321042.6c5eb91c.js.map');
       });
     });
 

--- a/packages/cli/test/cases/build.default.spa/build.default.spa.spec.js
+++ b/packages/cli/test/cases/build.default.spa/build.default.spa.spec.js
@@ -235,7 +235,8 @@ describe('Build Greenwood With: ', function() {
         // one for the footer.js
         // one for index.js
         // one for lit element bundle
-        expect(jsFiles.length).to.be.equal(5);
+        // TODO clean up lit-polyfill as part of https://github.com/ProjectEvergreen/greenwood/issues/728
+        expect(jsFiles.length).to.be.equal(6);
       });
 
       it('should have custom <title> tag in the <head>', function() {

--- a/packages/cli/test/cases/build.default.ssr-static-export/build.default.ssr-static-export.spec.js
+++ b/packages/cli/test/cases/build.default.ssr-static-export/build.default.ssr-static-export.spec.js
@@ -155,15 +155,16 @@ describe('Build Greenwood With: ', function() {
         expect(styles.length).to.equal(1);
       });
 
-      it('should have three script tags', function() {
+      // TODO clean up lit-polyfill as part of https://github.com/ProjectEvergreen/greenwood/issues/728
+      it('should have four script tags', function() {
         const scripts = dom.window.document.querySelectorAll('head > script');
 
-        expect(scripts.length).to.equal(3);
+        expect(scripts.length).to.equal(4);
       });
 
       it('should have expected SSR content from the non module script tag', function() {
         const scripts = Array.from(dom.window.document.querySelectorAll('head > script'))
-          .filter(tag => !tag.getAttribute('type'));
+          .filter(tag => !tag.getAttribute('type') && !tag.getAttribute('src'));
 
         expect(scripts.length).to.equal(1);
         expect(scripts[0].textContent).to.contain('console.log');
@@ -217,7 +218,7 @@ describe('Build Greenwood With: ', function() {
         const counterScript = Array.from(dom.window.document.querySelectorAll('head > script[src]'))
           .filter((tag) => tag.getAttribute('src').indexOf(`/${componentName}.`) === 0);
 
-        expect(artistsPageGraphData.imports[0]).to.equal(`/components/${componentName}.js`);
+        expect(artistsPageGraphData.imports[0].src).to.equal(`/components/${componentName}.js`);
         expect(counterScript.length).to.equal(1);
       });
     });

--- a/packages/cli/test/cases/build.default.ssr/build.default.ssr.spec.js
+++ b/packages/cli/test/cases/build.default.ssr/build.default.ssr.spec.js
@@ -193,7 +193,7 @@ describe('Build Greenwood With: ', function() {
         const counterScript = Array.from(artistsPageDom.window.document.querySelectorAll('head > script[src]'))
           .filter((tag) => tag.getAttribute('src').indexOf(`/${componentName}.`) === 0);
 
-        expect(artistsPageGraphData.imports[0]).to.equal(`/components/${componentName}.js`);
+        expect(artistsPageGraphData.imports[0].src).to.equal(`/components/${componentName}.js`);
         expect(counterScript.length).to.equal(1);
       });
     });

--- a/packages/cli/test/cases/build.default.workspace-getting-started/src/styles/theme.css
+++ b/packages/cli/test/cases/build.default.workspace-getting-started/src/styles/theme.css
@@ -1,4 +1,4 @@
-@import url('//fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap');
 
 * {
   margin: 0;

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -32,7 +32,7 @@ import { fileURLToPath, URL } from 'url';
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
-  const LABEL = 'Importing JavaScript and CSS using <script>, <style>, and <link> tags';
+  const LABEL = 'Including JavaScript and CSS using <script>, <style>, and <link> tags';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
@@ -58,7 +58,7 @@ describe('Build Greenwood With: ', function() {
       it('should have one <script> tag for other.js loaded in the <head>', function() {
         const scriptTags = dom.window.document.querySelectorAll('head > script[type="module"]');
         const mainScriptTags = Array.prototype.slice.call(scriptTags).filter(script => {
-          return (/other.*.js/).test(script.src);
+          return (/other.*[a-z0-9].js/).test(script.src);
         });
         
         expect(mainScriptTags.length).to.be.equal(1);
@@ -66,11 +66,11 @@ describe('Build Greenwood With: ', function() {
 
       // this includes the non module file in a spec below
       it('should have the expected number of bundled .js files in the output directory', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, '*.js'))).to.have.lengthOf(2);
+        expect(await glob.promise(path.join(this.context.publicDir, '*.*[a-z0-9].js'))).to.have.lengthOf(2);
       });
 
       it('should have the expected other.js file in the output directory', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, 'other.*.js'))).to.have.lengthOf(1);
+        expect(await glob.promise(path.join(this.context.publicDir, 'other.*[a-z0-9].js'))).to.have.lengthOf(1);
       });
     });
 
@@ -96,7 +96,7 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected inline content from inline <script> tag three in index.html', async function() {
         const scriptTagSrcTwo = dom.window.document.querySelectorAll('head > script:not([src])')[2];
 
-        expect(scriptTagSrcTwo.textContent).to.contain('document.getElementsByClassName(\'output-script-inline-three\')[0].innerHTML = three');
+        expect(scriptTagSrcTwo.textContent).to.contain('document.getElementsByClassName("output-script-inline-three")[0].innerHTML="script tag module inline three"');
       });
 
     });
@@ -105,14 +105,14 @@ describe('Build Greenwood With: ', function() {
       it('should have one <script> tag for non-module.js loaded in the <head>', function() {
         const scriptTags = dom.window.document.querySelectorAll('head > script[src]');
         const mainScriptTags = Array.prototype.slice.call(scriptTags).filter(script => {
-          return (/non-module.*.js/).test(script.src);
+          return (/non-module.*[a-z0-9].js/).test(script.src);
         });
         
         expect(mainScriptTags.length).to.be.equal(1);
       });
 
       it('should have the expected non-module.js file in the output directory', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, 'non-module.*.js'))).to.have.lengthOf(1);
+        expect(await glob.promise(path.join(this.context.publicDir, 'non-module.*[a-z0-9].js'))).to.have.lengthOf(1);
       });
     });
 
@@ -126,13 +126,13 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected output from the first inline <style> tag in index.html', async function() {
         const styleTags = dom.window.document.querySelectorAll('head > style');
 
-        expect(styleTags[0].textContent.replace(/\n/g, '').trim().replace(' ', '')).to.contain('p.output-style{        color: green;      }');
+        expect(styleTags[0].textContent.replace(/\n/g, '').trim().replace(' ', '')).to.contain('p.output-style{color:green}');
       });
 
       it('should have the expected output from the second inline <style> tag in index.html', async function() {
         const styleTags = dom.window.document.querySelectorAll('head > style');
 
-        expect(styleTags[1].textContent.replace(/\n/g, '').trim().replace(' ', '')).to.contain('span.output-style{        color: red;      }');
+        expect(styleTags[1].textContent.replace(/\n/g, '').trim().replace(' ', '')).to.contain('span.output-style{color:red}');
       });
 
       it('should have the color style for the output element', function() {
@@ -148,14 +148,17 @@ describe('Build Greenwood With: ', function() {
         const linkTags = dom.window.document.querySelectorAll('head > link[rel="stylesheet"]');
         
         expect(linkTags.length).to.be.equal(2);
+        linkTags.forEach(link => {
+          expect((/.*[a-z0-9].css/).test(link.href)).to.be.equal(true);
+        });
       });
 
       it('should have the expected main.css file in the output directory', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, 'styles', 'main.*.css'))).to.have.lengthOf(1);
+        expect(await glob.promise(path.join(this.context.publicDir, 'styles', 'main.*[a-z0-9].css'))).to.have.lengthOf(1);
       });
 
       it('should have the expected other.css file in the output directory', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, 'styles', 'other.*.css'))).to.have.lengthOf(1);
+        expect(await glob.promise(path.join(this.context.publicDir, 'styles', 'other.*[a-z0-9].css'))).to.have.lengthOf(1);
       });
 
       // JSDOM may not support this case of computing styles when using a <link> tag?

--- a/packages/cli/test/cases/build.default.workspace-template-page-and-app/build.default.workspace-template-page-and-app.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-template-page-and-app/build.default.workspace-template-page-and-app.spec.js
@@ -90,15 +90,16 @@ describe('Build Greenwood With: ', function() {
           expect(linkTags.length).to.equal(4);
         });
 
-        it('should have 5 <style> tags in the <head>', function() {
+        it('should have 4 <style> tags in the <head>', function() {
           expect(styleTags.length).to.equal(4);
         });
 
         it('should merge page template <script> tags after app template <script> tags', function() {
           expect(scriptTags[0].src).to.match(/app-template-one.*.js/);
           expect(scriptTags[1].src).to.match(/app-template-two.*.js/);
-          expect(scriptTags[2].src).to.match(/page-template-one.*.js/);
-          expect(scriptTags[3].src).to.match(/page-template-two.*.js/);
+          expect(scriptTags[2].textContent).to.contain('console.log("this should not break anything :)");');
+          expect(scriptTags[3].src).to.match(/page-template-one.*.js/);
+          expect(scriptTags[4].src).to.match(/page-template-two.*.js/);
 
           scriptTags.forEach((scriptTag) => {
             expect(scriptTag.type).to.equal('module');
@@ -117,10 +118,10 @@ describe('Build Greenwood With: ', function() {
         });
 
         it('should merge page template <style> tags after app template <style> tags', function() {
-          expect(styleTags[0].textContent).to.contain('app-template-one-style');
-          expect(styleTags[1].textContent).to.contain('app-template-two-style');
-          expect(styleTags[2].textContent).to.contain('page-template-one-style');
-          expect(styleTags[3].textContent).to.contain('page-template-two-style');
+          expect(styleTags[0].textContent).to.equal('span{text-align:center}');
+          expect(styleTags[1].textContent).to.equal('p{margin:0 auto}');
+          expect(styleTags[2].textContent).to.equal('ol{list-style:none}');
+          expect(styleTags[3].textContent).to.equal('h3{text-decoration:underline}');
         });
       });
 

--- a/packages/cli/test/cases/build.default.workspace-template-page/build.default.workspace-template-page.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-template-page/build.default.workspace-template-page.spec.js
@@ -122,7 +122,7 @@ describe('Build Greenwood With: ', function() {
           const customElement = dom.window.document.querySelector('.owen-test');
           const computedStyle = dom.window.getComputedStyle(customElement);
   
-          expect(computedStyle.color).to.equal('blue');
+          expect(computedStyle.color).to.equal('rgb(0, 0, 255)');
         });
   
         it('should have the color styles for the h3 element that we defined as part of our custom style', function() {

--- a/packages/cli/test/cases/build.default.workspace-template-page/build.default.workspace-template-page.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-template-page/build.default.workspace-template-page.spec.js
@@ -97,7 +97,7 @@ describe('Build Greenwood With: ', function() {
 
         it('should add one page template <link> tag', function() {
           expect(linkTags[0].rel).to.equal('stylesheet');
-          expect(linkTags[0].href).to.match(/styles\/theme.[a-z0-9]{8}.css/);
+          expect(linkTags[0].href).to.match(/styles\/theme.[a-z0-9]{10}.css/);
         });
 
         it('should add one page template <style> tag', function() {

--- a/packages/cli/test/cases/develop.ssr/develop.ssr.spec.js
+++ b/packages/cli/test/cases/develop.ssr/develop.ssr.spec.js
@@ -232,7 +232,7 @@ describe('Develop Greenwood With: ', function() {
         const counterScript = Array.from(dom.window.document.querySelectorAll('head > script[src]'))
           .filter((tag) => tag.getAttribute('src').indexOf(`${componentName}.js`) >= 0);
 
-        expect(artistsPageGraphData.imports[0]).to.equal(`/components/${componentName}.js`);
+        expect(artistsPageGraphData.imports[0].src).to.equal(`/components/${componentName}.js`);
         expect(counterScript.length).to.equal(1);
       });
     });

--- a/packages/cli/test/cases/theme-pack/theme-pack.build.spec.js
+++ b/packages/cli/test/cases/theme-pack/theme-pack.build.spec.js
@@ -37,7 +37,7 @@ import { fileURLToPath, URL } from 'url';
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
-  const LABEL = 'Developement environment for a Theme Pack';
+  const LABEL = 'Development environment for a Theme Pack';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;

--- a/packages/plugin-babel/README.md
+++ b/packages/plugin-babel/README.md
@@ -27,7 +27,7 @@ export default {
   ...
 
   plugins: [
-    ...greenwoodPluginBabel() // notice the spread ... !
+    greenwoodPluginBabel()
   ]
 }
 ```
@@ -68,8 +68,7 @@ If you would like to use it, either standalone or with your own custom _babel.co
       ...
 
       plugins: [
-        // notice the spread ... !
-        ...greenwoodPluginBabel({
+        greenwoodPluginBabel({
           extendConfig: true
         })
       ]

--- a/packages/plugin-google-analytics/src/index.js
+++ b/packages/plugin-google-analytics/src/index.js
@@ -26,7 +26,7 @@ class GoogleAnalyticsResource extends ResourceInterface {
         const newHtml = body.replace('</head>', `
           <link rel="preconnect" href="https://www.google-analytics.com/">
           <script async src="https://www.googletagmanager.com/gtag/js?id=${analyticsId}"></script>
-          <script>
+          <script data-gwd-opt="none">
             var getOutboundLink = function(url) {
               gtag('event', 'click', {
                 'event_category': 'outbound',

--- a/packages/plugin-google-analytics/test/cases/default/default.spec.js
+++ b/packages/plugin-google-analytics/test/cases/default/default.spec.js
@@ -77,7 +77,7 @@ describe('Build Greenwood With: ', function() {
         expect(inlineScript.length).to.be.equal(1);
       });
 
-      it('should have the expected code with users analyicsId', function() {
+      it('should have the expected code with users analyticsId', function() {
         const expectedContent = `
             var getOutboundLink = function(url) {
               gtag('event', 'click', {

--- a/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
+++ b/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
@@ -73,7 +73,7 @@ describe('Build Greenwood With: ', function() {
         expect(inlineScript.length).to.be.equal(1);
       });
 
-      it('should have the expected code with users analyicsId', function() {
+      it('should have the expected code with users analyticsId', function() {
         const expectedContent = `
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}

--- a/packages/plugin-graphql/README.md
+++ b/packages/plugin-graphql/README.md
@@ -42,8 +42,8 @@ export default {
   ...
 
   plugins: [
-    ...greenwoodPluginGraphQL(), // notice the spread ... !
-    ...greenwoodPluginRendererPuppeteer() // notice the spread ... !
+    greenwoodPluginGraphQL(),
+    greenwoodPluginRendererPuppeteer()
   ]
 }
 ```

--- a/packages/plugin-graphql/src/index.js
+++ b/packages/plugin-graphql/src/index.js
@@ -20,7 +20,7 @@ class GraphQLResource extends ResourceInterface {
   constructor(compilation, options = {}) {
     super(compilation, options);
     this.extensions = ['.gql'];
-    this.contentType = ['text/javascript'];
+    this.contentType = ['text/javascript', 'text/html'];
   }
 
   async serve(url) {
@@ -33,7 +33,7 @@ class GraphQLResource extends ResourceInterface {
 
         resolve({
           body,
-          contentType: this.contentType
+          contentType: this.contentType[0]
         });
       } catch (e) {
         reject(e);
@@ -42,7 +42,7 @@ class GraphQLResource extends ResourceInterface {
   }
   
   async shouldIntercept(url, body, headers) {
-    return Promise.resolve(headers.request.accept && headers.request.accept.indexOf('text/html') >= 0);
+    return Promise.resolve(headers.request.accept && headers.request.accept.indexOf(this.contentType[1]) >= 0);
   }
 
   async intercept(url, body) {
@@ -58,14 +58,14 @@ class GraphQLResource extends ResourceInterface {
   }
 
   async shouldOptimize(url = '', body, headers = {}) {
-    return Promise.resolve((url && path.extname(url) === '.html') || (headers.request && headers.request['content-type'].indexOf('text/html') >= 0));
+    return Promise.resolve(path.extname(url) === '.html' || (headers.request && headers.request['content-type'].indexOf('text/html') >= 0));
   }
 
   async optimize(url, body) {
     return new Promise((resolve, reject) => {
       try {
         body = body.replace('<head>', `
-          <script data-state="apollo">
+          <script data-state="apollo" data-gwd-opt="none">
             window.__APOLLO_STATE__ = true;
           </script>
           <head>

--- a/packages/plugin-import-commonjs/README.md
+++ b/packages/plugin-import-commonjs/README.md
@@ -27,7 +27,7 @@ export default {
   ...
 
   plugins: [
-    ...greenwoodPluginImportCommonJs() // notice the spread ... !
+    greenwoodPluginImportCommonJs()
   ]
 }
 ```

--- a/packages/plugin-import-css/README.md
+++ b/packages/plugin-import-css/README.md
@@ -31,7 +31,7 @@ export default {
   ...
 
   plugins: [
-    ...greenwoodPluginImportCss() // notice the spread ... !
+    greenwoodPluginImportCss()
   ]
 }
 ```

--- a/packages/plugin-import-css/package.json
+++ b/packages/plugin-import-css/package.json
@@ -21,11 +21,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0",
-    "postcss": "^8.3.11"
-  },
-  "dependencies": {
-    "rollup-plugin-postcss": "^4.0.2"
+    "@greenwood/cli": "^0.4.0"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.26.0"

--- a/packages/plugin-import-css/test/cases/default/default.spec.js
+++ b/packages/plugin-import-css/test/cases/default/default.spec.js
@@ -70,7 +70,8 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected output from importing styles.css in main.js', function() {
         const contents = fs.readFileSync(scripts[0], 'utf-8');
 
-        expect(contents).to.contain('import from styles.css: p{color:red}"');
+        // TODO minify CSS-in-JS?
+        expect(contents).to.contain('import from styles.css: p {   color: red; }"');
       });
     });
   });

--- a/packages/plugin-import-json/README.md
+++ b/packages/plugin-import-json/README.md
@@ -31,7 +31,7 @@ export default {
   ...
 
   plugins: [
-    ...greenwoodPluginImportJson() // notice the spread ... !
+    greenwoodPluginImportJson()
   ]
 }
 ```

--- a/packages/plugin-import-json/package.json
+++ b/packages/plugin-import-json/package.json
@@ -23,9 +23,6 @@
   "peerDependencies": {
     "@greenwood/cli": "^0.12.3"
   },
-  "dependencies": {
-    "@rollup/plugin-json": "^4.1.0"
-  },
   "devDependencies": {
     "@greenwood/cli": "^0.26.0"
   }

--- a/packages/plugin-import-json/test/cases/default/default.spec.js
+++ b/packages/plugin-import-json/test/cases/default/default.spec.js
@@ -72,7 +72,7 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected output from importing data.json in main.js', function() {
         const contents = fs.readFileSync(scripts[0], 'utf-8');
 
-        expect(contents).to.contain('const t=`${"got json"} via import, status is - ${200}`');
+        expect(contents).to.contain('document.getElementsByClassName("output-json-import")[0].innerHTML="got json via import, status is - 200"');
       });
     });
   });

--- a/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
@@ -93,8 +93,8 @@ describe('Develop Greenwood With: ', function() {
         done();
       });
 
-      it('should return an ECMASCript module', function(done) {
-        expect(response.body.replace(/\n/g, '')).to.equal('export default {  "status": 200,  "message": "got json"}');
+      it('should return an ECMAScript module', function(done) {
+        expect(response.body).to.equal('export default {"status":200,"message":"got json"}');
         done();
       });
     });

--- a/packages/plugin-include-html/README.md
+++ b/packages/plugin-include-html/README.md
@@ -15,7 +15,7 @@ export default {
   ...
 
   plugins: [
-    ...greenwoodPluginIncludeHtml() // notice the spread ... !
+    greenwoodPluginIncludeHtml()
   ]
 }
 ```

--- a/packages/plugin-polyfills/README.md
+++ b/packages/plugin-polyfills/README.md
@@ -35,7 +35,7 @@ export default {
   ...
 
   plugins: [
-    ...greenwoodPluginPolyfills() // notice the spread ... !
+    greenwoodPluginPolyfills()
   ]
 }
 ```

--- a/packages/plugin-polyfills/src/index.js
+++ b/packages/plugin-polyfills/src/index.js
@@ -14,11 +14,11 @@ class PolyfillsResource extends ResourceInterface {
     };
   }
 
-  async shouldOptimize(url = '', body, headers = {}) {
-    return Promise.resolve(path.extname(url) === '.html' || (headers.request && headers.request['content-type'].indexOf('text/html') >= 0));
+  async shouldIntercept(url, body, headers = { request: {} }) {
+    return Promise.resolve(headers.request['content-type'] && headers.request['content-type'].indexOf('text/html') >= 0);
   }
 
-  async optimize(url, body) {
+  async intercept(url, body) {
     return new Promise(async (resolve, reject) => {
       try {
         let newHtml = body;
@@ -59,7 +59,7 @@ class PolyfillsResource extends ResourceInterface {
           `);
         }
 
-        resolve(newHtml);
+        resolve({ body: newHtml });
       } catch (e) {
         reject(e);
       }

--- a/packages/plugin-polyfills/test/cases/lit/lit.spec.js
+++ b/packages/plugin-polyfills/test/cases/lit/lit.spec.js
@@ -139,13 +139,15 @@ describe('Build Greenwood With: ', function() {
         dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, 'index.html'));
       });
 
+      // TODO need to reconcile how this lit polyfilling is working since the CLI already adds it?
+      // related to https://github.com/ProjectEvergreen/greenwood/issues/728
       it('should have one <script> tag for lit polyfills loaded in the <head> tag', function() {
         const scriptTags = dom.window.document.querySelectorAll('head > script');
         const polyfillScriptTags = Array.prototype.slice.call(scriptTags).filter(script => {
           return script.src.indexOf('polyfill-support') >= 0;
         });
 
-        expect(polyfillScriptTags.length).to.be.equal(1);
+        expect(polyfillScriptTags.length).to.be.equal(2);
       });
 
       it('should have the expected lit polyfill files in the output directory', function() {

--- a/packages/plugin-postcss/README.md
+++ b/packages/plugin-postcss/README.md
@@ -79,7 +79,6 @@ By default, the configuration provided by this plugin is:
 ```javascript
 export default {
   plugins: [
-    (await import('cssnano')).default, // just for production builds
     (await import('postcss-preset-env')).default
   ]
 };

--- a/packages/plugin-postcss/package.json
+++ b/packages/plugin-postcss/package.json
@@ -7,7 +7,6 @@
   "license": "MIT",
   "keywords": [
     "Greenwood",
-    "CommonJS",
     "Static Site Generator",
     "NodeJS",
     "PostCSS"
@@ -21,11 +20,10 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0",
-    "postcss": "^8.3.11"
+    "@greenwood/cli": "^0.4.0"
   },
   "dependencies": {
-    "cssnano": "^5.0.11",
+    "postcss": "^8.3.11",
     "postcss-preset-env": "^7.0.1"
   },
   "devDependencies": {

--- a/packages/plugin-postcss/src/index.js
+++ b/packages/plugin-postcss/src/index.js
@@ -34,6 +34,10 @@ class PostCssResource extends ResourceInterface {
     this.contentType = ['text/css'];
   }
 
+  async shouldServe() {
+    return false;
+  }
+
   isCssFile(url) {
     return path.extname(url) === '.css';
   }
@@ -65,6 +69,7 @@ class PostCssResource extends ResourceInterface {
   }
   
   async optimize(url, body) {
+    const contents = body || await fs.promises.readFile(url, 'utf-8');
     const config = await getConfig(this.compilation, this.options.extendConfig);
     const plugins = config.plugins && config.plugins.length ? [...config.plugins] : [];
     
@@ -73,7 +78,7 @@ class PostCssResource extends ResourceInterface {
     );
 
     const css = plugins.length > 0
-      ? (await postcss(plugins).process(body, { from: url })).css
+      ? (await postcss(plugins).process(contents, { from: url })).css
       : body;
     
     return Promise.resolve(css);

--- a/packages/plugin-postcss/src/index.js
+++ b/packages/plugin-postcss/src/index.js
@@ -63,26 +63,6 @@ class PostCssResource extends ResourceInterface {
       }
     });
   }
-
-  async shouldOptimize(url) {
-    return Promise.resolve(this.isCssFile(url));
-  }
-  
-  async optimize(url, body) {
-    const contents = body || await fs.promises.readFile(url, 'utf-8');
-    const config = await getConfig(this.compilation, this.options.extendConfig);
-    const plugins = config.plugins && config.plugins.length ? [...config.plugins] : [];
-    
-    plugins.push(
-      (await import('cssnano')).default
-    );
-
-    const css = plugins.length > 0
-      ? (await postcss(plugins).process(contents, { from: url })).css
-      : body;
-    
-    return Promise.resolve(css);
-  }
 }
 
 const greenwoodPluginPostCss = (options = {}) => {

--- a/packages/plugin-postcss/test/cases/default/default.spec.js
+++ b/packages/plugin-postcss/test/cases/default/default.spec.js
@@ -59,7 +59,7 @@ describe('Build Greenwood With: ', function() {
 
     describe('Page referencing external nested CSS file', function() {
       it('should output correctly processed nested CSS as non nested', function() {
-        const expectedCss = 'body{color:red}h1{color:blue}';
+        const expectedCss = 'body{color:red}h1{color:#00f}';
         const cssFiles = glob.sync(path.join(this.context.publicDir, 'styles', '*.css'));
         const css = fs.readFileSync(cssFiles[0], 'utf-8');
 

--- a/packages/plugin-postcss/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-postcss/test/cases/options.extend-config/options.extend-config.spec.js
@@ -43,7 +43,7 @@ import { fileURLToPath, URL } from 'url';
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
-  const LABEL = 'Custom PostCSS configuration';
+  const LABEL = 'Custom PostCSS configuration with extended options';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
@@ -66,7 +66,7 @@ describe('Build Greenwood With: ', function() {
 
     describe('Page referencing external nested CSS file', function() {
       it('should output correctly processed nested CSS as non nested', function() {
-        const expectedCss = 'body{color:red}body h1{color:blue}';
+        const expectedCss = 'body{color:red}body h1{color:#00f}';
         const cssFiles = glob.sync(path.join(this.context.publicDir, 'styles', '*.css'));
         const css = fs.readFileSync(cssFiles[0], 'utf-8');
 

--- a/packages/plugin-renderer-puppeteer/README.md
+++ b/packages/plugin-renderer-puppeteer/README.md
@@ -75,7 +75,7 @@ export default {
   ...
 
   plugins: [
-    ...greenwoodPluginRendererPuppeteer() // notice the spread!
+    greenwoodPluginRendererPuppeteer()
   ]
 }
 ```

--- a/packages/plugin-renderer-puppeteer/README.md
+++ b/packages/plugin-renderer-puppeteer/README.md
@@ -9,6 +9,9 @@ A Greenwood plugin for using [**Puppeteer**](https://pptr.dev) as a custom [_pre
 #### Limitations
 Given this plugin instruments an entire browser, this plugin _only_ supports Greenwood's [`prerender` configuration](/docs/configuration/#prerender) option and so will NOT be viable for any [SSR](/docs/server-rendering/) or [Serverless and Edge](https://github.com/ProjectEvergreen/greenwood/discussions/626) features.  Instead, Greenwood will be focusing on making [**WCC**](https://github.com/ProjectEvergreen/wcc) the default and recommended first-party solution.
 
+In addition, **puppeteer** also leverages npm `postinstall` scripts which in some environments, like [Stackblitz](https://github.com/ProjectEvergreen/greenwood/discussions/639), would be disabled and so [YMMV](https://dictionary.cambridge.org/us/dictionary/english/ymmv).
+
+
 #### Dependencies
 
 You may need to install additional Operating System level libraries and dependencies depending on the system you are running on to support headless Chrome. For example, for a Docker based environment like [GitHub Actions](https://github.com/ProjectEvergreen/greenwood/blob/master/.github/workflows/master.yml#L19), you would need to add [this below setup script (or similar)](https://github.com/ProjectEvergreen/greenwood/blob/master/.github/workflows/chromium-lib-install.sh) to your runner

--- a/packages/plugin-renderer-puppeteer/src/plugins/resource.js
+++ b/packages/plugin-renderer-puppeteer/src/plugins/resource.js
@@ -23,26 +23,6 @@ class PuppeteerResource extends ResourceInterface {
 
     return Promise.resolve({ body });
   }
-
-  async shouldOptimize(url = '', body, headers = {}) {
-    return Promise.resolve(path.extname(url) === '.html' || (headers.request && headers.request['content-type'].indexOf(this.contentType) >= 0));
-  }
-
-  async optimize(url, body) {
-    return new Promise((resolve, reject) => {
-      try {
-        const hasHead = body.match(/\<head>(.*)<\/head>/s);
-
-        if (hasHead && hasHead.length > 0) {
-          body = body.replace(/<script src="(.*webcomponents-bundle.js)"><\/script>/, '');
-        }
-
-        resolve(body);
-      } catch (e) {
-        reject(e);
-      }
-    });
-  }
 }
 
 export { PuppeteerResource };

--- a/packages/plugin-renderer-puppeteer/src/puppeteer-handler.js
+++ b/packages/plugin-renderer-puppeteer/src/puppeteer-handler.js
@@ -10,10 +10,13 @@ export default async function(compilation, callback) {
         
         return await browserRunner
           .serialize(`${serverUrl}${route}`)
-          .then(async (contents) => {
+          .then(async (html) => {
             console.info(`prerendering complete for page ${route}.`);
-            
-            await callback(page, contents);
+
+            // clean this up here to avoid sending webcomponents-bundle to rollup
+            html = html.replace(/<script src="(.*webcomponents-bundle.js)"><\/script>/, '');
+
+            await callback(page, html);
           });
       }));
     } catch (e) {

--- a/packages/plugin-renderer-puppeteer/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-renderer-puppeteer/test/cases/build.default/build.default.spec.js
@@ -26,6 +26,7 @@
  */
 import chai from 'chai';
 import fs from 'fs/promises';
+import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
@@ -246,6 +247,10 @@ describe('Build Greenwood With: ', function() {
         expect(heading).to.equal('Welcome to Greenwood!');
       });
 
+      it('should contain the expected number of javascript files in the output directory', async function() {
+        expect(await glob.promise(path.join(this.context.publicDir, '*.js'))).to.have.lengthOf(3);
+      });
+
       it('should have the expected output from main.js for lit (ESM) in the page output', async function() {
         const litOutput = dom.window.document.querySelectorAll('body > .output-lit');
         
@@ -293,7 +298,7 @@ describe('Build Greenwood With: ', function() {
 
         expect(inlineScriptTag.textContent.replace('\n', '')).to
           // eslint-disable-next-line max-len
-          .equal('import"/lit-element.6ff69bae.js";document.getElementsByClassName("output-script-inline")[0].innerHTML="script tag module inline"//# sourceMappingURL=1807818843-scratch.537e8f03.js.map');
+          .contain('import"/lit-element.6ff69bae.js";document.getElementsByClassName("output-script-inline")[0].innerHTML="script tag module inline";//# sourceMappingURL=');
       });
 
       it('should have prerendered content from <app-header> component', function() {

--- a/packages/plugin-typescript/README.md
+++ b/packages/plugin-typescript/README.md
@@ -31,7 +31,7 @@ export default {
   ...
 
   plugins: [
-    ...greenwoodPluginTypeScript() // notice the spread ... !
+    greenwoodPluginTypeScript()
   ]
 }
 ```
@@ -90,8 +90,7 @@ If you would like to extend / override these options:
       ...
 
       plugins: [
-        // notice the spread ... !
-        ...greenwoodPluginTypeScript({
+        greenwoodPluginTypeScript({
           extendConfig: true
         })
       ]

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -20,11 +20,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0",
-    "typescript": "^4.3.5"
+    "@greenwood/cli": "^0.4.0"
   },
   "dependencies": {
-    "@rollup/plugin-typescript": "^8.2.1",
     "typescript": "^4.3.5"
   },
   "devDependencies": {

--- a/packages/plugin-typescript/src/index.js
+++ b/packages/plugin-typescript/src/index.js
@@ -3,13 +3,12 @@
  * Enables using JavaScript to import TypeScript files, using ESM syntax.
  *
  */
-import rollupPluginTypescript from '@rollup/plugin-typescript';
 import fs from 'fs';
 import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import tsc from 'typescript';
 
-const defaultcompilerOptions = {
+const defaultCompilerOptions = {
   target: 'es2020',
   module: 'es2020',
   moduleResolution: 'node',
@@ -22,7 +21,7 @@ function getCompilerOptions (projectDirectory, extendConfig) {
     : { compilerOptions: {} };
 
   return {
-    ...defaultcompilerOptions,
+    ...defaultCompilerOptions,
     ...customOptions.compilerOptions
   };
 }
@@ -60,16 +59,6 @@ const greenwoodPluginTypeScript = (options = {}) => {
     type: 'resource',
     name: 'plugin-import-typescript:resource',
     provider: (compilation) => new TypeScriptResource(compilation, options)
-  }, {
-    type: 'rollup',
-    name: 'plugin-import-typescript:rollup',
-    provider: (compilation) => {
-      const compilerOptions = getCompilerOptions(compilation.context.projectDirectory, options.extendConfig);
-
-      return [
-        rollupPluginTypescript(compilerOptions)
-      ];
-    }
   }];
 };
 

--- a/packages/plugin-typescript/test/cases/default/default.spec.js
+++ b/packages/plugin-typescript/test/cases/default/default.spec.js
@@ -70,14 +70,11 @@ describe('Build Greenwood With: ', function() {
 
     describe('TypeScript should process JavaScript that uses an interface', function() {
       it('should output correctly processed JavaScript without the interface', function() {
-        // Rollup is giving different [hash] filenames for us in Windows vs Linux / macOS so cant do a to.equal here :/
-        // https://github.com/ProjectEvergreen/greenwood/pull/650#issuecomment-877614947
-        const expectedJavaScript = 'const o="Angela",l="Davis",s="Professor";console.log(`Hello ${s} ${o} ${l}!`);//# sourceMappingURL=main.ts.';
         const jsFiles = glob.sync(path.join(this.context.publicDir, '*.js'));
         const javascript = fs.readFileSync(jsFiles[0], 'utf-8');
 
         expect(jsFiles.length).to.equal(1);
-        expect(javascript.replace(/\n/g, '')).to.contain(expectedJavaScript);
+        expect(javascript.replace(/\n/g, '')).to.contain('Hello Professor Angela Davis!');
       });
     });
   });

--- a/packages/plugin-typescript/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-typescript/test/cases/options.extend-config/options.extend-config.spec.js
@@ -29,7 +29,7 @@
  * User tsconfig.json (example)
  * {
  *   "compilerOptions": {
- *     "expirementalDecorators": true,
+ *     "experimentalDecorators": true,
  *     "noImplicitAny": true,
  *     "strict": true
  *   }

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -60,14 +60,32 @@ function commonIndexSpecs(dom, html, label) {
         expect(tagsMatch('script', html)).to.be.equal(true);
       });
 
+      it('should not have nested <script> tags in the <head>', function() {
+        const scripts = dom.window.document.querySelectorAll('head script > script');
+
+        expect(scripts.length).to.be.equal(0);
+      });
+
       it('should have matching opening and closing <link> tags in the <head>', function() {
         const html = dom.window.document.querySelector('html').textContent;
 
         expect(tagsMatch('link', html)).to.be.equal(true);
       });
 
+      it('should not have nested <link> tags in the <head>', function() {
+        const link = dom.window.document.querySelectorAll('head link > link');
+
+        expect(link.length).to.be.equal(0);
+      });
+
       it('should have matching opening and closing <style> tags in the <head>', function() {
         expect(tagsMatch('style', html)).to.be.equal(true);
+      });
+
+      it('should not have nested <style> tags in the <head>', function() {
+        const style = dom.window.document.querySelectorAll('head style > style');
+
+        expect(style.length).to.be.equal(0);
       });
 
       it('should have default viewport <meta> tag', function() {
@@ -79,10 +97,14 @@ function commonIndexSpecs(dom, html, label) {
       });
 
       it('should have default charset <meta> tag', function() {
-        const chartsetMeta = Array.from(metaTags).filter(meta => meta.getAttribute('charset') === 'utf-8');
+        const charsetMeta = Array.from(metaTags).filter(meta => meta.getAttribute('charset') === 'utf-8');
 
-        expect(chartsetMeta.length).to.be.equal(1);
-        expect(chartsetMeta[0].getAttribute('charset')).to.be.equal('utf-8');
+        expect(charsetMeta.length).to.be.equal(1);
+        expect(charsetMeta[0].getAttribute('charset')).to.be.equal('utf-8');
+      });
+
+      it('should not have any optimization markers left in the HTML', function() {
+        expect(html.match(/data-gwd-opt=".*[a-z]"/)).to.be.equal(null);
       });
     });
 

--- a/www/assets/fonts/source-sans-pro.css
+++ b/www/assets/fonts/source-sans-pro.css
@@ -1,11 +1,1 @@
-/* source-sans-pro-regular - latin */
-@font-face {
-  font-family: 'Source Sans Pro';
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  src: local('Source Sans Pro Regular'), local('SourceSansPro-Regular'),
-    url('/assets/fonts/source-sans-pro-v13-latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
-    url('/assets/fonts/source-sans-pro-v13-latin-regular.woff') format('woff'), /* Modern Browsers */
-    url('/assets/fonts/source-sans-pro-v13-latin-regular.ttf') format('truetype'); /* Safari, Android, iOS */
-}
+@font-face{font-family:Source Sans Pro;font-style:normal;font-weight:400;font-display:swap;src:local(Source Sans Pro Regular),local(SourceSansPro-Regular),url(/assets/fonts/source-sans-pro-v13-latin-regular.woff2)format("woff2"),url(/assets/fonts/source-sans-pro-v13-latin-regular.woff)format("woff"),url(/assets/fonts/source-sans-pro-v13-latin-regular.ttf)format("truetype")}

--- a/www/components/banner/eve-button.js
+++ b/www/components/banner/eve-button.js
@@ -1,5 +1,5 @@
 import { css, html, LitElement, unsafeCSS } from 'lit';
-import eveButtonCss from './eve-button.css';
+import eveButtonCss from './eve-button.css?type=css';
 
 class Button extends LitElement {
 

--- a/www/pages/blog/release/v0-26-0.md
+++ b/www/pages/blog/release/v0-26-0.md
@@ -187,7 +187,7 @@ So although WCC is now the default for SSR, Puppeteer is still available as a pl
     
     export default {
       plugins: [
-        ...greenwoodPluginRendererPuppeteer()
+        greenwoodPluginRendererPuppeteer()
       ]
     }
     ```

--- a/www/pages/plugins/resource.md
+++ b/www/pages/plugins/resource.md
@@ -7,17 +7,23 @@ index: 3
 
 ## Resource
 
-Resource plugins allow developers to interact with the request and response lifecycles of files at a variety of different points along the development and build workflow, when running the `develop` and `build` commands.  These lifecycles provide the ability to do things like:
-- Integrating Site Analytics (Google, Snowplow) in each generated _index.html_ page
-- Introduce additional file types, like TypeScript
+Resource plugins allow the manipulation of files loaded through ESM.  Depending on if you need to support a file with a custom extension, or to manipulate standard file extensions, Resource plugins provide the lifecycle hooks into Greenwood to do things like:
+- Integrating Site Analytics (Google, Snowplow) or third snippets into generated _index.html_ pages
+- Processing TypeScript into JavaScript
+
+This API is also used as part of our bundling process to "teach" Rollup how to process any non JavaScript files!
 
 ### API (Resource Interface)
+
+> _**Note**: This API is [planning to change soon](https://github.com/ProjectEvergreen/greenwood/issues/948) as part of a general alignment within Greenwood to align the signatures of these lifecycle method to be more consistent with web standards in support of Greenwood adopting compatibility with [serverless and edge runtimes](https://github.com/ProjectEvergreen/greenwood/issues/953)_.
+
 Although JavaScript is loosely typed, a [resource "interface"](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/cli/src/lib/resource-interface.js) has been provided by Greenwood that you can use to start building your own resource plugins.  Effectively you have to define two things:
 - `extensions`: The file types your plugin will operate on
 - `contentType`: A browser compatible contentType to ensure browsers correctly interpret you transformations
 
 ```javascript
 import fs from 'fs';
+import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
 class ResourceInterface {
@@ -61,10 +67,10 @@ class ResourceInterface {
 
   // return the new body
   async intercept(url, body, headers) {
-    return Promise.resolve({ body });
+    return Promise.resolve({ body, contentType: 'text/...' });
   }
 
-  // test if this plugin should manipulate any files prior to any final optimizations happening
+  // test if this plugin should manipulate the body and return a new body prior to any final optimizations happening
   // ex: add a "banner" to all .js files with a timestamp of the build, or minifying files
   // return true | false
   async shouldOptimize(url, body) {

--- a/www/pages/plugins/rollup.md
+++ b/www/pages/plugins/rollup.md
@@ -7,7 +7,7 @@ index: 5
 
 ## Rollup
 
-These plugins allow users to tap into the [Rollup](https://rollupjs.org/) configuration that Greenwood uses to build and optimize the static assets (JS / CSS) of your site when running the `build` command.  Simply use the `provider` method to return an array of rollup plugins.  Easy!
+Though rare, there may be cases and opportunities for tapping into the bundling process for Greenwood.  If so, this plugin type allow users to tap into Greenwood's [Rollup](https://rollupjs.org/) configuration to provide any Rollup plugins you may want to use.  Simply use the `provider` method to return an array of Rollup plugins.
 
 ### Example
 Install your favorite rollup plugin(s), then create a simple object to provide those plugins to Greenwood.
@@ -30,5 +30,3 @@ export function myRollupPlugin(options = {}) {
   };
 };
 ```
-
-> _You can click to see an [example of a rollup plugin](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-import-css), which requires a rollup plugin as part of enabling `import` syntax for CSS files._

--- a/www/templates/app.html
+++ b/www/templates/app.html
@@ -23,8 +23,8 @@
 
     <style>
       .gwd-content-outlet {
-        min-height: 100vh
-      };
+        min-height: 100vh;
+      }
     </style>
 
     <script type="module">

--- a/www/templates/app.html
+++ b/www/templates/app.html
@@ -42,7 +42,7 @@
 
       <page-outlet></page-outlet>
 
-      <app-footer src="../includes/footer.js"></app-footer2>
+      <app-footer src="../includes/footer.js"></app-footer>
     </div>
 
   </body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2351,6 +2351,13 @@
     "@open-wc/dedupe-mixin" "^1.3.0"
     "@webcomponents/scoped-custom-element-registry" "^0.0.3"
 
+"@parcel/css@^1.13.1":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@parcel/css/-/css-1.14.0.tgz#233750a1e3648b3746f27c2d8f3fd85a2290e512"
+  integrity sha512-r5tJWe6NF6lesfPw1N3g7N7WUKpHqi2ONnw9wl5ccSGGIxkmgcPaPQxfvmhdjXvQnktSuIOR0HjQXVXu+/en/w==
+  dependencies:
+    lightningcss "^1.14.0"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -2485,11 +2492,6 @@
   dependencies:
     remark "^13.0.0"
     unist-util-find-all-after "^3.0.2"
-
-"@trysound/sax@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
-  integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
 "@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.5"
@@ -3002,11 +3004,6 @@ ajv@^6.12.4:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
-
-alphanum-sort@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
-  integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
 ansi-colors@4.1.1:
   version "4.1.1"
@@ -3592,11 +3589,6 @@ body-parser@1.19.0, body-parser@^1.18.3:
     raw-body "2.4.0"
     type-is "~1.6.17"
 
-boolbase@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -3638,16 +3630,6 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-browserslist@^4.0.0:
-  version "4.14.2"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.2.tgz#1b3cec458a1ba87588cc5e9be62f19b6d48813ce"
-  integrity sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==
-  dependencies:
-    caniuse-lite "^1.0.30001125"
-    electron-to-chromium "^1.3.564"
-    escalade "^3.0.2"
-    node-releases "^1.1.61"
-
 browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.3:
   version "4.16.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.3.tgz#340aa46940d7db878748567c5dea24a48ddf3717"
@@ -3659,7 +3641,7 @@ browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.3:
     escalade "^3.1.1"
     node-releases "^1.1.70"
 
-browserslist@^4.16.0, browserslist@^4.16.6, browserslist@^4.17.5:
+browserslist@^4.17.5:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.18.1.tgz#60d3920f25b6860eb917c6c7b185576f4d8b017f"
   integrity sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==
@@ -3869,21 +3851,6 @@ camelcase@^6.0.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.1.tgz#250fd350cfd555d0d2160b1d51510eaf8326e86e"
   integrity sha512-tVI4q5jjFV5CavAU8DXfza/TJcZutVKo/5Foskmsqcm0MsL91moHvwiGNnqaa2o6PF/7yT5ikDRcVcl8Rj6LCA==
-
-caniuse-api@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
-  integrity sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==
-  dependencies:
-    browserslist "^4.0.0"
-    caniuse-lite "^1.0.0"
-    lodash.memoize "^4.1.2"
-    lodash.uniq "^4.5.0"
-
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001125:
-  version "1.0.30001131"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001131.tgz#afad8a28fc2b7a0d3ae9407e71085a0ead905d54"
-  integrity sha512-4QYi6Mal4MMfQMSqGIRPGbKIbZygeN83QsWq1ixpUwvtfgAZot5BrCKzGygvZaV+CnELdTwD0S4cqUNozq7/Cw==
 
 caniuse-lite@^1.0.30001109:
   version "1.0.30001196"
@@ -4161,11 +4128,6 @@ color-name@^1.1.4, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colord@^2.9.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.1.tgz#c961ea0efeb57c9f0f4834458f26cb9cc4a3f90e"
-  integrity sha512-4LBMSt09vR0uLnPVkOUBnmxgoaeN4ewRbx801wY/bXcltXfpR/G46OdWn96XpYmCWuYvO46aBZP4NgX8HpNAcw==
-
 colorette@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
@@ -4195,11 +4157,6 @@ commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
-commander@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
-  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
 
 commander@^8.2.0:
   version "8.2.0"
@@ -4497,13 +4454,6 @@ css-blank-pseudo@^2.0.0:
   resolved "https://registry.yarnpkg.com/css-blank-pseudo/-/css-blank-pseudo-2.0.0.tgz#10667f9c5f91e4fbde76c4efac55e8eaa6ed9967"
   integrity sha512-n7fxEOyuvAVPLPb9kL4XTIK/gnp2fKQ7KFQ+9lj60W9pDn/jTr5LjS/kHHm+rES/YJ3m0S6+uJgYSuAJg9zOyA==
 
-css-declaration-sorter@^6.0.3:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/css-declaration-sorter/-/css-declaration-sorter-6.1.3.tgz#e9852e4cf940ba79f509d9425b137d1f94438dc2"
-  integrity sha512-SvjQjNRZgh4ULK1LDJ2AduPKUKxIqmtU7ZAyi47BTV+M90Qvxr9AB6lKlLbDUfXqI9IQeYA8LbAsCZPpJEV3aA==
-  dependencies:
-    timsort "^0.3.0"
-
 css-has-pseudo@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/css-has-pseudo/-/css-has-pseudo-2.0.0.tgz#43ae03a990cf3d9e7356837c6b500e04037606b5"
@@ -4515,30 +4465,6 @@ css-prefers-color-scheme@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/css-prefers-color-scheme/-/css-prefers-color-scheme-5.0.0.tgz#a89bc1abfe946e77a1a1e12dbc25a1439705933f"
   integrity sha512-XpzVrdwbppHm+Nnrzcb/hQb8eq1aKv4U8Oh59LsLfTsbIZZ6Fvn9razb66ihH2aTJ0VhO9n9sVm8piyKXJAZMA==
-
-css-select@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.1.3.tgz#a70440f70317f2669118ad74ff105e65849c7067"
-  integrity sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==
-  dependencies:
-    boolbase "^1.0.0"
-    css-what "^5.0.0"
-    domhandler "^4.2.0"
-    domutils "^2.6.0"
-    nth-check "^2.0.0"
-
-css-tree@^1.1.2, css-tree@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.3.tgz#eb4870fb6fd7707327ec95c2ff2ab09b5e8db91d"
-  integrity sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==
-  dependencies:
-    mdn-data "2.0.14"
-    source-map "^0.6.1"
-
-css-what@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe"
-  integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
 
 cssdb@^5.0.0:
   version "5.0.0"
@@ -4554,63 +4480,6 @@ cssfilter@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
   integrity sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=
-
-cssnano-preset-default@^5.1.7:
-  version "5.1.7"
-  resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-5.1.7.tgz#68c3ad1ec6a810482ec7d06b2d70fc34b6b0d70c"
-  integrity sha512-bWDjtTY+BOqrqBtsSQIbN0RLGD2Yr2CnecpP0ydHNafh9ZUEre8c8VYTaH9FEbyOt0eIfEUAYYk5zj92ioO8LA==
-  dependencies:
-    css-declaration-sorter "^6.0.3"
-    cssnano-utils "^2.0.1"
-    postcss-calc "^8.0.0"
-    postcss-colormin "^5.2.1"
-    postcss-convert-values "^5.0.2"
-    postcss-discard-comments "^5.0.1"
-    postcss-discard-duplicates "^5.0.1"
-    postcss-discard-empty "^5.0.1"
-    postcss-discard-overridden "^5.0.1"
-    postcss-merge-longhand "^5.0.4"
-    postcss-merge-rules "^5.0.3"
-    postcss-minify-font-values "^5.0.1"
-    postcss-minify-gradients "^5.0.3"
-    postcss-minify-params "^5.0.2"
-    postcss-minify-selectors "^5.1.0"
-    postcss-normalize-charset "^5.0.1"
-    postcss-normalize-display-values "^5.0.1"
-    postcss-normalize-positions "^5.0.1"
-    postcss-normalize-repeat-style "^5.0.1"
-    postcss-normalize-string "^5.0.1"
-    postcss-normalize-timing-functions "^5.0.1"
-    postcss-normalize-unicode "^5.0.1"
-    postcss-normalize-url "^5.0.3"
-    postcss-normalize-whitespace "^5.0.1"
-    postcss-ordered-values "^5.0.2"
-    postcss-reduce-initial "^5.0.1"
-    postcss-reduce-transforms "^5.0.1"
-    postcss-svgo "^5.0.3"
-    postcss-unique-selectors "^5.0.2"
-
-cssnano-utils@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/cssnano-utils/-/cssnano-utils-2.0.1.tgz#8660aa2b37ed869d2e2f22918196a9a8b6498ce2"
-  integrity sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==
-
-cssnano@^5.0.11:
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-5.0.11.tgz#743397a05e04cb87e9df44b7659850adfafc3646"
-  integrity sha512-5SHM31NAAe29jvy0MJqK40zZ/8dGlnlzcfHKw00bWMVFp8LWqtuyPSFwbaoIoxvt71KWJOfg8HMRGrBR3PExCg==
-  dependencies:
-    cssnano-preset-default "^5.1.7"
-    is-resolvable "^1.1.0"
-    lilconfig "^2.0.3"
-    yaml "^1.10.2"
-
-csso@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-4.2.0.tgz#ea3a561346e8dc9f546d6febedd50187cf389529"
-  integrity sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
-  dependencies:
-    css-tree "^1.1.2"
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -4866,6 +4735,11 @@ detect-indent@^5.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
 
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==
+
 devtools-protocol@0.0.1011705:
   version "0.0.1011705"
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.1011705.tgz#2582ed29f84848df83fba488122015540a744539"
@@ -4925,15 +4799,6 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
-dom-serializer@^1.0.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
-  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^4.2.0"
-    entities "^2.0.0"
-
 domelementtype@1, domelementtype@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
@@ -4943,11 +4808,6 @@ domelementtype@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.2.tgz#f3b6e549201e46f588b59463dd77187131fe6971"
   integrity sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA==
-
-domelementtype@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
-  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -4963,13 +4823,6 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domhandler@^4.2.0:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.2.tgz#e825d721d19a86b8c201a35264e226c678ee755f"
-  integrity sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==
-  dependencies:
-    domelementtype "^2.2.0"
-
 domutils@^1.5.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
@@ -4977,15 +4830,6 @@ domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
-
-domutils@^2.6.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
-  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
-  dependencies:
-    dom-serializer "^1.0.1"
-    domelementtype "^2.2.0"
-    domhandler "^4.2.0"
 
 dot-prop@^4.2.0:
   version "4.2.1"
@@ -5028,11 +4872,6 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-
-electron-to-chromium@^1.3.564:
-  version "1.3.570"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.570.tgz#3f5141cc39b4e3892a276b4889980dabf1d29c7f"
-  integrity sha512-Y6OCoVQgFQBP5py6A/06+yWxUZHDlNr/gNDGatjH8AZqXl8X0tE4LfjLJsXGz/JmWJz8a6K7bR1k+QzZ+k//fg==
 
 electron-to-chromium@^1.3.649:
   version "1.3.674"
@@ -5194,11 +5033,6 @@ es6-promisify@^5.0.0:
   integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
-
-escalade@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.0.tgz#e8e2d7c7a8b76f6ee64c2181d6b8151441602d4e"
-  integrity sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -6813,11 +6647,6 @@ ipaddr.js@1.9.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
-is-absolute-url@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-3.0.3.tgz#96c6a22b6a23929b11ea0afb1836c36ad4a5d698"
-  integrity sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==
-
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -7132,11 +6961,6 @@ is-regexp@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-2.1.0.tgz#cd734a56864e23b956bf4e7c66c396a4c0b22c2d"
   integrity sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==
-
-is-resolvable@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
-  integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
 is-ssh@^1.3.0:
   version "1.3.2"
@@ -7517,10 +7341,61 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lilconfig@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.4.tgz#f4507d043d7058b380b6a8f5cb7bcd4b34cee082"
-  integrity sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==
+lightningcss-darwin-arm64@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.16.0.tgz#f3318a2e64ca160610977675ee1a7e611f4a3617"
+  integrity sha512-gIhz6eZFwsC4oVMjBGQ3QWDdLQY7vcXFyM/x91PilgHqu63B9uBa10EZA75YoTEkbKhoz0uDCqyHh/EoF1GrkQ==
+
+lightningcss-darwin-x64@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.16.0.tgz#46361b701b572ce9ec29730624000b439c2184bb"
+  integrity sha512-kLPi+OEpDj3UGY6DC8TfjbcULJDKMP+TVKSlrEkNGn8t1YRzi2g4oy7UVTSB5AnSbT0CusUItzdVjHQ49EdoNA==
+
+lightningcss-linux-arm-gnueabihf@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.16.0.tgz#5da29f465dd44d98434b00b424cc4b445ea49eff"
+  integrity sha512-oSwEbvXUPr//H/ainBRJXTxHerlheee/KgkTTmAQWiVnt8HV+bRohTBWWPBy5ZArgiGLwj7ogv45istgljPN2Q==
+
+lightningcss-linux-arm64-gnu@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.16.0.tgz#21d139f5201c9b8bb3972c24116a5bcbb7e2c3b5"
+  integrity sha512-Drq9BSVIvmV9zsDJbCZWCulMvKMQWFIlYXPCKV/iwRj+ZAJ1BRngma0cNHB6uW7Wac8Jg04CJN5IA4ELE3J+cQ==
+
+lightningcss-linux-arm64-musl@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.16.0.tgz#d06936e0570fb51d58cc18ef2fb8858aeecd1979"
+  integrity sha512-1QXWStnTEo4RFQf0mfGhRyNUeEHilCZ0NA97XgwKwrYr/M7sYKU/1HWY00dPxFJ6GITR2pfJGo9xi3ScSSBxbA==
+
+lightningcss-linux-x64-gnu@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.16.0.tgz#fd9881cd839cac4676a01b713b06b0b178743f87"
+  integrity sha512-gD2eQYD5OFs1p83R0TcMCEc5HRyJES4lR4THmclv7khm3dc9vc+2VT0kFBPxO1L2AwlZuvXaaMan7X1Ul7uSfA==
+
+lightningcss-linux-x64-musl@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.16.0.tgz#697d87448e0f6445b6fc3cf8529d89709f3bfacc"
+  integrity sha512-HJsKeYxloEvg2WCQhtYPqzZUliLu9JBJNeI5y9cPQeDR/7ayGGLbVhJaotPtzJkElOFL/SaXsS+FRuH4w+yafg==
+
+lightningcss-win32-x64-msvc@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.16.0.tgz#e4a09c12a48534121ecd03ef0be8dadbbbbb63b6"
+  integrity sha512-h4ayyAlOMLUHV9NdofcIu79aEjmly93adVxcg5wDJpkvMiwDTufEN30M8G4gGcjo1JE5jFjAcyQcRpXYkYcemA==
+
+lightningcss@^1.14.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.16.0.tgz#4c8e4ef8133d54488d1482a115d3758259191c52"
+  integrity sha512-5+ZS9h+xeADcJTF2oRCT3yNZBlDYyOgQSdrWNBCqsIwm8ucKbF061OBVv/WHP4Zk8FToNhwFklk/hMuOngqsIg==
+  dependencies:
+    detect-libc "^1.0.3"
+  optionalDependencies:
+    lightningcss-darwin-arm64 "1.16.0"
+    lightningcss-darwin-x64 "1.16.0"
+    lightningcss-linux-arm-gnueabihf "1.16.0"
+    lightningcss-linux-arm64-gnu "1.16.0"
+    lightningcss-linux-arm64-musl "1.16.0"
+    lightningcss-linux-x64-gnu "1.16.0"
+    lightningcss-linux-x64-musl "1.16.0"
+    lightningcss-win32-x64-msvc "1.16.0"
 
 lines-and-columns@^1.1.6:
   version "1.1.6"
@@ -7681,11 +7556,6 @@ lodash.ismatch@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
   integrity sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=
-
-lodash.memoize@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -7958,11 +7828,6 @@ mdast-util-to-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz#b8cfe6a713e1091cb5b728fc48885a4767f8b97b"
   integrity sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==
-
-mdn-data@2.0.14:
-  version "2.0.14"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
-  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
 
 mdurl@^1.0.0:
   version "1.0.1"
@@ -8401,11 +8266,6 @@ node-html-parser@^1.2.21:
   dependencies:
     he "1.2.0"
 
-node-releases@^1.1.61:
-  version "1.1.61"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.61.tgz#707b0fca9ce4e11783612ba4a2fcba09047af16e"
-  integrity sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==
-
 node-releases@^1.1.70:
   version "1.1.71"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
@@ -8463,11 +8323,6 @@ normalize-url@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
-
-normalize-url@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
-  integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
 npm-bundled@^1.0.1:
   version "1.1.1"
@@ -8539,13 +8394,6 @@ npmlog@^4.1.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
-
-nth-check@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
-  integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
-  dependencies:
-    boolbase "^1.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -9098,14 +8946,6 @@ postcss-attribute-case-insensitive@^5.0.0:
   dependencies:
     postcss-selector-parser "^6.0.2"
 
-postcss-calc@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-8.0.0.tgz#a05b87aacd132740a5db09462a3612453e5df90a"
-  integrity sha512-5NglwDrcbiy8XXfPM11F3HeC6hoT9W7GUH/Zi5U/p7u3Irv4rHhdDcIZwG0llHXV4ftsBjpfWMXAnXNl4lnt8g==
-  dependencies:
-    postcss-selector-parser "^6.0.2"
-    postcss-value-parser "^4.0.2"
-
 postcss-color-functional-notation@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-color-functional-notation/-/postcss-color-functional-notation-4.0.1.tgz#2fd769959e7fe658b4c0e7d40b0ab245fc8664f1"
@@ -9126,23 +8966,6 @@ postcss-color-rebeccapurple@^7.0.0:
   integrity sha512-+Ogw3SA0ESjjO87S8Dn+aAEHK6hFAWAVbTVnyXnmbV6Xh0TKi0vXpzhlKG/yrxujxtlgQcMQNQjg75uWWv28xA==
   dependencies:
     postcss-values-parser "^6"
-
-postcss-colormin@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-5.2.1.tgz#6e444a806fd3c578827dbad022762df19334414d"
-  integrity sha512-VVwMrEYLcHYePUYV99Ymuoi7WhKrMGy/V9/kTS0DkCoJYmmjdOMneyhzYUxcNgteKDVbrewOkSM7Wje/MFwxzA==
-  dependencies:
-    browserslist "^4.16.6"
-    caniuse-api "^3.0.0"
-    colord "^2.9.1"
-    postcss-value-parser "^4.1.0"
-
-postcss-convert-values@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-5.0.2.tgz#879b849dc3677c7d6bc94b6a2c1a3f0808798059"
-  integrity sha512-KQ04E2yadmfa1LqXm7UIDwW1ftxU/QWZmz6NKnHnUvJ3LEYbbcX6i329f/ig+WnEByHegulocXrECaZGLpL8Zg==
-  dependencies:
-    postcss-value-parser "^4.1.0"
 
 postcss-custom-media@^8.0.0:
   version "8.0.0"
@@ -9169,26 +8992,6 @@ postcss-dir-pseudo-class@^6.0.0:
   integrity sha512-TC4eB5ZnLRSV1PLsAPualEjxFysU9IVEBx8h+Md2qzo8iWdNqwWCckx5fTWfe6dJxUpB0TWEpWEFhZ/YHvjSCA==
   dependencies:
     postcss-selector-parser "6.0.6"
-
-postcss-discard-comments@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz#9eae4b747cf760d31f2447c27f0619d5718901fe"
-  integrity sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==
-
-postcss-discard-duplicates@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz#68f7cc6458fe6bab2e46c9f55ae52869f680e66d"
-  integrity sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==
-
-postcss-discard-empty@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz#ee136c39e27d5d2ed4da0ee5ed02bc8a9f8bf6d8"
-  integrity sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==
-
-postcss-discard-overridden@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz#454b41f707300b98109a75005ca4ab0ff2743ac6"
-  integrity sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==
 
 postcss-double-position-gradients@^3.0.1:
   version "3.0.1"
@@ -9238,15 +9041,6 @@ postcss-image-set-function@^4.0.2:
   dependencies:
     postcss-values-parser "6.0.1"
 
-postcss-import@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-13.0.0.tgz#d6960cd9e3de5464743b04dd8cd9d870662f8b8c"
-  integrity sha512-LPUbm3ytpYopwQQjqgUH4S3EM/Gb9QsaSPP/5vnoi+oKVy3/mIk2sc0Paqw7RL57GpScm9MdIMUypw2znWiBpg==
-  dependencies:
-    postcss-value-parser "^4.0.0"
-    read-cache "^1.0.0"
-    resolve "^1.1.7"
-
 postcss-initial@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-initial/-/postcss-initial-4.0.1.tgz#529f735f72c5724a0fb30527df6fb7ac54d7de42"
@@ -9282,58 +9076,6 @@ postcss-media-query-parser@^0.2.3:
   resolved "https://registry.yarnpkg.com/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz#27b39c6f4d94f81b1a73b8f76351c609e5cef244"
   integrity sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=
 
-postcss-merge-longhand@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-merge-longhand/-/postcss-merge-longhand-5.0.4.tgz#41f4f3270282ea1a145ece078b7679f0cef21c32"
-  integrity sha512-2lZrOVD+d81aoYkZDpWu6+3dTAAGkCKbV5DoRhnIR7KOULVrI/R7bcMjhrH9KTRy6iiHKqmtG+n/MMj1WmqHFw==
-  dependencies:
-    postcss-value-parser "^4.1.0"
-    stylehacks "^5.0.1"
-
-postcss-merge-rules@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-5.0.3.tgz#b5cae31f53129812a77e3eb1eeee448f8cf1a1db"
-  integrity sha512-cEKTMEbWazVa5NXd8deLdCnXl+6cYG7m2am+1HzqH0EnTdy8fRysatkaXb2dEnR+fdaDxTvuZ5zoBdv6efF6hg==
-  dependencies:
-    browserslist "^4.16.6"
-    caniuse-api "^3.0.0"
-    cssnano-utils "^2.0.1"
-    postcss-selector-parser "^6.0.5"
-
-postcss-minify-font-values@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-5.0.1.tgz#a90cefbfdaa075bd3dbaa1b33588bb4dc268addf"
-  integrity sha512-7JS4qIsnqaxk+FXY1E8dHBDmraYFWmuL6cgt0T1SWGRO5bzJf8sUoelwa4P88LEWJZweHevAiDKxHlofuvtIoA==
-  dependencies:
-    postcss-value-parser "^4.1.0"
-
-postcss-minify-gradients@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-minify-gradients/-/postcss-minify-gradients-5.0.3.tgz#f970a11cc71e08e9095e78ec3a6b34b91c19550e"
-  integrity sha512-Z91Ol22nB6XJW+5oe31+YxRsYooxOdFKcbOqY/V8Fxse1Y3vqlNRpi1cxCqoACZTQEhl+xvt4hsbWiV5R+XI9Q==
-  dependencies:
-    colord "^2.9.1"
-    cssnano-utils "^2.0.1"
-    postcss-value-parser "^4.1.0"
-
-postcss-minify-params@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-minify-params/-/postcss-minify-params-5.0.2.tgz#1b644da903473fbbb18fbe07b8e239883684b85c"
-  integrity sha512-qJAPuBzxO1yhLad7h2Dzk/F7n1vPyfHfCCh5grjGfjhi1ttCnq4ZXGIW77GSrEbh9Hus9Lc/e/+tB4vh3/GpDg==
-  dependencies:
-    alphanum-sort "^1.0.2"
-    browserslist "^4.16.6"
-    cssnano-utils "^2.0.1"
-    postcss-value-parser "^4.1.0"
-
-postcss-minify-selectors@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-minify-selectors/-/postcss-minify-selectors-5.1.0.tgz#4385c845d3979ff160291774523ffa54eafd5a54"
-  integrity sha512-NzGBXDa7aPsAcijXZeagnJBKBPMYLaJJzB8CQh6ncvyl2sIndLVWfbcDi0SBjRWk5VqEjXvf8tYwzoKf4Z07og==
-  dependencies:
-    alphanum-sort "^1.0.2"
-    postcss-selector-parser "^6.0.5"
-
 postcss-nested@^4.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/postcss-nested/-/postcss-nested-4.2.3.tgz#c6f255b0a720549776d220d00c4b70cd244136f6"
@@ -9348,81 +9090,6 @@ postcss-nesting@^10.0.2:
   integrity sha512-FdecapAKIe+kp6uLNW7icw1g1B2HRhAAfsNv/TPzopeM08gpUbnBpqKSVqxrCqLDwzQG854ZJn5I0BiJ35WvmA==
   dependencies:
     postcss-selector-parser "6.0.6"
-
-postcss-normalize-charset@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz#121559d1bebc55ac8d24af37f67bd4da9efd91d0"
-  integrity sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==
-
-postcss-normalize-display-values@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-display-values/-/postcss-normalize-display-values-5.0.1.tgz#62650b965981a955dffee83363453db82f6ad1fd"
-  integrity sha512-uupdvWk88kLDXi5HEyI9IaAJTE3/Djbcrqq8YgjvAVuzgVuqIk3SuJWUisT2gaJbZm1H9g5k2w1xXilM3x8DjQ==
-  dependencies:
-    cssnano-utils "^2.0.1"
-    postcss-value-parser "^4.1.0"
-
-postcss-normalize-positions@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-positions/-/postcss-normalize-positions-5.0.1.tgz#868f6af1795fdfa86fbbe960dceb47e5f9492fe5"
-  integrity sha512-rvzWAJai5xej9yWqlCb1OWLd9JjW2Ex2BCPzUJrbaXmtKtgfL8dBMOOMTX6TnvQMtjk3ei1Lswcs78qKO1Skrg==
-  dependencies:
-    postcss-value-parser "^4.1.0"
-
-postcss-normalize-repeat-style@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.0.1.tgz#cbc0de1383b57f5bb61ddd6a84653b5e8665b2b5"
-  integrity sha512-syZ2itq0HTQjj4QtXZOeefomckiV5TaUO6ReIEabCh3wgDs4Mr01pkif0MeVwKyU/LHEkPJnpwFKRxqWA/7O3w==
-  dependencies:
-    cssnano-utils "^2.0.1"
-    postcss-value-parser "^4.1.0"
-
-postcss-normalize-string@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-string/-/postcss-normalize-string-5.0.1.tgz#d9eafaa4df78c7a3b973ae346ef0e47c554985b0"
-  integrity sha512-Ic8GaQ3jPMVl1OEn2U//2pm93AXUcF3wz+OriskdZ1AOuYV25OdgS7w9Xu2LO5cGyhHCgn8dMXh9bO7vi3i9pA==
-  dependencies:
-    postcss-value-parser "^4.1.0"
-
-postcss-normalize-timing-functions@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.0.1.tgz#8ee41103b9130429c6cbba736932b75c5e2cb08c"
-  integrity sha512-cPcBdVN5OsWCNEo5hiXfLUnXfTGtSFiBU9SK8k7ii8UD7OLuznzgNRYkLZow11BkQiiqMcgPyh4ZqXEEUrtQ1Q==
-  dependencies:
-    cssnano-utils "^2.0.1"
-    postcss-value-parser "^4.1.0"
-
-postcss-normalize-unicode@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.1.tgz#82d672d648a411814aa5bf3ae565379ccd9f5e37"
-  integrity sha512-kAtYD6V3pK0beqrU90gpCQB7g6AOfP/2KIPCVBKJM2EheVsBQmx/Iof+9zR9NFKLAx4Pr9mDhogB27pmn354nA==
-  dependencies:
-    browserslist "^4.16.0"
-    postcss-value-parser "^4.1.0"
-
-postcss-normalize-url@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-url/-/postcss-normalize-url-5.0.3.tgz#42eca6ede57fe69075fab0f88ac8e48916ef931c"
-  integrity sha512-qWiUMbvkRx3kc1Dp5opzUwc7MBWZcSDK2yofCmdvFBCpx+zFPkxBC1FASQ59Pt+flYfj/nTZSkmF56+XG5elSg==
-  dependencies:
-    is-absolute-url "^3.0.3"
-    normalize-url "^6.0.1"
-    postcss-value-parser "^4.1.0"
-
-postcss-normalize-whitespace@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.1.tgz#b0b40b5bcac83585ff07ead2daf2dcfbeeef8e9a"
-  integrity sha512-iPklmI5SBnRvwceb/XH568yyzK0qRVuAG+a1HFUsFRf11lEJTiQQa03a4RSCQvLKdcpX7XsI1Gen9LuLoqwiqA==
-  dependencies:
-    postcss-value-parser "^4.1.0"
-
-postcss-ordered-values@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-ordered-values/-/postcss-ordered-values-5.0.2.tgz#1f351426977be00e0f765b3164ad753dac8ed044"
-  integrity sha512-8AFYDSOYWebJYLyJi3fyjl6CqMEG/UVworjiyK1r573I56kb3e879sCJLGvR3merj+fAdPpVplXKQZv+ey6CgQ==
-  dependencies:
-    cssnano-utils "^2.0.1"
-    postcss-value-parser "^4.1.0"
 
 postcss-overflow-shorthand@^3.0.0:
   version "3.0.0"
@@ -9488,22 +9155,6 @@ postcss-pseudo-class-any-link@^7.0.0:
   dependencies:
     postcss-selector-parser "^6"
 
-postcss-reduce-initial@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-5.0.1.tgz#9d6369865b0f6f6f6b165a0ef5dc1a4856c7e946"
-  integrity sha512-zlCZPKLLTMAqA3ZWH57HlbCjkD55LX9dsRyxlls+wfuRfqCi5mSlZVan0heX5cHr154Dq9AfbH70LyhrSAezJw==
-  dependencies:
-    browserslist "^4.16.0"
-    caniuse-api "^3.0.0"
-
-postcss-reduce-transforms@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-reduce-transforms/-/postcss-reduce-transforms-5.0.1.tgz#93c12f6a159474aa711d5269923e2383cedcf640"
-  integrity sha512-a//FjoPeFkRuAguPscTVmRQUODP+f3ke2HqFNgGPwdYnpeC29RZdCBvGRGTsKpMURb/I3p6jdKoBQ2zI+9Q7kA==
-  dependencies:
-    cssnano-utils "^2.0.1"
-    postcss-value-parser "^4.1.0"
-
 postcss-replace-overflow-wrap@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz#d2df6bed10b477bf9c52fab28c568b4b29ca4319"
@@ -9543,7 +9194,7 @@ postcss-selector-not@^5.0.0:
   dependencies:
     balanced-match "^1.0.0"
 
-postcss-selector-parser@6.0.6, postcss-selector-parser@^6, postcss-selector-parser@^6.0.5:
+postcss-selector-parser@6.0.6, postcss-selector-parser@^6:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
   integrity sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==
@@ -9570,28 +9221,12 @@ postcss-selector-parser@^6.0.4:
     uniq "^1.0.1"
     util-deprecate "^1.0.2"
 
-postcss-svgo@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-5.0.3.tgz#d945185756e5dfaae07f9edb0d3cae7ff79f9b30"
-  integrity sha512-41XZUA1wNDAZrQ3XgWREL/M2zSw8LJPvb5ZWivljBsUQAGoEKMYm6okHsTjJxKYI4M75RQEH4KYlEM52VwdXVA==
-  dependencies:
-    postcss-value-parser "^4.1.0"
-    svgo "^2.7.0"
-
 postcss-syntax@^0.36.2:
   version "0.36.2"
   resolved "https://registry.yarnpkg.com/postcss-syntax/-/postcss-syntax-0.36.2.tgz#f08578c7d95834574e5593a82dfbfa8afae3b51c"
   integrity sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==
 
-postcss-unique-selectors@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-5.0.2.tgz#5d6893daf534ae52626708e0d62250890108c0c1"
-  integrity sha512-w3zBVlrtZm7loQWRPVC0yjUwwpty7OM6DnEHkxcSQXO1bMS3RJ+JUS5LFMSDZHJcvGsRwhZinCWVqn8Kej4EDA==
-  dependencies:
-    alphanum-sort "^1.0.2"
-    postcss-selector-parser "^6.0.5"
-
-postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
+postcss-value-parser@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
@@ -9851,13 +9486,6 @@ react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-read-cache@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
-  integrity sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=
-  dependencies:
-    pify "^2.3.0"
 
 read-cmd-shim@^1.0.1:
   version "1.0.5"
@@ -10320,14 +9948,6 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.7, resolve@^1.17.0:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
-  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
-  dependencies:
-    is-core-module "^2.1.0"
-    path-parse "^1.0.6"
-
 resolve@^1.10.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
@@ -10350,6 +9970,14 @@ resolve@^1.12.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.3.2:
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
   dependencies:
     is-core-module "^2.2.0"
+    path-parse "^1.0.6"
+
+resolve@^1.17.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
+  integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+  dependencies:
+    is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
 restore-cursor@^2.0.0:
@@ -10887,11 +10515,6 @@ ssri@^6.0.0, ssri@^6.0.1:
   dependencies:
     figgy-pudding "^3.5.1"
 
-stable@^0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
-  integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
-
 state-toggle@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.3.tgz#e123b16a88e143139b09c6852221bc9815917dfe"
@@ -11125,14 +10748,6 @@ style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
-stylehacks@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/stylehacks/-/stylehacks-5.0.1.tgz#323ec554198520986806388c7fdaebc38d2c06fb"
-  integrity sha512-Es0rVnHIqbWzveU1b24kbw92HsebBepxfcqe5iix7t9j0PQqhs0IxXVXv0pY2Bxa08CgMkzD6OWql7kbGOuEdA==
-  dependencies:
-    browserslist "^4.16.0"
-    postcss-selector-parser "^6.0.4"
-
 stylelint-a11y@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/stylelint-a11y/-/stylelint-a11y-1.2.3.tgz#e8db461fd493cdb9106da0c8040e0576ef96b8fd"
@@ -11259,19 +10874,6 @@ svg-tags@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
   integrity sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=
-
-svgo@^2.7.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/svgo/-/svgo-2.8.0.tgz#4ff80cce6710dc2795f0c7c74101e6764cfccd24"
-  integrity sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==
-  dependencies:
-    "@trysound/sax" "0.2.0"
-    commander "^7.2.0"
-    css-select "^4.1.3"
-    css-tree "^1.1.3"
-    csso "^4.2.0"
-    picocolors "^1.0.0"
-    stable "^0.1.8"
 
 symbol-observable@^1.0.4, symbol-observable@^1.2.0:
   version "1.2.0"
@@ -11421,11 +11023,6 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-
-timsort@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
-  integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
 tiny-emitter@^2.0.0:
   version "2.1.0"
@@ -12306,11 +11903,6 @@ yaml@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
-
-yaml@^1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@20.2.4, yargs-parser@^20.2.3:
   version "20.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,13 +2432,6 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
-"@rollup/plugin-json@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
-  integrity sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
-  dependencies:
-    "@rollup/pluginutils" "^3.0.8"
-
 "@rollup/plugin-node-resolve@^13.0.0":
   version "13.0.5"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.0.5.tgz#016abe58796a4ff544d6beac7818921e3d3777fc"
@@ -2459,15 +2452,7 @@
     "@rollup/pluginutils" "^3.1.0"
     magic-string "^0.25.7"
 
-"@rollup/plugin-typescript@^8.2.1":
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-8.2.1.tgz#f1a32d4030cc83432ce36a80a922280f0f0b5d44"
-  integrity sha512-Qd2E1pleDR4bwyFxqbjt4eJf+wB0UKVMLc7/BAFDGVdAXQMCsD4DUv5/7/ww47BZCYxWtJqe1Lo0KVNswBJlRw==
-  dependencies:
-    "@rollup/pluginutils" "^3.1.0"
-    resolve "^1.17.0"
-
-"@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
+"@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
@@ -3563,11 +3548,6 @@ before-after-hook@^2.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
-big.js@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
-  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
-
 binary-extensions@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
@@ -4269,7 +4249,7 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
-concat-with-sourcemaps@*, concat-with-sourcemaps@^1.1.0:
+concat-with-sourcemaps@*:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz#d4ea93f05ae25790951b99e7b3b09e3908a4082e"
   integrity sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==
@@ -4615,7 +4595,7 @@ cssnano-utils@^2.0.1:
   resolved "https://registry.yarnpkg.com/cssnano-utils/-/cssnano-utils-2.0.1.tgz#8660aa2b37ed869d2e2f22918196a9a8b6498ce2"
   integrity sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==
 
-cssnano@^5.0.1, cssnano@^5.0.11:
+cssnano@^5.0.11:
   version "5.0.11"
   resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-5.0.11.tgz#743397a05e04cb87e9df44b7659850adfafc3646"
   integrity sha512-5SHM31NAAe29jvy0MJqK40zZ/8dGlnlzcfHKw00bWMVFp8LWqtuyPSFwbaoIoxvt71KWJOfg8HMRGrBR3PExCg==
@@ -5079,11 +5059,6 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
-emojis-list@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
-  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
-
 encodeurl@^1.0.2, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -5375,11 +5350,6 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
-estree-walker@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
-  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
-
 estree-walker@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
@@ -5404,11 +5374,6 @@ eventemitter3@^3.1.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
-
-eventemitter3@^4.0.4:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
-  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
 execa@^1.0.0:
   version "1.0.0"
@@ -5922,13 +5887,6 @@ gauge@~2.7.3:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
-
-generic-names@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/generic-names/-/generic-names-2.0.1.tgz#f8a378ead2ccaa7a34f0317b05554832ae41b872"
-  integrity sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==
-  dependencies:
-    loader-utils "^1.1.0"
 
 genfun@^5.0.0:
   version "5.0.0"
@@ -6644,16 +6602,6 @@ iconv-lite@^0.6.2:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-icss-replace-symbols@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
-  integrity sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=
-
-icss-utils@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
-  integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
-
 ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
@@ -6681,13 +6629,6 @@ ignore@^5.1.4, ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-import-cwd@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-3.0.0.tgz#20845547718015126ea9b3676b7592fb8bd4cf92"
-  integrity sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==
-  dependencies:
-    import-from "^3.0.0"
-
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -6711,13 +6652,6 @@ import-fresh@^3.2.1:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
-
-import-from@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/import-from/-/import-from-3.0.0.tgz#055cfec38cd5a27d8057ca51376d7d3bf0891966"
-  integrity sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==
-  dependencies:
-    resolve-from "^5.0.0"
 
 import-lazy@^4.0.0:
   version "4.0.0"
@@ -7430,13 +7364,6 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  dependencies:
-    minimist "^1.2.0"
-
 json5@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
@@ -7695,15 +7622,6 @@ load-json-file@^5.3.0:
     strip-bom "^3.0.0"
     type-fest "^0.3.0"
 
-loader-utils@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
-  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^1.0.1"
-
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -7743,11 +7661,6 @@ lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
-
-lodash.camelcase@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
@@ -8921,25 +8834,10 @@ p-queue@^4.0.0:
   dependencies:
     eventemitter3 "^3.1.0"
 
-p-queue@^6.6.2:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
-  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
-  dependencies:
-    eventemitter3 "^4.0.4"
-    p-timeout "^3.2.0"
-
 p-reduce@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-1.0.0.tgz#18c2b0dd936a4690a529f8231f58a0fdb6a47dfa"
   integrity sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=
-
-p-timeout@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
-  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
-  dependencies:
-    p-finally "^1.0.0"
 
 p-try@^1.0.0:
   version "1.0.0"
@@ -9162,11 +9060,6 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-pify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-5.0.0.tgz#1f5eca3f5e87ebec28cc6d54a0e4aaf00acc127f"
-  integrity sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==
-
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -9374,15 +9267,6 @@ postcss-less@^3.1.4:
   dependencies:
     postcss "^7.0.14"
 
-postcss-load-config@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.1.0.tgz#d39c47091c4aec37f50272373a6a648ef5e97829"
-  integrity sha512-ipM8Ds01ZUophjDTQYSVP70slFSYg3T0/zyfII5vzhN6V57YSxMgG5syXuwi5VtS8wSf3iL30v0uBdoIVx4Q0g==
-  dependencies:
-    import-cwd "^3.0.0"
-    lilconfig "^2.0.3"
-    yaml "^1.10.2"
-
 postcss-logical@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-logical/-/postcss-logical-5.0.0.tgz#f646ef6a3562890e1123a32e695d14cc271afb21"
@@ -9449,48 +9333,6 @@ postcss-minify-selectors@^5.1.0:
   dependencies:
     alphanum-sort "^1.0.2"
     postcss-selector-parser "^6.0.5"
-
-postcss-modules-extract-imports@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
-  integrity sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==
-
-postcss-modules-local-by-default@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz#ebbb54fae1598eecfdf691a02b3ff3b390a5a51c"
-  integrity sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==
-  dependencies:
-    icss-utils "^5.0.0"
-    postcss-selector-parser "^6.0.2"
-    postcss-value-parser "^4.1.0"
-
-postcss-modules-scope@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz#9ef3151456d3bbfa120ca44898dfca6f2fa01f06"
-  integrity sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==
-  dependencies:
-    postcss-selector-parser "^6.0.4"
-
-postcss-modules-values@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz#d7c5e7e68c3bb3c9b27cbf48ca0bb3ffb4602c9c"
-  integrity sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==
-  dependencies:
-    icss-utils "^5.0.0"
-
-postcss-modules@^4.0.0:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/postcss-modules/-/postcss-modules-4.2.2.tgz#5e7777c5a8964ea176919d90b2e54ef891321ce5"
-  integrity sha512-/H08MGEmaalv/OU8j6bUKi/kZr2kqGF6huAW8m9UAgOLWtpFdhA14+gPBoymtqyv+D4MLsmqaF2zvIegdCxJXg==
-  dependencies:
-    generic-names "^2.0.1"
-    icss-replace-symbols "^1.1.0"
-    lodash.camelcase "^4.3.0"
-    postcss-modules-extract-imports "^3.0.0"
-    postcss-modules-local-by-default "^4.0.0"
-    postcss-modules-scope "^3.0.0"
-    postcss-modules-values "^4.0.0"
-    string-hash "^1.1.1"
 
 postcss-nested@^4.1.2:
   version "4.2.3"
@@ -9820,11 +9662,6 @@ promise-retry@^1.1.1:
   dependencies:
     err-code "^1.0.0"
     retry "^0.10.0"
-
-promise.series@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/promise.series/-/promise.series-0.2.0.tgz#2cc7ebe959fc3a6619c04ab4dbdc9e452d864bbd"
-  integrity sha1-LMfr6Vn8OmYZwEq029yeRS2GS70=
 
 promzard@^0.3.0:
   version "0.3.0"
@@ -10577,25 +10414,6 @@ rollup-plugin-analyzer@^4.0.0:
   resolved "https://registry.yarnpkg.com/rollup-plugin-analyzer/-/rollup-plugin-analyzer-4.0.0.tgz#96b757ed64a098b59d72f085319e68cdd86d5798"
   integrity sha512-LL9GEt3bkXp6Wa19SNR5MWcvHNMvuTFYg+eYBZN2OIFhSWN+pEJUQXEKu5BsOeABob3x9PDaLKW7w5iOJnsESQ==
 
-rollup-plugin-postcss@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-postcss/-/rollup-plugin-postcss-4.0.2.tgz#15e9462f39475059b368ce0e49c800fa4b1f7050"
-  integrity sha512-05EaY6zvZdmvPUDi3uCcAQoESDcYnv8ogJJQRp6V5kZ6J6P7uAVJlrTZcaaA20wTH527YTnKfkAoPxWI/jPp4w==
-  dependencies:
-    chalk "^4.1.0"
-    concat-with-sourcemaps "^1.1.0"
-    cssnano "^5.0.1"
-    import-cwd "^3.0.0"
-    p-queue "^6.6.2"
-    pify "^5.0.0"
-    postcss-load-config "^3.0.0"
-    postcss-modules "^4.0.0"
-    promise.series "^0.2.0"
-    resolve "^1.19.0"
-    rollup-pluginutils "^2.8.2"
-    safe-identifier "^0.4.2"
-    style-inject "^0.3.0"
-
 rollup-plugin-terser@^7.0.0:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
@@ -10605,13 +10423,6 @@ rollup-plugin-terser@^7.0.0:
     jest-worker "^26.2.1"
     serialize-javascript "^4.0.0"
     terser "^5.0.0"
-
-rollup-pluginutils@^2.8.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
-  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
-  dependencies:
-    estree-walker "^0.6.1"
 
 rollup@^2.58.0:
   version "2.58.0"
@@ -10660,11 +10471,6 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, 
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
-safe-identifier@^0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/safe-identifier/-/safe-identifier-0.4.2.tgz#cf6bfca31c2897c588092d1750d30ef501d59fcb"
-  integrity sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -11132,11 +10938,6 @@ streamsearch@0.1.2:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
   integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
 
-string-hash@^1.1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
-  integrity sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=
-
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -11311,11 +11112,6 @@ strong-log-transformer@^2.0.0:
     duplexer "^0.1.1"
     minimist "^1.2.0"
     through "^2.3.4"
-
-style-inject@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/style-inject/-/style-inject-0.3.0.tgz#d21c477affec91811cc82355832a700d22bf8dd3"
-  integrity sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==
 
 style-search@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

#763 

## Summary of Changes
1. Swapped out PostCSS with ParcelCSS in CLI package
1. Updated PostCSS plugin and deps accordingly 
1. Ensure Style bundling includes interception

As for making our own CSS bundler, we probably could, but maybe more of 2.0 thing?

> _Builds off #971.  See [here](https://github.com/ProjectEvergreen/greenwood/compare/enhancement/issue-971-refactor-bundling-and-optimizations...enhancement/issue-763-parcel-css-bundling?expand=1) for the stacked diff._

## TODO
1. [ ] Update specs due to ParcelCSS "fixing" styles?
    ```sh
    -body{color:red}h1{color:#00f}
    +body{color:red}h1{color:blue}
    ```
1. [ ] Update tech stack docs
1. [ ] More specs failing in GitHub Actions than locally?
1. [ ] Getting a 404 on nested CSS paths when deep link refreshing, e.g. /blog/releases/0.27.0 - seems that only the `bundle` method supports inlining `@import`, [but it requires a file to seed the compiler](https://github.com/parcel-bundler/lightningcss#from-node).  Which means we have to work on scratch files, but that loses the context of relative paths, which is something [PostCSS Import had a solution for](https://github.com/postcss/postcss-import#usage).
    - so there is a custom resolver, but it borks on non-relative URLs?  (like google font URLs)
  <details>
    <img width="835" alt="Screen Shot 2022-09-03 at 7 46 18 PM" src="https://user-images.githubusercontent.com/895923/188768218-abb2689d-7203-4da6-a1a8-afa80122b669.png">
  </details>