### PR TITLE
use jsonplaceholder API for testing

### DIFF
--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -11,7 +11,7 @@
  * User Config
  * devServer: {
  *   proxy: {
- *     '/api': 'https://www.analogstudios.net'
+ *     '/post': 'https://jsonplaceholder.typicode.com'
  *   }
  * }
  *
@@ -1170,14 +1170,13 @@ describe('Develop Greenwood With: ', function() {
       });
     });
 
-    // proxies to analogstudios.net/api/events vis greenwood.config.js
-    // ideally should find something else to avoid using something "live" in our tests
+    // proxies to https://jsonplaceholder.typicode.com/posts via greenwood.config.js
     describe('Develop command with dev proxy', function() {
       let response = {};
 
       before(async function() {
         return new Promise((resolve, reject) => {
-          request.get(`${hostname}:${port}/api/albums?artistId=2`, (err, res, body) => {
+          request.get(`${hostname}:${port}/posts?id=7`, (err, res, body) => {
             if (err) {
               reject();
             }

--- a/packages/cli/test/cases/develop.default/greenwood.config.js
+++ b/packages/cli/test/cases/develop.default/greenwood.config.js
@@ -1,7 +1,7 @@
 export default {
   devServer: {
     proxy: {
-      '/api': 'https://www.analogstudios.net'
+      '/posts': 'https://jsonplaceholder.typicode.com'
     }
   }
 };

--- a/packages/cli/test/cases/serve.default/greenwood.config.js
+++ b/packages/cli/test/cases/serve.default/greenwood.config.js
@@ -1,7 +1,7 @@
 export default {
   devServer: {
     proxy: {
-      '/api': 'https://www.analogstudios.net'
+      '/posts': 'https://jsonplaceholder.typicode.com'
     }
   },
   port: 8181

--- a/packages/cli/test/cases/serve.default/serve.default.spec.js
+++ b/packages/cli/test/cases/serve.default/serve.default.spec.js
@@ -12,7 +12,7 @@
  * {
  *   devServer: {
  *    proxy: {
-        '/api': 'https://www.analogstudios.net'
+        '/post': 'https://jsonplaceholder.typicode.com'
       }
  *   },
  *   port: 8181
@@ -61,14 +61,13 @@ describe('Serve Greenwood With: ', function() {
 
     runSmokeTest(['serve'], LABEL);
 
-    // proxies to analogstudios.net/api/events vis greenwood.config.js
-    // ideally should find something else to avoid using something "live" in our tests
+    // proxies to https://jsonplaceholder.typicode.com/posts via greenwood.config.js
     describe('Serve command with dev proxy', function() {
       let response = {};
 
       before(async function() {
         return new Promise((resolve, reject) => {
-          request.get(`${hostname}/api/albums?artistId=2`, (err, res, body) => {
+          request.get(`${hostname}/posts?id=7`, (err, res, body) => {
             if (err) {
               reject();
             }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Seeing some flakiness in the Analog Studios API
https://github.com/AnalogStudiosRI/www.analogstudios.net/issues/81

and thus causing our tests to fail
https://github.com/ProjectEvergreen/greenwood/actions/runs/3451915835
```sh
  1) Develop Greenwood With: 
       Default Greenwood Configuration and Workspace
         Develop command with dev proxy
           should return the correct response body:

      AssertionError: expected [ Array(14) ] to have a length of 1 but got 14
      + expected - actual

      -14
      +1
      
      at Context.<anonymous> (file:///home/runner/work/greenwood/greenwood/packages/cli/test/cases/develop.default/develop.default.spec.js:1204:39)
      at processImmediate (internal/timers.js:464:21)
```


## Summary of Changes
1. Use a [placeholder API](https://jsonplaceholder.typicode.com/) instead