### PR TITLE
update rollup preserveEntrySignatures to neutral setting to silence warning output

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -121,7 +121,7 @@ const getRollupConfig = async (compilation) => {
   }).flat();
 
   return [{
-    preserveEntrySignatures: 'strict',
+    preserveEntrySignatures: 'strict', // https://github.com/ProjectEvergreen/greenwood/pull/990
     input,
     output: { 
       dir: outputDir,

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -121,6 +121,7 @@ const getRollupConfig = async (compilation) => {
   }).flat();
 
   return [{
+    preserveEntrySignatures: 'strict',
     input,
     output: { 
       dir: outputDir,


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#979 + https://github.com/ContributaryCommunity/www.contributary.community/pull/115

```sh
To preserve the export signature of the entry module "src/index.js", an empty facade chunk was created. This often happens when creating a bundle for a web app where chunks are placed in script tags and exports are ignored. In this case it is recommended to set "preserveEntrySignatures: false" to avoid this and reduce the number of chunks. Otherwise if this is intentional, set "preserveEntrySignatures: 'strict'" explicitly to silence this warning.
```

## Summary of Changes
1. Set Rollup's [`preserveEntrySignatures` setting to `'strict'`](https://rollupjs.org/guide/en/#preserveentrysignatures)