### PR TITLE
Bug/leading slash in CSS (`<link>`) paths break bundling

### DIFF
--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -67,10 +67,6 @@ async function bundleStyleResources(compilation, optimizationPlugins) {
         const basenamePieces = path.basename(srcPath).split('.');
         const fileNamePieces = srcPath.split('/').filter(piece => piece !== ''); // normalize by removing any leading /'s  
 
-        console.debug({ srcPath });
-        console.debug({ basename });
-        console.debug({ basenamePieces });
-        console.debug({ fileNamePieces });
         optimizedFileName = srcPath.indexOf('/node_modules') >= 0
           ? `${basenamePieces[0]}.${hashString(contents)}.css`
           : fileNamePieces.join('/').replace(basename, `${basenamePieces[0]}.${hashString(contents)}.css`);
@@ -101,8 +97,6 @@ async function bundleStyleResources(compilation, optimizationPlugins) {
         optimizedFileContents = optimizedStyles;
       }
 
-      console.debug({ optimizedFileName });
-      console.debug('==============================');
       compilation.resources.set(resourceKey, {
         ...compilation.resources.get(resourceKey),
         optimizedFileName,

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -65,10 +65,15 @@ async function bundleStyleResources(compilation, optimizationPlugins) {
       if (src) {
         const basename = path.basename(srcPath);
         const basenamePieces = path.basename(srcPath).split('.');
+        const fileNamePieces = srcPath.split('/').filter(piece => piece !== ''); // normalize by removing any leading /'s  
 
+        console.debug({ srcPath });
+        console.debug({ basename });
+        console.debug({ basenamePieces });
+        console.debug({ fileNamePieces });
         optimizedFileName = srcPath.indexOf('/node_modules') >= 0
           ? `${basenamePieces[0]}.${hashString(contents)}.css`
-          : srcPath.replace(basename, `${basenamePieces[0]}.${hashString(contents)}.css`);
+          : fileNamePieces.join('/').replace(basename, `${basenamePieces[0]}.${hashString(contents)}.css`);
       } else {
         optimizedFileName = `${hashString(contents)}.css`;
       }
@@ -96,6 +101,8 @@ async function bundleStyleResources(compilation, optimizationPlugins) {
         optimizedFileContents = optimizedStyles;
       }
 
+      console.debug({ optimizedFileName });
+      console.debug('==============================');
       compilation.resources.set(resourceKey, {
         ...compilation.resources.get(resourceKey),
         optimizedFileName,

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -105,7 +105,9 @@ describe('Build Greenwood With: ', function() {
       it('should have one <script> tag for non-module.js loaded in the <head>', function() {
         const scriptTags = dom.window.document.querySelectorAll('head > script[src]');
         const mainScriptTags = Array.prototype.slice.call(scriptTags).filter(script => {
-          return (/non-module.*[a-z0-9].js/).test(script.src);
+          const src = script.getAttribute('src');
+
+          return (/non-module.*[a-z0-9].js/).test(src) && src.indexOf('//') < 0;
         });
         
         expect(mainScriptTags.length).to.be.equal(1);
@@ -148,8 +150,12 @@ describe('Build Greenwood With: ', function() {
         const linkTags = dom.window.document.querySelectorAll('head > link[rel="stylesheet"]');
         
         expect(linkTags.length).to.be.equal(2);
+
         linkTags.forEach(link => {
-          expect((/.*[a-z0-9].css/).test(link.href)).to.be.equal(true);
+          const href = link.getAttribute('href');
+          const hrefPieces = link.getAttribute('href').split('/');
+
+          expect(href).to.be.equal(`/styles/${hrefPieces[2]}`);
         });
       });
 

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/src/pages/index.html
@@ -17,7 +17,7 @@
     </style>
 
     <link rel="stylesheet" href="../styles/main.css"></link>
-    <link href="../styles/other.css" rel="stylesheet"></link>
+    <link href="/styles/other.css" rel="stylesheet"></link>
 
     <script type="module">
       const two = 'script tag module inline two';
@@ -46,7 +46,7 @@
         })
     </script>
 
-    <script src="../scripts/non-module.js"></script>
+    <script src="/scripts/non-module.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#971 

Found that CSS paths with a leading `/` in their path was throwing a 404 with production bundling
```html
<link rel="stylesheet" href="/styles/theme.css"></link>
```

![Screen Shot 2022-10-01 at 2 09 39 PM](https://user-images.githubusercontent.com/895923/193423223-288ff93a-cb83-49d7-98e7-e9516a9443d7.png)

## Summary of Changes
1. Normalize creating `optimizedFileName` for CSS (`<link>`) assets

## TODO
1. [x] Should make sure this is covered by a test case somewhere (and remove `console.log`)