### PR TITLE
introduce worker thread pools for SSR page generation

### DIFF
--- a/packages/cli/src/lib/ssr-route-worker.js
+++ b/packages/cli/src/lib/ssr-route-worker.js
@@ -1,6 +1,6 @@
 // https://github.com/nodejs/modules/issues/307#issuecomment-858729422
 import { pathToFileURL } from 'url';
-import { workerData, parentPort } from 'worker_threads';
+import { parentPort } from 'worker_threads';
 import { renderToString, renderFromHTML } from 'wc-compiler';
 
 async function executeRouteModule({ modulePath, compilation, route, label, id, prerender, htmlContents, scripts }) {
@@ -43,4 +43,6 @@ async function executeRouteModule({ modulePath, compilation, route, label, id, p
   parentPort.postMessage(data);
 }
 
-executeRouteModule(workerData);
+parentPort.on('message', async (task) => {
+  await executeRouteModule(task);
+});

--- a/packages/cli/src/lib/threadpool.js
+++ b/packages/cli/src/lib/threadpool.js
@@ -1,0 +1,79 @@
+// https://amagiacademy.com/blog/posts/2021-04-09/node-worker-threads-pool
+import { AsyncResource } from 'async_hooks';
+import { EventEmitter } from 'events';
+import { Worker } from 'worker_threads';
+
+const kTaskInfo = Symbol('kTaskInfo');
+const kWorkerFreedEvent = Symbol('kWorkerFreedEvent');
+
+class WorkerPoolTaskInfo extends AsyncResource {
+  constructor(callback) {
+    super('WorkerPoolTaskInfo');
+    this.callback = callback;
+  }
+
+  done(err, result) {
+    this.runInAsyncScope(this.callback, null, err, result);
+    this.emitDestroy();
+  }
+}
+
+class WorkerPool extends EventEmitter {
+  constructor(numThreads, workerFile) {
+    super();
+    this.numThreads = numThreads;
+    this.workerFile = workerFile;
+    this.workers = [];
+    this.freeWorkers = [];
+
+    for (let i = 0; i < numThreads; i += 1) {
+      this.addNewWorker();
+    }
+  }
+
+  addNewWorker() {
+    const worker = new Worker(this.workerFile);
+
+    worker.on('message', (result) => {
+      worker[kTaskInfo].done(null, result);
+      worker[kTaskInfo] = null;
+
+      this.freeWorkers.push(worker);
+      this.emit(kWorkerFreedEvent);
+    });
+
+    worker.on('error', (err) => {
+      if (worker[kTaskInfo]) {
+        worker[kTaskInfo].done(err, null);
+      } else {
+        this.emit('error', err);
+      }
+      this.workers.splice(this.workers.indexOf(worker), 1);
+      this.addNewWorker();
+    });
+
+    this.workers.push(worker);
+    this.freeWorkers.push(worker);
+    this.emit(kWorkerFreedEvent);
+  }
+
+  runTask(task, callback) {
+    if (this.freeWorkers.length === 0) {
+      this.once(kWorkerFreedEvent, () => this.runTask(task, callback));
+      return;
+    }
+
+    const worker = this.freeWorkers.pop();
+
+    worker[kTaskInfo] = new WorkerPoolTaskInfo(callback);
+    worker.postMessage(task);
+  }
+
+  close() {
+    for (const worker of this.workers) {
+      worker.terminate();
+    }
+  }
+}
+
+export { WorkerPool };

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -138,13 +138,8 @@ const generateGraph = async (compilation) => {
               filePath = route;
   
               await new Promise((resolve, reject) => {
-                const worker = new Worker(routeWorkerUrl, {
-                  workerData: {
-                    modulePath: fullPath,
-                    compilation: JSON.stringify(compilation),
-                    route
-                  }
-                });
+                const worker = new Worker(routeWorkerUrl);
+
                 worker.on('message', (result) => {
                   if (result.frontmatter) {
                     const resources = (result.frontmatter.imports || []).map((resource) => {
@@ -163,6 +158,12 @@ const generateGraph = async (compilation) => {
                   if (code !== 0) {
                     reject(new Error(`Worker stopped with exit code ${code}`));
                   }
+                });
+
+                worker.postMessage({
+                  modulePath: fullPath,
+                  compilation: JSON.stringify(compilation),
+                  route
                 });
               });
   

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -294,13 +294,8 @@ class StandardHtmlResource extends ResourceInterface {
           const routeWorkerUrl = this.compilation.config.plugins.filter(plugin => plugin.type === 'renderer')[0].provider().workerUrl;
 
           await new Promise((resolve, reject) => {
-            const worker = new Worker(routeWorkerUrl, {
-              workerData: {
-                modulePath: routeModuleLocation,
-                compilation: JSON.stringify(this.compilation),
-                route: fullPath
-              }
-            });
+            const worker = new Worker(routeWorkerUrl);
+
             worker.on('message', (result) => {
               if (result.template) {
                 ssrTemplate = result.template;
@@ -331,6 +326,12 @@ class StandardHtmlResource extends ResourceInterface {
               if (code !== 0) {
                 reject(new Error(`Worker stopped with exit code ${code}`));
               }
+            });
+
+            worker.postMessage({
+              modulePath: routeModuleLocation,
+              compilation: JSON.stringify(this.compilation),
+              route: fullPath
             });
           });
         }

--- a/packages/plugin-renderer-lit/src/ssr-route-worker-lit.js
+++ b/packages/plugin-renderer-lit/src/ssr-route-worker-lit.js
@@ -5,7 +5,7 @@ import { html } from 'lit';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import { pathToFileURL } from 'url';
 import { Readable } from 'stream';
-import { workerData, parentPort } from 'worker_threads';
+import { parentPort } from 'worker_threads';
 
 async function streamToString (stream) {
   const chunks = [];
@@ -71,4 +71,6 @@ async function executeRouteModule({ modulePath, compilation, route, label, id, p
   parentPort.postMessage(data);
 }
 
-executeRouteModule(workerData);
+parentPort.on('message', async (task) => {
+  await executeRouteModule(task);
+});


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #970 (mostly)

> This now greatly improves performance and while it takes a while, Greenwood can now easily generate 4000 pages from the linked benchmarks and at least improves perceived performance as it start spitting out pages / terminal output right away (terminal doesn't hang)

## Summary of Changes
1. Introduce a Worker thread pool for SSR rendering (minor update to custom renderer plugin for worker based API)

## TODOs
1. [x] Handle lit polyfills + `prerender` + WCC combo as it seems WCC errors out? - Can't reproduce?
1. [x] development graph gathering un-optimized (TBD)?  Actually, even for 4000 pages seems pretty fast actually!
1. [x] Pool configuration, how to best gauge for various scenarios?  (right now just defaults to CPU count) - - seems like [adding more thread didn't help much](https://github.com/ProjectEvergreen/greenwood/issues/970#issuecomment-1283194296)?
   - configuration override
   - account for number of pages?
1. [x] Node version testing / compatibility
    - 14.x ✅ 
    - 16.x ✅ 
    - 18.x ✅ 
1. [x] Update in [benchmarks repo](https://github.com/thescientist13/bench-framework-markdown) and capture latest measurements (testing using MBA + 4000 pages) - https://github.com/ProjectEvergreen/greenwood/issues/970#issuecomment-1283194296