### PR TITLE
Revert "Revert "Enhancement/issue 763 restore postcss import""

### DIFF
--- a/packages/plugin-postcss/README.md
+++ b/packages/plugin-postcss/README.md
@@ -79,6 +79,7 @@ By default, the configuration provided by this plugin is:
 ```javascript
 export default {
   plugins: [
+    (await import('postcss-import')).default,
     (await import('postcss-preset-env')).default
   ]
 };

--- a/packages/plugin-postcss/package.json
+++ b/packages/plugin-postcss/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "postcss": "^8.3.11",
+    "postcss-import": "^13.0.0",
     "postcss-preset-env": "^7.0.1"
   },
   "devDependencies": {

--- a/packages/plugin-postcss/src/postcss.config.js
+++ b/packages/plugin-postcss/src/postcss.config.js
@@ -1,5 +1,6 @@
 export default {
   plugins: [
+    (await import('postcss-import')).default,
     (await import('postcss-preset-env')).default
   ]
 };

--- a/packages/plugin-postcss/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-postcss/test/cases/options.extend-config/options.extend-config.spec.js
@@ -66,7 +66,7 @@ describe('Build Greenwood With: ', function() {
 
     describe('Page referencing external nested CSS file', function() {
       it('should output correctly processed nested CSS as non nested', function() {
-        const expectedCss = 'body{color:red}body h1{color:blue}';
+        const expectedCss = ':host{color:red}body{color:red}body h1{color:blue}';
         const cssFiles = glob.sync(path.join(this.context.publicDir, 'styles', '*.css'));
         const css = fs.readFileSync(cssFiles[0], 'utf-8');
 

--- a/packages/plugin-postcss/test/cases/options.extend-config/src/styles/main.css
+++ b/packages/plugin-postcss/test/cases/options.extend-config/src/styles/main.css
@@ -1,3 +1,5 @@
+@import './theme.css';
+
 body {
   color: red;
 

--- a/packages/plugin-postcss/test/cases/options.extend-config/src/styles/theme.css
+++ b/packages/plugin-postcss/test/cases/options.extend-config/src/styles/theme.css
@@ -1,0 +1,3 @@
+:host {
+  color: red;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6740,6 +6740,13 @@ is-core-module@^2.8.0:
   dependencies:
     has "^1.0.3"
 
+is-core-module@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
+  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
+  dependencies:
+    has "^1.0.3"
+
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -8991,6 +8998,15 @@ postcss-image-set-function@^4.0.2:
   dependencies:
     postcss-values-parser "6.0.1"
 
+postcss-import@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-13.0.0.tgz#d6960cd9e3de5464743b04dd8cd9d870662f8b8c"
+  integrity sha512-LPUbm3ytpYopwQQjqgUH4S3EM/Gb9QsaSPP/5vnoi+oKVy3/mIk2sc0Paqw7RL57GpScm9MdIMUypw2znWiBpg==
+  dependencies:
+    postcss-value-parser "^4.0.0"
+    read-cache "^1.0.0"
+    resolve "^1.1.7"
+
 postcss-initial@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/postcss-initial/-/postcss-initial-4.0.1.tgz#529f735f72c5724a0fb30527df6fb7ac54d7de42"
@@ -9175,6 +9191,11 @@ postcss-syntax@^0.36.2:
   version "0.36.2"
   resolved "https://registry.yarnpkg.com/postcss-syntax/-/postcss-syntax-0.36.2.tgz#f08578c7d95834574e5593a82dfbfa8afae3b51c"
   integrity sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==
+
+postcss-value-parser@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
 postcss-value-parser@^4.1.0:
   version "4.1.0"
@@ -9436,6 +9457,13 @@ react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+read-cache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
+  integrity sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==
+  dependencies:
+    pify "^2.3.0"
 
 read-cmd-shim@^1.0.1:
   version "1.0.5"
@@ -9897,6 +9925,15 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
+
+resolve@^1.1.7:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 resolve@^1.10.0:
   version "1.17.0"


### PR DESCRIPTION
Reverts ProjectEvergreen/greenwood#1001

---

I got this all wrong, it was the [CLI package that contained the **postcss-plugin** dependency](https://github.com/ProjectEvergreen/greenwood/blob/v0.26.2/packages/cli/package.json#L41).  🤦 

I also got a little spooked because I noticed though that there is a compatibility issue when using `extendConfig`, which seems to have boiled down to [some issue between Bootstrap v4 and the **postcss-preset-env** plugin](https://github.com/ProjectEvergreen/greenwood/discussions/1002), which predates this release.