### PR TITLE
move tech stack docs to the about page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,7 @@
 
 [build.environment]
   NODE_VERSION = "14.16.0"
+
+[[redirects]]
+  from = "/docs/tech-stack/"
+  to = "/about/tech-stack/"

--- a/www/pages/about/tech-stack.md
+++ b/www/pages/about/tech-stack.md
@@ -2,7 +2,7 @@
 label: 'tech-stack'
 menu: side
 title: 'Tech Stack'
-index: 11
+index: 4
 linkheadings: 3
 ---
 

--- a/www/pages/docs/index.md
+++ b/www/pages/docs/index.md
@@ -72,4 +72,4 @@ To continue learning more about Greenwood, please feel free to browse the other 
 - [Markdown](/docs/markdown/): Using markdown and related authoring capabilities supported by Greenwood.
 - [Styles and Assets](/docs/css-and-images/): How to style and theme your project with CSS.
 - [Templates](/docs/layouts/): Controlling the layout of your pages.
-- [Tech Stack](/docs/tech-stack/): What's under the hood.
+- [Tech Stack](/about/tech-stack/): What's under the hood.

--- a/www/pages/getting-started/index.md
+++ b/www/pages/getting-started/index.md
@@ -6,7 +6,7 @@ index: 3
 ---
 
 ## Introduction
-First off, thank you for taking the time to check out **Greenwood**!  Under the hood Greenwood is taking advantage of the power of the modern web ([and friends !](/docs/tech-stack/)) to drive a modern development workflow that helps you deliver a modern, performant and pleasant experience for your users... using the web languages you already know!
+First off, thank you for taking the time to check out **Greenwood**!  Under the hood Greenwood is taking advantage of the power of the modern web ([and friends !](/about/tech-stack/)) to drive a modern development workflow that helps you deliver a modern, performant and pleasant experience for your users... using the web languages you already know!
 
 ## Your First Project
 To get things started, we first want to make sure everyone can get their first project up and running as easily and quickly as possible, and so through this guide, we will walk through everything you need to get started with your first project, including:


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

Thought it would be good to keep the _Docs_ page as tight as possible, so figured this content could live under the _About_ page instead.

## Summary of Changes
1. Move `/docs/tech-stack/` -> `/about/tech-stack/`
1. Add redirect in _netlify.toml_
1. Update links in docs