### PR TITLE
Website/responsive banner header text tweak

### DIFF
--- a/www/components/banner/banner.css
+++ b/www/components/banner/banner.css
@@ -45,12 +45,13 @@
 
       & h3 {
         padding: 10px 0;
-        max-width: 65%;
-        margin: 0 auto;
+        max-width: 70%;
+        margin: 0 auto 10px;
         color: #201e2e;
 
         @media (min-width: 768px) {
           max-width: 50%;
+          margin: 0 auto;
         }
       }
 

--- a/www/components/banner/banner.css
+++ b/www/components/banner/banner.css
@@ -45,9 +45,13 @@
 
       & h3 {
         padding: 10px 0;
-        max-width: 50%;
+        max-width: 65%;
         margin: 0 auto;
         color: #201e2e;
+
+        @media (min-width: 768px) {
+          max-width: 50%;
+        }
       }
 
       & img {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
The current home page banner text feels a little cramped on mobile
![Screen Shot 2022-12-14 at 9 15 23 PM](https://user-images.githubusercontent.com/895923/207756707-0c19fbfe-2ad6-4f40-8f8e-0307a1d388f7.png)

## Summary of Changes
1. Tweak home page banner header text to have a little more breathing room on mobile
![Screen Shot 2022-12-14 at 9 15 14 PM](https://user-images.githubusercontent.com/895923/207756770-c153480b-f772-4964-af35-7999b7f90ac2.png)