### PR TITLE
setting up test cases for additional import rule examples

### DIFF
--- a/packages/cli/test/cases/build.config.optimization-default/fixtures/expected.css
+++ b/packages/cli/test/cases/build.config.optimization-default/fixtures/expected.css
@@ -1,6 +1,12 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root,:host{--primary-color:#16f;--secondary-color:#ff7;}
 
 @font-face {font-family:'Source Sans Pro';font-style:normal;font-weight:400;font-display:swap;src:local('Source Sans Pro Regular'),local('SourceSansPro-Regular'),url('/assets/fonts/source-sans-pro-v13-latin-regular.woff2')format('woff2'),url('/assets/fonts/source-sans-pro-v13-latin-regular.woff')format('woff'),url('/assets/fonts/source-sans-pro-v13-latin-regular.ttf')format('truetype');}
+
+@import url('https://fonts.googleapis.com/css?family=Raleway&display=swap');
 
 *{margin:0;padding:0;font-family:'Comic Sans',sans-serif;}
 

--- a/packages/cli/test/cases/build.config.optimization-default/src/styles/theme.css
+++ b/packages/cli/test/cases/build.config.optimization-default/src/styles/theme.css
@@ -1,1 +1,6 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 @import url('../system/variables.css');
+@import url('https://fonts.googleapis.com/css?family=Raleway&display=swap');


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Found some gaps in our `@import` rule handling
- https://github.com/ProjectEvergreen/greenwood-template-blog/pull/6
- https://github.com/ProjectEvergreen/greenwood-getting-started/pull/66
- https://github.com/ProjectEvergreen/projectevergreen.github.io/pull/92

```css 
/* expected */
@tailwind base;
@tailwind components;
@tailwind utilities;

/* actual */
@tailwind base}
@tailwind components}
@tailwind utilities}

/* not support at all!! */
@import url('https://fonts.googleapis.com/css?family=Raleway&display=swap');
```

## Summary of Changes
N / A

## TODO
1. [ ] Add support for remote `@import` url
1. [ ] Add support for "plain" at rule, per Tailwind style
1. [ ] Add test cases