### PR TITLE
remove redundant greenwood prerender config from website config

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -10,7 +10,6 @@ import { fileURLToPath, URL } from 'url';
 
 export default {
   workspace: fileURLToPath(new URL('./www', import.meta.url)),
-  // prerender: true,
   optimization: 'inline',
   staticRouter: true,
   interpolateFrontmatter: true,

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -10,7 +10,7 @@ import { fileURLToPath, URL } from 'url';
 
 export default {
   workspace: fileURLToPath(new URL('./www', import.meta.url)),
-  prerender: true,
+  // prerender: true,
   optimization: 'inline',
   staticRouter: true,
   interpolateFrontmatter: true,


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

Since we are using a plugin for prerendering, this is set automatically, so it shouldn't need to be set in _greenwood.config.js_ too.

## Summary of Changes
1. remove redundant greenwood prerender config from website config