### PR TITLE
Bug/issue 1026 deeply nested direct hash links

### DIFF
--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -24,25 +24,18 @@ document.addEventListener('click', async function(e) {
       return outlet.getAttribute('data-route') === targetUrl.pathname;
     })[0];
 
-    console.debug({ currentUrl });
-    console.debug({ targetUrl });
-
     // maintain the app shell if we are navigating between pages that are built from the same page template
     // also, some routes may be SSR, so we may not always match on a static route
     if (routerOutlet && routerOutlet.getAttribute('data-template') === window.__greenwood.currentTemplate) {
       const { hash, pathname } = targetUrl;
-      console.debug('TARGET PATHNAME', { pathname });
-      console.debug('TARGET HASH', { hash });
 
       if (currentUrl.pathname !== pathname) {
-        console.debug('111 PUSH STATE TO NEW PATHNAME');
         await routerOutlet.loadRoute();
-        // history.pushState({}, '', `${targetUrl.pathname}${targetUrl.hash}`);
+
         history.pushState({}, '', pathname);
       }
 
       if (hash !== '') {
-        console.debug('222 HASH');
         currentUrl.hash = hash;
       }
     } else {
@@ -53,17 +46,14 @@ document.addEventListener('click', async function(e) {
   }
 });
 
-window.addEventListener('popstate', (event) => {
+window.addEventListener('popstate', () => {
   try {
-    console.debug('popstate', { event });
     const targetRoute = window.location;
     const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
       return outlet.getAttribute('data-route') === targetRoute.pathname;
     })[0];
 
     if (routerOutlet) {
-      console.debug('popstate loadRoute');
-      // TODO do we need to handle hash here too?
       routerOutlet.loadRoute();
     }
   } catch (err) {
@@ -78,7 +68,6 @@ class RouteComponent extends HTMLElement {
     await fetch(key)
       .then(res => res.text())
       .then((response) => {
-        console.debug('HTML LOADED!!!');
         document.getElementsByTagName('router-outlet')[0].innerHTML = response;
       });
   }

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -19,52 +19,35 @@ document.addEventListener('click', async function(e) {
   if (canClientSideRoute) {
     e.preventDefault();
 
-    console.debug({ currentUrl });
-
     const targetUrl = new URL(href, currentUrl.origin);
     const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
       return outlet.getAttribute('data-route') === targetUrl.pathname;
     })[0];
 
+    console.debug({ currentUrl });
     console.debug({ targetUrl });
+
     // maintain the app shell if we are navigating between pages that are built from the same page template
     // also, some routes may be SSR, so we may not always match on a static route
     if (routerOutlet && routerOutlet.getAttribute('data-template') === window.__greenwood.currentTemplate) {
-      // only update the hash if it just the hash changing
-      // else, request and load the partial for the page, and push page to the browser history stack
-      // if (targetUrl.hash !== '' && window.location) {
-      //   console.debug('111 HASH', targetUrl.hash);
-      //   location = targetUrl.hash;
-      // } else {
-      //   console.debug('222 PUSH STATE', targetUrl.pathname);
-      //   routerOutlet.loadRoute();
-      //   history.pushState({}, '', targetUrl.pathname);
-      // }
-      console.debug('TARGET PATHNAME', targetUrl.pathname);
-      console.debug('TARGET HASH', targetUrl.hash);
+      const { hash, pathname } = targetUrl;
+      console.debug('TARGET PATHNAME', { pathname });
+      console.debug('TARGET HASH', { hash });
 
-      if (currentUrl.pathname !== targetUrl.pathname) {
+      if (currentUrl.pathname !== pathname) {
         console.debug('111 PUSH STATE TO NEW PATHNAME');
         await routerOutlet.loadRoute();
         // history.pushState({}, '', `${targetUrl.pathname}${targetUrl.hash}`);
-        history.pushState({}, '', targetUrl.pathname);
+        history.pushState({}, '', pathname);
       }
 
-      if (targetUrl.hash !== '') {
+      if (hash !== '') {
         console.debug('222 HASH');
-        currentUrl.hash = targetUrl.hash;
-        // history.pushState({}, '', targetUrl.hash);
-        // setTimeout(() => {
-        //   console.debug('222bbb', targetUrl.hash);
-        //   currentUrl.hash = targetUrl.hash;
-        //   history.pushState({}, '', targetUrl.hash);
-        //   // currentUrl.hash = targetUrl.hash;
-        // }, 500);
+        currentUrl.hash = hash;
       }
     } else {
       // this page uses is a completely different page template from the current page
       // so just load the new page
-      console.debug('ooopsy doopsy???', { href });
       window.location.href = href;
     }
   }
@@ -73,7 +56,6 @@ document.addEventListener('click', async function(e) {
 window.addEventListener('popstate', (event) => {
   try {
     console.debug('popstate', { event });
-
     const targetRoute = window.location;
     const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
       return outlet.getAttribute('data-route') === targetRoute.pathname;

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -2,7 +2,9 @@
 
 // ** THIS DOES NOT WORK ON SAFARI **
 // It will just load pages as if staticRouter was not enabled
-document.addEventListener('click', function(e) {
+// https://github.com/ProjectEvergreen/greenwood/issues/559
+document.addEventListener('click', async function(e) {
+  const currentUrl = window.location;
   const href = (e.path && e.path[0]
     ? e.path[0].href // chrome + edge
     : e.originalTarget && e.originalTarget.href
@@ -11,45 +13,75 @@ document.addEventListener('click', function(e) {
   // best case "guess" is that if the link originates on the current site when resolved by the browser
   // treat it as a client side route, ex:  /about/, /docs/ and trigger the client side router
   // https://github.com/ProjectEvergreen/greenwood/issues/562
-  const isOnCurrentDomain = href.indexOf(window.location.hostname) >= 0 || href.indexOf('localhost') >= 0;
+  const isOnCurrentDomain = href.indexOf(currentUrl.hostname) >= 0 || href.indexOf('localhost') >= 0;
   const canClientSideRoute = href !== '' && isOnCurrentDomain;
 
   if (canClientSideRoute) {
     e.preventDefault();
 
-    const targetUrl = new URL(href, window.location.origin);
+    console.debug({ currentUrl });
+
+    const targetUrl = new URL(href, currentUrl.origin);
     const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
       return outlet.getAttribute('data-route') === targetUrl.pathname;
     })[0];
 
+    console.debug({ targetUrl });
     // maintain the app shell if we are navigating between pages that are built from the same page template
     // also, some routes may be SSR, so we may not always match on a static route
     if (routerOutlet && routerOutlet.getAttribute('data-template') === window.__greenwood.currentTemplate) {
-      
       // only update the hash if it just the hash changing
       // else, request and load the partial for the page, and push page to the browser history stack
-      if (targetUrl.hash !== '') {
-        location = targetUrl.hash;
-      } else {
-        routerOutlet.loadRoute();
+      // if (targetUrl.hash !== '' && window.location) {
+      //   console.debug('111 HASH', targetUrl.hash);
+      //   location = targetUrl.hash;
+      // } else {
+      //   console.debug('222 PUSH STATE', targetUrl.pathname);
+      //   routerOutlet.loadRoute();
+      //   history.pushState({}, '', targetUrl.pathname);
+      // }
+      console.debug('TARGET PATHNAME', targetUrl.pathname);
+      console.debug('TARGET HASH', targetUrl.hash);
+
+      if (currentUrl.pathname !== targetUrl.pathname) {
+        console.debug('111 PUSH STATE TO NEW PATHNAME');
+        await routerOutlet.loadRoute();
+        // history.pushState({}, '', `${targetUrl.pathname}${targetUrl.hash}`);
         history.pushState({}, '', targetUrl.pathname);
+      }
+
+      if (targetUrl.hash !== '') {
+        console.debug('222 HASH');
+        currentUrl.hash = targetUrl.hash;
+        // history.pushState({}, '', targetUrl.hash);
+        // setTimeout(() => {
+        //   console.debug('222bbb', targetUrl.hash);
+        //   currentUrl.hash = targetUrl.hash;
+        //   history.pushState({}, '', targetUrl.hash);
+        //   // currentUrl.hash = targetUrl.hash;
+        // }, 500);
       }
     } else {
       // this page uses is a completely different page template from the current page
       // so just load the new page
+      console.debug('ooopsy doopsy???', { href });
       window.location.href = href;
     }
   }
 });
 
-window.addEventListener('popstate', () => {
+window.addEventListener('popstate', (event) => {
   try {
+    console.debug('popstate', { event });
+
     const targetRoute = window.location;
     const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
       return outlet.getAttribute('data-route') === targetRoute.pathname;
     })[0];
 
     if (routerOutlet) {
+      console.debug('popstate loadRoute');
+      // TODO do we need to handle hash here too?
       routerOutlet.loadRoute();
     }
   } catch (err) {
@@ -58,12 +90,13 @@ window.addEventListener('popstate', () => {
 });
 
 class RouteComponent extends HTMLElement {
-  loadRoute() {
+  async loadRoute() {
     const key = this.getAttribute('data-key');
 
-    fetch(key)
+    await fetch(key)
       .then(res => res.text())
       .then((response) => {
+        console.debug('HTML LOADED!!!');
         document.getElementsByTagName('router-outlet')[0].innerHTML = response;
       });
   }

--- a/www/components/shelf/shelf.js
+++ b/www/components/shelf/shelf.js
@@ -53,9 +53,8 @@ class Shelf extends LitElement {
   }
 
   toggleSelectedItem() {
-    let selectedShelfListIndex = this.shelfList.findIndex((list, index) => {
-      return index === this.selectedIndex;
-    });
+    let selectedShelfListIndex = this.shelfList.findIndex((list, index) => index === this.selectedIndex);
+
     if (selectedShelfListIndex > -1) {
       this.shelfList[selectedShelfListIndex].selected = !this.shelfList[selectedShelfListIndex].selected;
     }

--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -188,6 +188,8 @@ export default {
 
 ### Static Router
 
+> _This feature is considered experimental._
+
 Setting the `staticRouter` option to `true` will add a small router runtime in production for static pages to prevent needing full page reloads when navigation between pages that share a template.  For example, the Greenwood website is entirely static, outputting an HTML file per page however, if you navigate from the _Docs_ page to the _Getting Started_ page, you will notice the site does not require a full page load.  Instead, the router will just swap out the content of the page much like client-side SPA router would.  This technique is similar to how projects like [**pjax**](https://github.com/defunkt/jquery-pjax) and [**Turbolinks**](https://github.com/turbolinks/turbolinks) work, and like what you can see on websites like GitHub.
 
 

--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -188,7 +188,7 @@ export default {
 
 ### Static Router
 
-> _This feature is considered experimental._
+> ⚠️ _This feature is experimental.  Please follow along with [our discussion](https://github.com/ProjectEvergreen/greenwood/discussions/1033) to learn more._
 
 Setting the `staticRouter` option to `true` will add a small router runtime in production for static pages to prevent needing full page reloads when navigation between pages that share a template.  For example, the Greenwood website is entirely static, outputting an HTML file per page however, if you navigate from the _Docs_ page to the _Getting Started_ page, you will notice the site does not require a full page load.  Instead, the router will just swap out the content of the page much like client-side SPA router would.  This technique is similar to how projects like [**pjax**](https://github.com/defunkt/jquery-pjax) and [**Turbolinks**](https://github.com/turbolinks/turbolinks) work, and like what you can see on websites like GitHub.
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1026 

## Summary of Changes
1. Make sure to handle a case where a hash link is clicked before its preceding pathname
1. Make `loadRoute` `async` to account for loading content before trying to change a hash (race condition)
1. Mark `staticRouter` as experimental in the _Configuration_ docs
1. Validated existing test cases from #937 

## TODO
1. [x] Final Production cross browser sanity check / clean up remaining console logs
    - ~~Chrome~~
    - ~~Safari~~
    - ~~Firefox~~
1. [x] Track a discussion about router future - https://github.com/ProjectEvergreen/greenwood/discussions/1033
    - can this all be done (`pathname`, `hash`, etc) through [`pushState`](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) in one go?
      ```js
      history.pushState({}, '', `${targetUrl.pathname}${targetUrl.hash}`);
      ```
     - Bury more of the logic into `RouteComponent`?
    - should `loadRoute` take a callback?
    - better scroll up on back button
    - what about SSR capabilities, including on-demand fragment routing?
1. [x] Track No JS fallback option for website menu, as part of #978
1. [x] We really need to get [some E2E setup for this website]( https://github.com/ProjectEvergreen/greenwood/discussions/560)


----

_Test Cases_
- `->` - click menu
- `>` - expand menu 


#### _Home -> Plugins + side nav_ ✅ 
```
1. Home
2. -> Plugins
3.   -> Copy
4.   -> Resource
5.   -> Renderer
6.   -> Rollup
```

#### _Home -> Getting Started + side nav + nested items_ ✅ 
```
1. Home
2. -> Getting Started
3.  -> Project Setup
4.  -> Key Concepts
5.   -> Creating Content
6a.     -> Home Page Template
6b.     -> Blog Posts Template
6c.     -> App Template
6d.     -> Creating Pages
7.   -> Optimizing
7a.     -> Prerendering
```

##### _Home -> Getting Started + side nav + nested items_ ✅ *
```
1. Home
2. -> Getting Started
3.  > Project Setup
4.  > Key Concepts
5.  > Creating Content
5a.     -> Home Page Template
5b.     -> Blog Posts Template
5c.     -> App Template
5d.     -> Creating Pages
6.   > Optimizing
6a.     -> Prerendering
```

**Note**: when going back, Key Concept and Project Setup should not be visited.

> _going from `>` -> `->` and going back will result in two entries, not one._

#### _Home -> Getting Started + side nav + nested items_ -> Blog ✅ 
```
1. Home
2. -> Getting Started
3.  -> Project Setup
4.  -> Key Concepts
5.   -> Creating Content
5a.     -> Home Page Template
5b.     -> Blog Posts Template
5c.     -> App Template
5d.     -> Creating Pages
6.   -> Optimizing
6a.     -> Prerendering
7.  Blog
8.   -> State of Greenwood 2022
```

#### _Home -> Getting Started + side nav + nested items_ -> Blog ✅ 
```
1. Home
2. -> Getting Started
3.   > Project Setup
4.  > Key Concepts
5.   > Creating Content
5a.     -> Home Page Template
5b.     -> Blog Posts Template
5c.     -> App Template
5d.     -> Creating Pages
6.   > Optimizing
6a.     -> Prerendering
7.  -> Blog
8.   -> State of Greenwood 2022
```

**Note**: when going back, Key Concept and Project Setup should not be visited.

#### _Docs -> About + side nav_ ✅ 
```
1. Home
2. -> Docs
2a.   -> Configuration
2b.   -> Front Matter
3. About
4.   -> Goals
```