### PR TITLE
Feature/issue 948 web api standardization

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -20,9 +20,9 @@ jobs:
     - name: Installing project dependencies
       run: |
         yarn install --frozen-lockfile --network-timeout 1000000 && yarn lerna bootstrap
-    - name: Lint
-      run: |
-        yarn lint
+    # - name: Lint
+    #   run: |
+    #     yarn lint
     - name: Test
       run: |
         yarn test

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -20,9 +20,9 @@ jobs:
     - name: Installing project dependencies
       run: |
         yarn install --frozen-lockfile --network-timeout 1000000 && yarn lerna bootstrap
-    # - name: Lint
-    #   run: |
-    #     yarn lint
+    - name: Lint
+      run: |
+        yarn lint
     - name: Test
       run: |
         yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
     - name: Installing project dependencies
       run: |
         yarn install --frozen-lockfile && yarn lerna bootstrap
-    - name: Lint
-      run: |
-        yarn lint
+    # - name: Lint
+    #   run: |
+    #     yarn lint
     - name: Test
       run: |
         yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
     - name: Installing project dependencies
       run: |
         yarn install --frozen-lockfile && yarn lerna bootstrap
-    # - name: Lint
-    #   run: |
-    #     yarn lint
+    - name: Lint
+      run: |
+        yarn lint
     - name: Test
       run: |
         yarn test

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -19,6 +19,8 @@ export default {
     greenwoodPluginPostCss(),
     greenwoodPluginImportJson(),
     greenwoodPluginImportCss(),
+    greenwoodPluginIncludeHTML(),
+    greenwoodPluginRendererPuppeteer(),
     {
       type: 'rollup',
       name: 'rollup-plugin-analyzer',
@@ -32,9 +34,7 @@ export default {
           })
         ];
       }
-    },
-    greenwoodPluginIncludeHTML(),
-    greenwoodPluginRendererPuppeteer()
+    }
   ],
   markdown: {
     plugins: [

--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -6,10 +6,9 @@ import { greenwoodPluginPolyfills } from '@greenwood/plugin-polyfills';
 import { greenwoodPluginPostCss } from '@greenwood/plugin-postcss';
 import { greenwoodPluginRendererPuppeteer } from '@greenwood/plugin-renderer-puppeteer';
 import rollupPluginAnalyzer from 'rollup-plugin-analyzer';
-import { fileURLToPath, URL } from 'url';
 
 export default {
-  workspace: fileURLToPath(new URL('./www', import.meta.url)),
+  workspace: new URL('./www/', import.meta.url),
   prerender: true,
   optimization: 'inline',
   staticRouter: true,

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -11,8 +11,8 @@ const runProductionBuild = async (compilation) => {
     try {
       const { prerender } = compilation.config;
       const outputDir = compilation.context.outputDir;
-      const prerenderPlugin = (compilation.config.plugins.filter(plugin => plugin.type === 'renderer') || []).length === 1
-        ? compilation.config.plugins.filter(plugin => plugin.type === 'renderer')[0].provider(compilation)
+      const prerenderPlugin = compilation.config.plugins.find(plugin => plugin.type === 'renderer')
+        ? compilation.config.plugins.find(plugin => plugin.type === 'renderer').provider(compilation)
         : {};
 
       if (!fs.existsSync(outputDir.pathname)) {

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -17,10 +17,10 @@ const runProductionBuild = async (compilation) => {
 
       try {
         await fs.access(outputDir);
-      } catch(e) {
+      } catch (e) {
         await fs.mkdir(outputDir, {
           recursive: true
-        })
+        });
       }
 
       if (prerender || prerenderPlugin.prerender) {

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -1,6 +1,6 @@
 import { bundleCompilation } from '../lifecycles/bundle.js';
 import { copyAssets } from '../lifecycles/copy.js';
-import fs from 'fs';
+import fs from 'fs/promises';
 import { preRenderCompilationWorker, preRenderCompilationCustom, staticRenderCompilation } from '../lifecycles/prerender.js';
 import { ServerInterface } from '../lib/server-interface.js';
 
@@ -15,8 +15,12 @@ const runProductionBuild = async (compilation) => {
         ? compilation.config.plugins.find(plugin => plugin.type === 'renderer').provider(compilation)
         : {};
 
-      if (!fs.existsSync(outputDir.pathname)) {
-        fs.mkdirSync(outputDir.pathname);
+      try {
+        await fs.access(outputDir);
+      } catch(e) {
+        await fs.mkdir(outputDir, {
+          recursive: true
+        })
       }
 
       if (prerender || prerenderPlugin.prerender) {

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -15,8 +15,8 @@ const runProductionBuild = async (compilation) => {
         ? compilation.config.plugins.filter(plugin => plugin.type === 'renderer')[0].provider(compilation)
         : {};
 
-      if (!fs.existsSync(outputDir)) {
-        fs.mkdirSync(outputDir);
+      if (!fs.existsSync(outputDir.pathname)) {
+        fs.mkdirSync(outputDir.pathname);
       }
 
       if (prerender || prerenderPlugin.prerender) {

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -1,4 +1,5 @@
 import { bundleCompilation } from '../lifecycles/bundle.js';
+import { checkResourceExists } from '../lib/resource-utils.js';
 import { copyAssets } from '../lifecycles/copy.js';
 import fs from 'fs/promises';
 import { preRenderCompilationWorker, preRenderCompilationCustom, staticRenderCompilation } from '../lifecycles/prerender.js';
@@ -15,9 +16,7 @@ const runProductionBuild = async (compilation) => {
         ? compilation.config.plugins.find(plugin => plugin.type === 'renderer').provider(compilation)
         : {};
 
-      try {
-        await fs.access(outputDir);
-      } catch (e) {
+      if (!await checkResourceExists(outputDir)) {
         await fs.mkdir(outputDir, {
           recursive: true
         });

--- a/packages/cli/src/commands/eject.js
+++ b/packages/cli/src/commands/eject.js
@@ -1,18 +1,16 @@
 import fs from 'fs';
-import path from 'path';
-import { fileURLToPath, URL } from 'url';
 
 const ejectConfiguration = async (compilation) => {
   return new Promise(async (resolve, reject) => {
     try {
-      const configFilePath = fileURLToPath(new URL('../config', import.meta.url));
-      const configFiles = fs.readdirSync(configFilePath);
+      const configFileDirUrl = new URL('../config/', import.meta.url);
+      const configFiles = await fs.promises.readdir(configFileDirUrl);
       
       configFiles.forEach((configFile) => {
-        const from = path.join(configFilePath, configFile);
-        const to = `${compilation.context.projectDirectory}/${configFile}`;
+        const from = new URL(`./${configFile}`, configFileDirUrl);
+        const to = new URL(`./${configFile}`, compilation.context.projectDirectory);
 
-        fs.copyFileSync(from, to);
+        fs.copyFileSync(from.pathname, to.pathname);
         
         console.log(`Ejected ${configFile} successfully.`);
       });

--- a/packages/cli/src/commands/eject.js
+++ b/packages/cli/src/commands/eject.js
@@ -1,10 +1,10 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 const ejectConfiguration = async (compilation) => {
   return new Promise(async (resolve, reject) => {
     try {
       const configFileDirUrl = new URL('../config/', import.meta.url);
-      const configFiles = await fs.promises.readdir(configFileDirUrl);
+      const configFiles = await fs.readdir(configFileDirUrl);
       
       configFiles.forEach((configFile) => {
         const from = new URL(`./${configFile}`, configFileDirUrl);

--- a/packages/cli/src/commands/eject.js
+++ b/packages/cli/src/commands/eject.js
@@ -6,14 +6,14 @@ const ejectConfiguration = async (compilation) => {
       const configFileDirUrl = new URL('../config/', import.meta.url);
       const configFiles = await fs.readdir(configFileDirUrl);
       
-      configFiles.forEach((configFile) => {
-        const from = new URL(`./${configFile}`, configFileDirUrl);
-        const to = new URL(`./${configFile}`, compilation.context.projectDirectory);
+      for (const file of configFiles) {
+        const from = new URL(`./${file}`, configFileDirUrl);
+        const to = new URL(`./${file}`, compilation.context.projectDirectory);
 
-        fs.copyFileSync(from.pathname, to.pathname);
+        await fs.copyFile(from.pathname, to.pathname);
         
-        console.log(`Ejected ${configFile} successfully.`);
-      });
+        console.log(`Ejected ${file} successfully.`);
+      }
 
       console.debug('all configuration files ejected.');
 

--- a/packages/cli/src/commands/eject.js
+++ b/packages/cli/src/commands/eject.js
@@ -10,7 +10,7 @@ const ejectConfiguration = async (compilation) => {
         const from = new URL(`./${file}`, configFileDirUrl);
         const to = new URL(`./${file}`, compilation.context.projectDirectory);
 
-        await fs.copyFile(from.pathname, to.pathname);
+        await fs.copyFile(from, to);
         
         console.log(`Ejected ${file} successfully.`);
       }

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -36,8 +36,8 @@ function greenwoodResourceLoader (compilation) {
         }
 
         for (const plugin of resourcePlugins) {
-          if (plugin.shouldIntercept && await plugin.shouldIntercept(url, request, response)) {
-            response = await plugin.intercept(url, request, response);
+          if (plugin.shouldIntercept && await plugin.shouldIntercept(url, request, response.clone())) {
+            response = await plugin.intercept(url, request, response.clone());
           }
         }
 

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -9,7 +9,7 @@ function greenwoodResourceLoader (compilation) {
 
   return {
     name: 'greenwood-resource-loader',
-    resolveId(id) {
+    async resolveId(id) {
       const normalizedId = id.replace(/\?type=(.*)/, '');
       const { userWorkspace } = compilation.context;
 
@@ -24,11 +24,6 @@ function greenwoodResourceLoader (compilation) {
       } catch (e) {
         return null;
       }
-      // if ((id.indexOf('./') === 0 || id.indexOf('/') === 0) && fs.existsSync(new URL(`./${normalizedId}`, userWorkspace).pathname)) {
-      //   return new URL(`./${normalizedId}`, userWorkspace).pathname;
-      // }
-
-      // return null;
     },
     async load(id) {
       const pathname = id.indexOf('?') >= 0 ? id.slice(0, id.indexOf('?')) : id;
@@ -60,7 +55,7 @@ function greenwoodResourceLoader (compilation) {
 function greenwoodSyncPageResourceBundlesPlugin(compilation) {
   return {
     name: 'greenwood-sync-page-resource-bundles-plugin',
-    writeBundle(outputOptions, bundles) {
+    async writeBundle(outputOptions, bundles) {
       const { outputDir } = compilation.context;
 
       for (const resource of compilation.resources.values()) {
@@ -89,19 +84,13 @@ function greenwoodSyncPageResourceBundlesPlugin(compilation) {
            */
           try {
             if (facadeModuleId && resourceKey.indexOf('/node_modules/@greenwood/cli') > 0 && facadeModuleId.indexOf('/packages/cli') > 0) {
-              console.debug({ facadeModuleId });
               await fs.access(facadeModuleId);
 
               facadeModuleId = facadeModuleId.replace('/packages/cli', '/node_modules/@greenwood/cli');
             }
           } catch (e) {
-            console.debug('facademodule id', e);
-            // return null;
-          }
 
-          // if (facadeModuleId && resourceKey.indexOf('/node_modules/@greenwood/cli') > 0 && facadeModuleId.indexOf('/packages/cli') > 0 && fs.existsSync(facadeModuleId)) {
-          //   facadeModuleId = facadeModuleId.replace('/packages/cli', '/node_modules/@greenwood/cli');
-          // }
+          }
 
           if (resourceKey === facadeModuleId) {
             const { fileName } = bundles[bundle];

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -30,7 +30,7 @@ function greenwoodResourceLoader (compilation) {
       const extension = pathname.split('.').pop();
 
       if (extension !== '' && extension !== 'js') {
-        const url = new URL(`file://${pathname}`);
+        const url = new URL(`file://${pathname}?type=${extension}`);
         const request = new Request(url.href);
         let response = new Response('');
 

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -28,7 +28,6 @@ function greenwoodResourceLoader (compilation) {
         const request = new Request(url.href);
         let response = new Response('');
 
-        // TODO should this use the reduce pattern too?
         for (const plugin of resourcePlugins) {
           if (plugin.shouldServe && await plugin.shouldServe(url, request)) {
             response = await plugin.serve(url, request);

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -12,8 +12,8 @@ function greenwoodResourceLoader (compilation) {
     resolveId(id) {
       const { userWorkspace } = compilation.context;
 
-      if ((id.indexOf('./') === 0 || id.indexOf('/') === 0) && fs.existsSync(new URL(`./${id}`, userWorkspace).pathname)) {
-        return new URL(`./${id.replace(/\?type=(.*)/, '')}`, userWorkspace);
+      if ((id.indexOf('./') === 0 || id.indexOf('/') === 0) && fs.existsSync(new URL(`./${id.replace(/\?type=(.*)/, '')}`, userWorkspace).pathname)) {
+        return new URL(`./${id.replace(/\?type=(.*)/, '')}`, userWorkspace).pathname;
       }
 
       return null;

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -6,11 +6,11 @@
 process.setMaxListeners(0);
 
 import { generateCompilation } from './lifecycles/compile.js';
-import fs from 'fs';
+import fs from 'fs/promises';
 import program from 'commander';
 import { URL } from 'url';
 
-const greenwoodPackageJson = JSON.parse(await fs.promises.readFile(new URL('../package.json', import.meta.url), 'utf-8'));
+const greenwoodPackageJson = JSON.parse(await fs.readFile(new URL('../package.json', import.meta.url), 'utf-8'));
 let cmdOption = {};
 let command = '';
 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -69,22 +69,22 @@ const run = async() => {
     switch (command) {
 
       case 'build':
-        await (await import('./commands/build.js')).runProductionBuild(compilation);
+        // await (await import('./commands/build.js')).runProductionBuild(compilation);
 
         break;
       case 'develop':
-        await (await import('./commands/develop.js')).runDevServer(compilation);
+        // await (await import('./commands/develop.js')).runDevServer(compilation);
 
         break;
       case 'serve':
         process.env.__GWD_COMMAND__ = 'build';
 
-        await (await import('./commands/build.js')).runProductionBuild(compilation);
-        await (await import('./commands/serve.js')).runProdServer(compilation);
+        // await (await import('./commands/build.js')).runProductionBuild(compilation);
+        // await (await import('./commands/serve.js')).runProdServer(compilation);
 
         break;
       case 'eject':
-        await (await import('./commands/eject.js')).ejectConfiguration(compilation);
+        // await (await import('./commands/eject.js')).ejectConfiguration(compilation);
 
         break;
       default: 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -69,22 +69,22 @@ const run = async() => {
     switch (command) {
 
       case 'build':
-        // await (await import('./commands/build.js')).runProductionBuild(compilation);
+        await (await import('./commands/build.js')).runProductionBuild(compilation);
 
         break;
       case 'develop':
-        // await (await import('./commands/develop.js')).runDevServer(compilation);
+        await (await import('./commands/develop.js')).runDevServer(compilation);
 
         break;
       case 'serve':
         process.env.__GWD_COMMAND__ = 'build';
 
-        // await (await import('./commands/build.js')).runProductionBuild(compilation);
-        // await (await import('./commands/serve.js')).runProdServer(compilation);
+        await (await import('./commands/build.js')).runProductionBuild(compilation);
+        await (await import('./commands/serve.js')).runProdServer(compilation);
 
         break;
       case 'eject':
-        // await (await import('./commands/eject.js')).ejectConfiguration(compilation);
+        await (await import('./commands/eject.js')).ejectConfiguration(compilation);
 
         break;
       default: 

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -1,4 +1,5 @@
 // TODO convert this to use / return URLs
+// https://github.com/ProjectEvergreen/greenwood/issues/953
 import { createRequire } from 'module'; // https://stackoverflow.com/a/62499498/417806
 import { checkResourceExists } from '../lib/resource-utils.js';
 import fs from 'fs/promises';

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -1,3 +1,4 @@
+// TODO convert this to use / return URLs
 import { createRequire } from 'module'; // https://stackoverflow.com/a/62499498/417806
 import fs from 'fs';
 import path from 'path';

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -1,6 +1,7 @@
 // TODO convert this to use / return URLs
 import { createRequire } from 'module'; // https://stackoverflow.com/a/62499498/417806
 import { checkResourceExists } from '../lib/resource-utils.js';
+import fs from 'fs/promises';
 
 // defer to NodeJS to find where on disk a package is located using import.meta.resolve
 // and return the root absolute location
@@ -62,7 +63,21 @@ function getPackageNameFromUrl(url) {
   return packageName;
 }
 
+async function getPackageJson({ userWorkspace, projectDirectory }) {
+  const monorepoPackageJsonUrl = new URL('./package.json', userWorkspace);
+  const topLevelPackageJsonUrl = new URL('./package.json', projectDirectory);
+  const hasMonorepoPackageJson = await checkResourceExists(monorepoPackageJsonUrl);
+  const hasTopLevelPackageJson = await checkResourceExists(topLevelPackageJsonUrl);
+
+  return hasMonorepoPackageJson // handle monorepos first
+    ? JSON.parse(await fs.readFile(monorepoPackageJsonUrl, 'utf-8'))
+    : hasTopLevelPackageJson
+      ? JSON.parse(await fs.readFile(topLevelPackageJsonUrl, 'utf-8'))
+      : {};
+}
+
 export {
   getNodeModulesLocationForPackage,
+  getPackageJson,
   getPackageNameFromUrl
 };

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -1,6 +1,6 @@
 // TODO convert this to use / return URLs
 import { createRequire } from 'module'; // https://stackoverflow.com/a/62499498/417806
-import fs from 'fs/promises';
+import { checkResourceExists } from '../lib/resource-utils.js';
 
 // defer to NodeJS to find where on disk a package is located using import.meta.resolve
 // and return the root absolute location
@@ -35,11 +35,8 @@ async function getNodeModulesLocationForPackage(packageName) {
       const nodeModulesPackageRoot = `${locations[location]}/${packageName}`;
       const packageJsonLocation = `${nodeModulesPackageRoot}/package.json`;
 
-      try {
-        await fs.access(new URL(`file://${packageJsonLocation}`));
+      if (await checkResourceExists(new URL(`file://${packageJsonLocation}`))) {
         nodeModulesUrl = nodeModulesPackageRoot;
-      } catch(e) {
-        // console.debug('shouldSeRvE hiding', { e })
       }
     }
 

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -1,7 +1,6 @@
 // TODO convert this to use / return URLs
 import { createRequire } from 'module'; // https://stackoverflow.com/a/62499498/417806
-import fs from 'fs';
-import path from 'path';
+import fs from 'fs/promises';
 
 // defer to NodeJS to find where on disk a package is located using import.meta.resolve
 // and return the root absolute location
@@ -36,14 +35,17 @@ async function getNodeModulesLocationForPackage(packageName) {
       const nodeModulesPackageRoot = `${locations[location]}/${packageName}`;
       const packageJsonLocation = `${nodeModulesPackageRoot}/package.json`;
 
-      if (fs.existsSync(packageJsonLocation)) {
+      try {
+        await fs.access(new URL(`file://${packageJsonLocation}`));
         nodeModulesUrl = nodeModulesPackageRoot;
+      } catch(e) {
+        // console.debug('shouldSeRvE hiding', { e })
       }
     }
 
     if (!nodeModulesUrl) {
       console.debug(`Unable to look up ${packageName} using NodeJS require.resolve.  Falling back to process.cwd()`);
-      nodeModulesUrl = path.join(process.cwd(), 'node_modules', packageName); // force / for consistency and path matching);
+      nodeModulesUrl = new URL(`./node_modules/${packageName}`, `file://${process.cwd()}`).pathname;
     }
   }
 

--- a/packages/cli/src/lib/resource-interface.js
+++ b/packages/cli/src/lib/resource-interface.js
@@ -1,43 +1,8 @@
-import { checkResourceExists } from './resource-utils.js';
-
 class ResourceInterface {
   constructor(compilation, options = {}) {
     this.compilation = compilation;
     this.options = options;
     this.extensions = [];
-  }
-
-  hasExtension(url) {
-    const extension = url.pathname.split('.').pop();
-
-    return extension !== '' && !extension.startsWith('/');
-  }
-
-  // turn relative paths into relatively absolute based on a known root directory
-  // * deep link route - /blog/releases/some-post
-  // * and a nested path in the template - ../../styles/theme.css
-  // so will get resolved as `${rootUrl}/styles/theme.css`
-  async resolveForRelativeUrl(url, rootUrl) {
-    const search = url.search || '';
-    let reducedUrl;
-
-    if (await checkResourceExists(new URL(`.${url.pathname}`, rootUrl))) {
-      return new URL(`.${url.pathname}${search}`, rootUrl);
-    }
-
-    const segments = url.pathname.split('/').filter(segment => segment !== '');
-    segments.shift();
-
-    for (let i = 0, l = segments.length - 1; i < l; i += 1) {
-      const nextSegments = segments.slice(i);
-      const urlToCheck = new URL(`./${nextSegments.join('/')}`, rootUrl);
-
-      if (await checkResourceExists(urlToCheck)) {
-        reducedUrl = new URL(`${urlToCheck}${search}`);
-      }
-    }
-
-    return reducedUrl;
   }
 }
 

--- a/packages/cli/src/lib/resource-interface.js
+++ b/packages/cli/src/lib/resource-interface.js
@@ -18,6 +18,7 @@ class ResourceInterface {
   // * and a nested path in the template - ../../styles/theme.css
   // so will get resolved as `${rootUrl}/styles/theme.css`
   async resolveForRelativeUrl(url, rootUrl) {
+    const search = url.search || '';
     let reducedUrl;
     let atRoot;
 
@@ -25,11 +26,11 @@ class ResourceInterface {
       await fs.access(new URL(`.${url.pathname}`, rootUrl));
       atRoot = true;
     } catch (e) {
-      // console.debug('reesolveFoRRelative', { e });
+
     }
 
     if (atRoot) {
-      return new URL(`.${url.pathname}`, rootUrl);
+      return new URL(`.${url.pathname}${search}`, rootUrl);
     }
 
     const segments = url.pathname.split('/').filter(segment => segment !== '');
@@ -39,10 +40,12 @@ class ResourceInterface {
       try {
         const nextSegments = segments.slice(i);
         const urlToCheck = new URL(`./${nextSegments.join('/')}`, rootUrl);
+
         await fs.access(urlToCheck);
-        reducedUrl = urlToCheck;
+
+        reducedUrl = new URL(`${urlToCheck}${search}`);
       } catch (e) {
-        // console.debug('resolveForRelativeUrl trying again....');
+
       }
     }
 

--- a/packages/cli/src/lib/resource-interface.js
+++ b/packages/cli/src/lib/resource-interface.js
@@ -5,7 +5,6 @@ class ResourceInterface {
     this.compilation = compilation;
     this.options = options;
     this.extensions = [];
-    this.contentType = ''; // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
   }
 
   hasExtension(url) {
@@ -38,61 +37,6 @@ class ResourceInterface {
 
     return reducedUrl;
   }
-
-  // test if this plugin should change a relative URL from the browser to an absolute path on disk 
-  // like for node_modules/ resolution. not commonly needed by most resource plugins
-  // return true | false
-  // eslint-disable-next-line no-unused-vars
-  // async shouldResolve(url) {
-  //   return Promise.resolve(false);
-  // }
-
-  // // return an absolute path
-  // async resolve(url) {
-  //   return Promise.resolve(url);
-  // }
-
-  // test if this plugin should be used to process a given url / header combo the browser and retu
-  // ex: `<script type="module" src="index.ts">`
-  // return true | false
-  // eslint-disable-next-line no-unused-vars
-  // async shouldServe(url, headers) {
-  //   return Promise.resolve(this.extensions.indexOf(path.extname(url)) >= 0);
-  // }
-
-  // return the new body and / or contentType, e.g. convert file.foo -> file.js
-  // eslint-disable-next-line no-unused-vars
-  // async serve(url, headers) {
-  //   return Promise.resolve({});
-  // }
-
-  // test if this plugin should return a new body for an already resolved resource
-  // useful for modifying code on the fly without needing to read the file from disk
-  // return true | false
-  // eslint-disable-next-line no-unused-vars
-  // async shouldIntercept(url, body, headers) {
-  //   return Promise.resolve(false);
-  // }
-
-  // return the new body
-  // eslint-disable-next-line no-unused-vars
-  // async intercept(url, body, headers) {
-  //   return Promise.resolve({ body });
-  // }
-
-  // test if this plugin should manipulate any files prior to any final optmizations happening 
-  // ex: add a "banner" to all .js files with a timestamp of the build, or minifying files
-  // return true | false
-  // eslint-disable-next-line no-unused-vars
-  // async shouldOptimize(url, body, headers) {
-  //   return Promise.resolve(false);
-  // }
-
-  // return the new body
-  // eslint-disable-next-line no-unused-vars
-  // async optimize (url, body, headers) {
-  //   return Promise.resolve(body);
-  // }
 }
 
 export { ResourceInterface };

--- a/packages/cli/src/lib/resource-interface.js
+++ b/packages/cli/src/lib/resource-interface.js
@@ -1,5 +1,4 @@
-import fs from 'fs';
-import path from 'path';
+// import fs from 'fs';
 
 class ResourceInterface {
   constructor(compilation, options = {}) {
@@ -11,87 +10,94 @@ class ResourceInterface {
 
   // get rid of things like query string parameters
   // that will break when trying to use with fs
-  getBareUrlPath(url) {
-    return url.replace(/\?(.*)/, '');
-  }
+  // TODO URLs will not contain query strings by default, right?
+  // getBareUrlPath(url) {
+  //   console.debug('getBareUrlPath', { url });
+  //   return url.replace(/\?(.*)/, '');
+  // }
 
   // turn relative paths into relatively absolute based on a known root directory
   // e.g. "../styles/theme.css" -> `${userWorkspace}/styles/theme.css`
-  resolveRelativeUrl(root, url) {
-    if (fs.existsSync(path.join(root, url))) {
-      return url;
-    }
+  // resolveRelativeUrl(root, pathname) {
+  //   // console.debug('getBareUrlPath', { root, pathname });
+  //   if (fs.existsSync(new URL(pathname, root).pathname)) {
+  //     return url;
+  //   }
 
-    let reducedUrl;
+  //   let reducedPathname;
 
-    url.split('/')
-      .filter((segment) => segment !== '')
-      .reduce((acc, segment) => {
-        const reducedPath = url.replace(`${acc}/${segment}`, '');
+  //   pathname.split('/')
+  //     .filter((segment) => segment !== '')
+  //     .reduce((acc, segment) => {
+  //       // console.debug({ acc, segment });
+  //       const reducedPath = pathname.replace(`${acc}/${segment}`, '');
 
-        if (path.extname(reducedPath) !== '' && fs.existsSync(path.join(root, reducedPath))) {
-          reducedUrl = reducedPath;
-        }
-        return `${acc}/${segment}`;
-      }, '');
+  //       // console.debug({ reducedPath });
+  //       // console.debug(new URL(`.${reducedPath}`, root).pathname);
+  //       if (reducedPath.split('.').pop() !== '' && fs.existsSync(new URL(`.${reducedPath}`, root).pathname)) {
+  //         reducedPathname = reducedPath;
+  //       }
+  //       return `${acc}/${segment}`;
+  //     }, '');
 
-    return reducedUrl;
-  }
+  //   // console.debug({ reducedPathname });
+  //   return reducedPathname;
+  // }
 
   // test if this plugin should change a relative URL from the browser to an absolute path on disk 
   // like for node_modules/ resolution. not commonly needed by most resource plugins
   // return true | false
   // eslint-disable-next-line no-unused-vars
-  async shouldResolve(url) {
-    return Promise.resolve(false);
-  }
+  // async shouldResolve(url) {
+  //   return Promise.resolve(false);
+  // }
 
-  // return an absolute path
-  async resolve(url) {
-    return Promise.resolve(url);
-  }
+  // // return an absolute path
+  // async resolve(url) {
+  //   return Promise.resolve(url);
+  // }
 
   // test if this plugin should be used to process a given url / header combo the browser and retu
   // ex: `<script type="module" src="index.ts">`
   // return true | false
   // eslint-disable-next-line no-unused-vars
-  async shouldServe(url, headers) {
-    return Promise.resolve(this.extensions.indexOf(path.extname(url)) >= 0);
-  }
+  // async shouldServe(url, headers) {
+  //   return Promise.resolve(this.extensions.indexOf(path.extname(url)) >= 0);
+  // }
 
   // return the new body and / or contentType, e.g. convert file.foo -> file.js
   // eslint-disable-next-line no-unused-vars
-  async serve(url, headers) {
-    return Promise.resolve({});
-  }
+  // async serve(url, headers) {
+  //   return Promise.resolve({});
+  // }
 
   // test if this plugin should return a new body for an already resolved resource
   // useful for modifying code on the fly without needing to read the file from disk
   // return true | false
   // eslint-disable-next-line no-unused-vars
-  async shouldIntercept(url, body, headers) {
-    return Promise.resolve(false);
-  }
+  // async shouldIntercept(url, body, headers) {
+  //   return Promise.resolve(false);
+  // }
 
   // return the new body
   // eslint-disable-next-line no-unused-vars
-  async intercept(url, body, headers) {
-    return Promise.resolve({ body });
-  }
+  // async intercept(url, body, headers) {
+  //   return Promise.resolve({ body });
+  // }
 
   // test if this plugin should manipulate any files prior to any final optmizations happening 
   // ex: add a "banner" to all .js files with a timestamp of the build, or minifying files
   // return true | false
   // eslint-disable-next-line no-unused-vars
-  async shouldOptimize(url, body, headers) {
-    return Promise.resolve(false);
-  }
+  // async shouldOptimize(url, body, headers) {
+  //   return Promise.resolve(false);
+  // }
 
   // return the new body
   // eslint-disable-next-line no-unused-vars
-  async optimize (url, body, headers) {
-    return Promise.resolve(body);
-  }
+  // async optimize (url, body, headers) {
+  //   return Promise.resolve(body);
+  // }
 }
 
 export { ResourceInterface };

--- a/packages/cli/src/lib/resource-interface.js
+++ b/packages/cli/src/lib/resource-interface.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import { checkResourceExists } from './resource-utils.js';
 
 class ResourceInterface {
   constructor(compilation, options = {}) {
@@ -20,16 +20,8 @@ class ResourceInterface {
   async resolveForRelativeUrl(url, rootUrl) {
     const search = url.search || '';
     let reducedUrl;
-    let atRoot;
 
-    try {
-      await fs.access(new URL(`.${url.pathname}`, rootUrl));
-      atRoot = true;
-    } catch (e) {
-
-    }
-
-    if (atRoot) {
+    if (await checkResourceExists(new URL(`.${url.pathname}`, rootUrl))) {
       return new URL(`.${url.pathname}${search}`, rootUrl);
     }
 
@@ -37,15 +29,11 @@ class ResourceInterface {
     segments.shift();
 
     for (let i = 0, l = segments.length - 1; i < l; i += 1) {
-      try {
-        const nextSegments = segments.slice(i);
-        const urlToCheck = new URL(`./${nextSegments.join('/')}`, rootUrl);
+      const nextSegments = segments.slice(i);
+      const urlToCheck = new URL(`./${nextSegments.join('/')}`, rootUrl);
 
-        await fs.access(urlToCheck);
-
+      if (await checkResourceExists(urlToCheck)) {
         reducedUrl = new URL(`${urlToCheck}${search}`);
-      } catch (e) {
-
       }
     }
 

--- a/packages/cli/src/lib/resource-interface.js
+++ b/packages/cli/src/lib/resource-interface.js
@@ -24,30 +24,27 @@ class ResourceInterface {
     try {
       await fs.access(new URL(`.${url.pathname}`, rootUrl));
       atRoot = true;
-    } catch(e) {
-      console.debug('reesolveFoRRelative', { e })
+    } catch (e) {
+      // console.debug('reesolveFoRRelative', { e });
     }
 
     if (atRoot) {
       return new URL(`.${url.pathname}`, rootUrl);
     }
 
-    url.pathname.split('/')
-      .filter((segment) => segment !== '')
-      .reduce(async (acc, segment) => {
-        const reducedPath = url.pathname.replace(`${acc}/${segment}`, '');
+    const segments = url.pathname.split('/').filter(segment => segment !== '');
+    segments.shift();
 
-        try {
-          if(reducedPath !== '') {
-            await fs.access(new URL(`.${reducedPath}`, rootUrl));
-            reducedUrl = new URL(`.${reducedPath}`, rootUrl);
-          }
-        } catch(e) {
-          console.debug('reesolveFoRRelative reducing', { e })
-        }
-
-        return `${acc}/${segment}`;
-      }, '');
+    for (let i = 0, l = segments.length - 1; i < l; i += 1) {
+      try {
+        const nextSegments = segments.slice(i);
+        const urlToCheck = new URL(`./${nextSegments.join('/')}`, rootUrl);
+        await fs.access(urlToCheck);
+        reducedUrl = urlToCheck;
+      } catch (e) {
+        // console.debug('resolveForRelativeUrl trying again....');
+      }
+    }
 
     return reducedUrl;
   }

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -1,10 +1,10 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { hashString } from '../lib/hashing-utils.js';
 
-function modelResource(context, type, src = undefined, contents = undefined, optimizationAttr = undefined, rawAttributes = undefined) {
+async function modelResource(context, type, src = undefined, contents = undefined, optimizationAttr = undefined, rawAttributes = undefined) {
   const { projectDirectory, scratchDir, userWorkspace } = context;
   const extension = type === 'script' ? 'js' : 'css';
-  const windowsDriveRegex = /\/[a-zA-Z]{1}:\//;
+  // const windowsDriveRegex = /\/[a-zA-Z]{1}:\//;
   let sourcePathURL;
 
   if (src) {
@@ -14,26 +14,26 @@ function modelResource(context, type, src = undefined, contents = undefined, opt
         ? new URL(`.${src}`, userWorkspace)
         : new URL(`./${src.replace(/\.\.\//g, '').replace('./', '')}`, userWorkspace);
 
-    contents = fs.readFileSync(sourcePathURL, 'utf-8');
+    contents = await fs.readFile(sourcePathURL, 'utf-8');
   } else {
     const scratchFileName = hashString(contents);
 
     sourcePathURL = new URL(`./${scratchFileName}.${extension}`, scratchDir);
-    fs.writeFileSync(sourcePathURL, contents);
+    await fs.writeFile(sourcePathURL, contents);
   }
 
   // TODO (good first issue) handle for Windows adding extra / in front of drive letter for whatever reason :(
   // e.g. turn /C:/... -> C:/...
   // and also URL is readonly in NodeJS??
-  if (windowsDriveRegex.test(sourcePathURL.pathname)) {
-    const driveMatch = sourcePathURL.pathname.match(windowsDriveRegex)[0];
+  // if (windowsDriveRegex.test(sourcePathURL.pathname)) {
+  //   const driveMatch = sourcePathURL.pathname.match(windowsDriveRegex)[0];
 
-    sourcePathURL = {
-      ...sourcePathURL,
-      pathname: sourcePathURL.pathname.replace(driveMatch, driveMatch.replace('/', '')),
-      href: sourcePathURL.href.replace(driveMatch, driveMatch.replace('/', ''))
-    };
-  }
+  //   sourcePathURL = {
+  //     ...sourcePathURL,
+  //     pathname: sourcePathURL.pathname.replace(driveMatch, driveMatch.replace('/', '')),
+  //     href: sourcePathURL.href.replace(driveMatch, driveMatch.replace('/', ''))
+  //   };
+  // }
 
   return {
     src, // if <script src="..."></script> or <link href="..."></link>

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -1,8 +1,7 @@
 import fs from 'fs';
 import { hashString } from '../lib/hashing-utils.js';
-import path from 'path';
-import { pathToFileURL } from 'url';
 
+// TODO could make async?
 function modelResource(context, type, src = undefined, contents = undefined, optimizationAttr = undefined, rawAttributes = undefined) {
   const { projectDirectory, scratchDir, userWorkspace } = context;
   const extension = type === 'script' ? 'js' : 'css';
@@ -10,15 +9,15 @@ function modelResource(context, type, src = undefined, contents = undefined, opt
   let sourcePathURL;
 
   if (src) {
-    sourcePathURL = src.indexOf('/node_modules') === 0
-      ? pathToFileURL(path.join(projectDirectory, src)) // TODO (good first issue) get "real" location of node modules
-      : pathToFileURL(path.join(userWorkspace, src.replace(/\.\.\//g, '').replace('./', '')));
+    sourcePathURL = src.startsWith('/node_modules')
+      ? new URL(`./${src}`, projectDirectory) // pathToFileURL(path.join(projectDirectory, src)) // TODO (good first issue) get "real" location of node modules
+      : new URL(`./${src.replace(/\.\.\//g, '').replace('./', '')}`, userWorkspace); // pathToFileURL(path.join(userWorkspace, src.replace(/\.\.\//g, '').replace('./', '')));
 
     contents = fs.readFileSync(sourcePathURL, 'utf-8');
   } else {
     const scratchFileName = hashString(contents);
 
-    sourcePathURL = pathToFileURL(path.join(scratchDir, `${scratchFileName}.${extension}`));
+    sourcePathURL = new URL(`./${scratchFileName}.${extension}`, scratchDir);
     fs.writeFileSync(sourcePathURL, contents);
   }
 

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -53,21 +53,32 @@ function mergeResponse(destination, source) {
 
 // On Windows, a URL with a drive letter like C:/ thinks it is a protocol and so prepends a /, e.g. /C:/
 // This is fine with never fs methods that Greenwood uses, but tools like Rollupand PostCSS will need this handled manually
+// https://github.com/rollup/rollup/issues/3779
 function normalizePathnameForWindows(url) {
   const windowsDriveRegex = /\/[a-zA-Z]{1}:\//;
   const { pathname = '' } = url;
 
   if (windowsDriveRegex.test(pathname)) {
-   const driveMatch = pathname.match(windowsDriveRegex)[0];
+    const driveMatch = pathname.match(windowsDriveRegex)[0];
 
-   return pathname.replace(driveMatch, driveMatch.replace('/', ''))
+    return pathname.replace(driveMatch, driveMatch.replace('/', ''));
   }
 
   return pathname;
 }
 
+async function checkResourceExists(url) {
+  try {
+    await fs.access(url);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 export {
   mergeResponse,
   modelResource,
-  normalizePathnameForWindows
+  normalizePathnameForWindows,
+  checkResourceExists
 };

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import { hashString } from '../lib/hashing-utils.js';
 
-// TODO could make async?
 function modelResource(context, type, src = undefined, contents = undefined, optimizationAttr = undefined, rawAttributes = undefined) {
   const { projectDirectory, scratchDir, userWorkspace } = context;
   const extension = type === 'script' ? 'js' : 'css';
@@ -49,4 +48,25 @@ function modelResource(context, type, src = undefined, contents = undefined, opt
   };
 }
 
-export { modelResource };
+function mergeResponse(destination, source) {
+  const headers = destination.headers || new Headers();
+
+  source.headers.forEach((value, key) => {
+    // TODO better way to handle Response automatically setting content-type
+    const isDefaultHeader = key.toLowerCase() === 'content-type' && value === 'text/plain;charset=UTF-8';
+
+    if (!isDefaultHeader) {
+      headers.set(key, value);
+    }
+  });
+
+  // TODO handle merging in state (aborted, type, status, etc)
+  return new Response(source.body, {
+    headers
+  });
+}
+
+export {
+  mergeResponse,
+  modelResource
+};

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -8,7 +8,6 @@ function modelResource(context, type, src = undefined, contents = undefined, opt
   let sourcePathURL;
 
   if (src) {
-    // TODO more elegant way to normalize paths with ../, ./, /, etc?
     sourcePathURL = src.startsWith('/node_modules')
       ? new URL(`.${src}`, projectDirectory)
       : src.startsWith('/')

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -51,7 +51,23 @@ function mergeResponse(destination, source) {
   });
 }
 
+// On Windows, a URL with a drive letter like C:/ thinks it is a protocol and so prepends a /, e.g. /C:/
+// This is fine with never fs methods that Greenwood uses, but tools like Rollupand PostCSS will need this handled manually
+function normalizePathnameForWindows(url) {
+  const windowsDriveRegex = /\/[a-zA-Z]{1}:\//;
+  const { pathname = '' } = url;
+
+  if (windowsDriveRegex.test(pathname)) {
+   const driveMatch = pathname.match(windowsDriveRegex)[0];
+
+   return pathname.replace(driveMatch, driveMatch.replace('/', ''))
+  }
+
+  return pathname;
+}
+
 export {
   mergeResponse,
-  modelResource
+  modelResource,
+  normalizePathnameForWindows
 };

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -9,9 +9,12 @@ function modelResource(context, type, src = undefined, contents = undefined, opt
   let sourcePathURL;
 
   if (src) {
+    // TODO more elegant way to normalize paths with ../, ./, /, etc?
     sourcePathURL = src.startsWith('/node_modules')
       ? new URL(`.${src}`, projectDirectory)
-      : new URL(`${src.replace(/\.\.\//g, '').replace('./', '')}`, userWorkspace);
+      : src.startsWith('/')
+        ? new URL(`.${src}`, userWorkspace)
+        : new URL(`./${src.replace(/\.\.\//g, '').replace('./', '')}`, userWorkspace);
 
     contents = fs.readFileSync(sourcePathURL, 'utf-8');
   } else {

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -38,6 +38,7 @@ function mergeResponse(destination, source) {
 
   source.headers.forEach((value, key) => {
     // TODO better way to handle Response automatically setting content-type
+    // https://github.com/ProjectEvergreen/greenwood/issues/1049
     const isDefaultHeader = key.toLowerCase() === 'content-type' && value === 'text/plain;charset=UTF-8';
 
     if (!isDefaultHeader) {

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -4,7 +4,6 @@ import { hashString } from '../lib/hashing-utils.js';
 async function modelResource(context, type, src = undefined, contents = undefined, optimizationAttr = undefined, rawAttributes = undefined) {
   const { projectDirectory, scratchDir, userWorkspace } = context;
   const extension = type === 'script' ? 'js' : 'css';
-  // const windowsDriveRegex = /\/[a-zA-Z]{1}:\//;
   let sourcePathURL;
 
   if (src) {
@@ -21,19 +20,6 @@ async function modelResource(context, type, src = undefined, contents = undefine
     sourcePathURL = new URL(`./${scratchFileName}.${extension}`, scratchDir);
     await fs.writeFile(sourcePathURL, contents);
   }
-
-  // TODO (good first issue) handle for Windows adding extra / in front of drive letter for whatever reason :(
-  // e.g. turn /C:/... -> C:/...
-  // and also URL is readonly in NodeJS??
-  // if (windowsDriveRegex.test(sourcePathURL.pathname)) {
-  //   const driveMatch = sourcePathURL.pathname.match(windowsDriveRegex)[0];
-
-  //   sourcePathURL = {
-  //     ...sourcePathURL,
-  //     pathname: sourcePathURL.pathname.replace(driveMatch, driveMatch.replace('/', '')),
-  //     href: sourcePathURL.href.replace(driveMatch, driveMatch.replace('/', ''))
-  //   };
-  // }
 
   return {
     src, // if <script src="..."></script> or <link href="..."></link>

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -10,8 +10,8 @@ function modelResource(context, type, src = undefined, contents = undefined, opt
 
   if (src) {
     sourcePathURL = src.startsWith('/node_modules')
-      ? new URL(`./${src}`, projectDirectory) // pathToFileURL(path.join(projectDirectory, src)) // TODO (good first issue) get "real" location of node modules
-      : new URL(`./${src.replace(/\.\.\//g, '').replace('./', '')}`, userWorkspace); // pathToFileURL(path.join(userWorkspace, src.replace(/\.\.\//g, '').replace('./', '')));
+      ? new URL(`.${src}`, projectDirectory)
+      : new URL(`${src.replace(/\.\.\//g, '').replace('./', '')}`, userWorkspace);
 
     contents = fs.readFileSync(sourcePathURL, 'utf-8');
   } else {

--- a/packages/cli/src/lib/ssr-route-worker.js
+++ b/packages/cli/src/lib/ssr-route-worker.js
@@ -21,7 +21,7 @@ async function executeRouteModule({ moduleUrl, compilation, route, label, id, pr
     const { getTemplate = null, getBody = null, getFrontmatter = null } = module;
 
     if (module.default) {
-      const { html } = await renderToString(moduleUrl);
+      const { html } = await renderToString(new URL(moduleUrl));
 
       data.body = html;
     } else {

--- a/packages/cli/src/lib/ssr-route-worker.js
+++ b/packages/cli/src/lib/ssr-route-worker.js
@@ -1,9 +1,8 @@
 // https://github.com/nodejs/modules/issues/307#issuecomment-858729422
-import { pathToFileURL } from 'url';
 import { parentPort } from 'worker_threads';
 import { renderToString, renderFromHTML } from 'wc-compiler';
 
-async function executeRouteModule({ modulePath, compilation, route, label, id, prerender, htmlContents, scripts }) {
+async function executeRouteModule({ moduleUrl, compilation, route, label, id, prerender, htmlContents, scripts }) {
   const parsedCompilation = JSON.parse(compilation);
   const data = {
     template: null,
@@ -18,11 +17,11 @@ async function executeRouteModule({ modulePath, compilation, route, label, id, p
 
     data.html = html;
   } else {
-    const module = await import(pathToFileURL(modulePath)).then(module => module);
+    const module = await import(moduleUrl).then(module => module);
     const { getTemplate = null, getBody = null, getFrontmatter = null } = module;
 
     if (module.default) {
-      const { html } = await renderToString(pathToFileURL(modulePath));
+      const { html } = await renderToString(moduleUrl);
 
       data.body = html;
     } else {

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -83,13 +83,13 @@ async function bundleStyleResources(compilation, resourcePlugins) {
       const outputPathRoot = new URL(`./${optimizedFileName}`, outputDir).pathname
         .split('/')
         .slice(0, -1)
-        .join('/');
+        .join('/')
+        .concat('/');
 
-      console.debug('???', new URL(`file://${outputPathRoot}`))
       try {
-        fs.access(new URL(`file://${outputPathRoot}`));
+        await fs.access(new URL(`file://${outputPathRoot}`));
       } catch (error) {
-        fs.mkdir(new URL(`file://${outputPathRoot}`), {
+        await fs.mkdir(new URL(`file://${outputPathRoot}`), {
           recursive: true
         });
       }

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -33,7 +33,7 @@ async function optimizeStaticPages(compilation, plugins) {
       let response = new Response(contents, { headers });
 
       try {
-        await fs.access(new URL(`.${route}`, outputDir))
+        await fs.access(new URL(`.${route}`, outputDir));
       } catch (error) {
         await fs.mkdir(new URL(`.${route}`, outputDir), {
           recursive: true

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -106,8 +106,7 @@ async function bundleStyleResources(compilation, resourcePlugins) {
             const currentResponse = await plugin.intercept(url, request, intermediateResponse.clone());
             const mergedResponse = mergeResponse(intermediateResponse.clone(), currentResponse.clone());
 
-            // TODO better way to handle Response automatically setting content-type
-            if ((mergedResponse.headers.get('Content-Type') || mergedResponse.headers.get('content-type')).indexOf(contentType) >= 0) {
+            if (mergedResponse.headers.get('Content-Type').indexOf(contentType) >= 0) {
               return Promise.resolve(mergedResponse.clone());
             }
           }

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -161,7 +161,7 @@ const bundleCompilation = async (compilation) => {
 
       await Promise.all([
         await bundleScriptResources(compilation),
-        await bundleStyleResources(compilation, optimizeResourcePlugins.filter(plugin => plugin.contentType.includes('text/css')))
+        await bundleStyleResources(compilation, optimizeResourcePlugins)
       ]);
 
       console.info('optimizing static pages....');

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -14,7 +14,7 @@ async function cleanUpResources(compilation) {
     const optAttr = ['inline', 'static'].indexOf(optimizationAttr) >= 0;
 
     if (optimizedFileName && (!src || (optAttr || optConfig))) {
-      fs.unlinkSync(path.join(outputDir, optimizedFileName));
+      fs.unlinkSync(new URL(`./${optimizedFileName}`, outputDir).pathname);
     }
   }
 }
@@ -67,6 +67,7 @@ async function bundleStyleResources(compilation, plugins) {
       let optimizedFileContents;
 
       if (src) {
+        // TODO remove path. usage
         const basename = path.basename(srcPath);
         const basenamePieces = path.basename(srcPath).split('.');
         const fileNamePieces = srcPath.split('/').filter(piece => piece !== ''); // normalize by removing any leading /'s  

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -15,7 +15,7 @@ async function cleanUpResources(compilation) {
     const optAttr = ['inline', 'static'].indexOf(optimizationAttr) >= 0;
 
     if (optimizedFileName && (!src || (optAttr || optConfig))) {
-      await fs.unlink(new URL(`./${optimizedFileName}`, outputDir).pathname);
+      await fs.unlink(new URL(`./${optimizedFileName}`, outputDir));
     }
   }
 }

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -104,7 +104,7 @@ async function bundleStyleResources(compilation, resourcePlugins) {
           const shouldIntercept = plugin.shouldIntercept && await plugin.shouldIntercept(url, request, intermediateResponse.clone());
 
           if (shouldIntercept) {
-            const thisResponse = await plugin.intercept(url, request.clone(), intermediateResponse.clone());
+            const thisResponse = await plugin.intercept(url, request, intermediateResponse.clone());
 
             if (thisResponse.headers.get('Content-Type').indexOf(contentType) >= 0) {
               return Promise.resolve(thisResponse.clone());

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -107,7 +107,7 @@ async function bundleStyleResources(compilation, resourcePlugins) {
             const thisResponse = await plugin.intercept(url, request.clone(), intermediateResponse.clone());
 
             if (thisResponse.headers.get('Content-Type').indexOf(contentType) >= 0) {
-              return Promise.resolve(intermediateResponse.clone());
+              return Promise.resolve(thisResponse.clone());
             }
           }
 

--- a/packages/cli/src/lifecycles/compile.js
+++ b/packages/cli/src/lifecycles/compile.js
@@ -22,7 +22,7 @@ const generateCompilation = () => {
       
       // generate a graph of all pages / components to build
       console.info('Generating graph of workspace files...');
-      // compilation = await generateGraph(compilation);
+      compilation = await generateGraph(compilation);
 
       resolve(compilation);
     } catch (err) {

--- a/packages/cli/src/lifecycles/compile.js
+++ b/packages/cli/src/lifecycles/compile.js
@@ -22,7 +22,7 @@ const generateCompilation = () => {
       
       // generate a graph of all pages / components to build
       console.info('Generating graph of workspace files...');
-      compilation = await generateGraph(compilation);
+      // compilation = await generateGraph(compilation);
 
       resolve(compilation);
     } catch (err) {

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -89,7 +89,7 @@ const readAndMergeConfig = async() => {
           try {
             await fs.access(workspace);
             customConfig.workspace = workspace;
-          } catch(e) {
+          } catch (e) {
             reject('Error: greenwood.config.js workspace doesn\'t exist! Please double check your configuration.');
           }
         }

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -64,7 +64,7 @@ const readAndMergeConfig = async() => {
 
         // workspace validation
         if (workspace) {
-          if (!workspace instanceof URL) {
+          if (!(workspace instanceof URL)) {
             reject('Error: greenwood.config.js workspace must be an instance of URL');
           }
 
@@ -207,7 +207,7 @@ const readAndMergeConfig = async() => {
         }
       } else {
         // SPA should _not_ prerender unless if user has specified prerender should be true
-        if (fs.existsSync(path.join(customConfig.workspace, 'index.html'))) {
+        if (fs.existsSync(new URL('./index.html', customConfig.workspace).pathname)) {
           customConfig.prerender = false;
         }
       }

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import { checkResourceExists } from '../lib/resource-utils.js';
 
 const cwd = new URL(`file://${process.cwd()}/`);
 const greenwoodPluginsDirectoryUrl = new URL('../plugins/', import.meta.url);
@@ -61,19 +62,13 @@ const readAndMergeConfig = async() => {
       let isSPA;
 
       // check for greenwood.config.js
-      try {
-        await fs.access(configUrl);
+      if (await checkResourceExists(configUrl)) {
         hasConfigFile = true;
-      } catch (e) {
-
       }
 
       // check for SPA
-      try {
-        await fs.access(new URL('./index.html', customConfig.workspace));
+      if (await checkResourceExists(new URL('./index.html', customConfig.workspace))) {
         isSPA = true;
-      } catch (e) {
-
       }
 
       if (hasConfigFile) {
@@ -86,10 +81,9 @@ const readAndMergeConfig = async() => {
             reject('Error: greenwood.config.js workspace must be an instance of URL');
           }
 
-          try {
-            await fs.access(workspace);
+          if (await checkResourceExists(workspace)) {
             customConfig.workspace = workspace;
-          } catch (e) {
+          } else {
             reject('Error: greenwood.config.js workspace doesn\'t exist! Please double check your configuration.');
           }
         }

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -7,7 +7,6 @@ const PLUGINS_FLATTENED_DEPTH = 2;
 
 // get and "tag" all plugins provided / maintained by the @greenwood/cli
 // and include as the default set, with all user plugins getting appended
-// TODO could probably refactored to use a for loop
 const greenwoodPlugins = (await Promise.all([
   new URL('./copy/', greenwoodPluginsDirectoryUrl),
   new URL('./renderer/', greenwoodPluginsDirectoryUrl),

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -64,7 +64,7 @@ const readAndMergeConfig = async() => {
       try {
         await fs.access(configUrl);
         hasConfigFile = true;
-      } catch(e) {
+      } catch (e) {
 
       }
 
@@ -72,7 +72,7 @@ const readAndMergeConfig = async() => {
       try {
         await fs.access(new URL('./index.html', customConfig.workspace));
         isSPA = true;
-      } catch(e) {
+      } catch (e) {
 
       }
 

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -194,7 +194,7 @@ const readAndMergeConfig = async() => {
         }
 
         // SPA should _not_ prerender unless if user has specified prerender should be true
-        if (prerender === undefined && fs.existsSync(path.join(customConfig.workspace, 'index.html'))) {
+        if (prerender === undefined && fs.existsSync(new URL('./index.html', customConfig.workspace))) {
           customConfig.prerender = false;
         }
 

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -1,19 +1,19 @@
 import fs from 'fs';
-import path from 'path';
-import { fileURLToPath, URL } from 'url';
 
 const initContext = async({ config }) => {
-  const scratchDir = path.join(process.cwd(), './.greenwood');
-  const outputDir = path.join(process.cwd(), './public');
-  const dataDir = fileURLToPath(new URL('../data', import.meta.url));
 
   return new Promise(async (resolve, reject) => {
     try {
-      const projectDirectory = process.cwd();
-      const userWorkspace = path.join(config.workspace);
-      const apisDir = path.join(userWorkspace, 'api/');
-      const pagesDir = path.join(userWorkspace, `${config.pagesDirectory}/`);
-      const userTemplatesDir = path.join(userWorkspace, `${config.templatesDirectory}/`);
+      const { workspace, pagesDirectory, templatesDirectory } = config;
+
+      const projectDirectory = new URL(`file://${process.cwd()}/`);
+      const scratchDir = new URL('./.greenwood/', projectDirectory);
+      const outputDir = new URL('./public/', projectDirectory);
+      const dataDir = new URL('../data/', import.meta.url);
+      const userWorkspace = workspace;
+      const apisDir = new URL('./apis/', userWorkspace);
+      const pagesDir = new URL(`./${pagesDirectory}/`, userWorkspace);
+      const userTemplatesDir = new URL(`./${templatesDirectory}/`, userWorkspace);
 
       const context = {
         dataDir,
@@ -26,8 +26,8 @@ const initContext = async({ config }) => {
         projectDirectory
       };
 
-      if (!fs.existsSync(scratchDir)) {
-        fs.mkdirSync(scratchDir, {
+      if (!fs.existsSync(scratchDir.pathname)) {
+        fs.mkdirSync(scratchDir.pathname, {
           recursive: true
         });
       }

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -11,7 +11,7 @@ const initContext = async({ config }) => {
       const outputDir = new URL('./public/', projectDirectory);
       const dataDir = new URL('../data/', import.meta.url);
       const userWorkspace = workspace;
-      const apisDir = new URL('./apis/', userWorkspace);
+      const apisDir = new URL('./api/', userWorkspace);
       const pagesDir = new URL(`./${pagesDirectory}/`, userWorkspace);
       const userTemplatesDir = new URL(`./${templatesDirectory}/`, userWorkspace);
 

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import { checkResourceExists } from '../lib/resource-utils.js';
 
 const initContext = async({ config }) => {
 
@@ -25,12 +26,10 @@ const initContext = async({ config }) => {
         projectDirectory
       };
 
-      try {
-        await fs.access(scratchDir);
-      } catch(e) {
+      if (!await checkResourceExists(scratchDir)) {
         await fs.mkdir(scratchDir, {
           recursive: true
-        })
+        });
       }
       
       resolve(context);

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 const initContext = async({ config }) => {
 
@@ -14,7 +14,6 @@ const initContext = async({ config }) => {
       const apisDir = new URL('./api/', userWorkspace);
       const pagesDir = new URL(`./${pagesDirectory}/`, userWorkspace);
       const userTemplatesDir = new URL(`./${templatesDirectory}/`, userWorkspace);
-
       const context = {
         dataDir,
         outputDir,
@@ -26,10 +25,12 @@ const initContext = async({ config }) => {
         projectDirectory
       };
 
-      if (!fs.existsSync(scratchDir.pathname)) {
-        fs.mkdirSync(scratchDir.pathname, {
+      try {
+        await fs.access(scratchDir);
+      } catch(e) {
+        await fs.mkdir(scratchDir, {
           recursive: true
-        });
+        })
       }
       
       resolve(context);

--- a/packages/cli/src/lifecycles/copy.js
+++ b/packages/cli/src/lifecycles/copy.js
@@ -16,8 +16,8 @@ async function rreaddir (dir, allFiles = []) {
 async function copyFile(source, target, projectDirectory) {
   try {
     console.info(`copying file... ${source.pathname.replace(projectDirectory.pathname, '')}`);
-    const rd = fs.createReadStream(source.pathname);
-    const wr = fs.createWriteStream(target.pathname);
+    const rd = fs.createReadStream(source);
+    const wr = fs.createWriteStream(target);
 
     return await new Promise((resolve, reject) => {
       rd.on('error', reject);
@@ -51,7 +51,13 @@ async function copyDirectory(fromUrl, toUrl, projectDirectory) {
         const isDirectory = (await fs.promises.stat(fileUrl)).isDirectory();
 
         if (isDirectory) {
-          await fs.promises.mkdir(targetUrl);
+          try {
+            await fs.promises.access(targetUrl);
+          } catch (e) {
+            await fs.promises.mkdir(targetUrl, {
+              recursive: true
+            });
+          }
         } else if (!isDirectory) {
           await copyFile(fileUrl, targetUrl, projectDirectory);
         }

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -216,7 +216,7 @@ const generateGraph = async (compilation) => {
       };
 
       console.debug('building from local sources...');
-      if (fs.existsSync(path.join(userWorkspace.pathname, 'index.html'))) { // SPA
+      if (fs.existsSync(new URL('./index.html', userWorkspace).pathname)) { // SPA
         graph = [{
           ...graph[0],
           path: `${userWorkspace.pathname}index.html`,

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -214,16 +214,16 @@ const generateGraph = async (compilation) => {
       };
 
       console.debug('building from local sources...');
-      if (fs.existsSync(path.join(userWorkspace, 'index.html'))) { // SPA
+      if (fs.existsSync(path.join(userWorkspace.pathname, 'index.html'))) { // SPA
         graph = [{
           ...graph[0],
-          path: `${userWorkspace}${path.sep}index.html`,
+          path: `${userWorkspace.pathname}index.html`,
           isSPA: true
         }];
       } else {
         const oldGraph = graph[0];
         
-        graph = fs.existsSync(pagesDir) ? await walkDirectoryForPages(pagesDir) : graph;
+        graph = fs.existsSync(pagesDir.pathname) ? await walkDirectoryForPages(pagesDir.pathname) : graph;
 
         const has404Page = graph.filter(page => page.route === '/404/').length === 1;
 
@@ -279,11 +279,11 @@ const generateGraph = async (compilation) => {
 
       compilation.graph = graph;
 
-      if (!fs.existsSync(context.scratchDir)) {
-        await fs.promises.mkdir(context.scratchDir);
+      if (!fs.existsSync(context.scratchDir.pathname)) {
+        await fs.promises.mkdir(context.scratchDir.pathname);
       }
 
-      await fs.promises.writeFile(`${context.scratchDir}/graph.json`, JSON.stringify(compilation.graph));
+      await fs.promises.writeFile(`${context.scratchDir.pathname}graph.json`, JSON.stringify(compilation.graph));
 
       resolve(compilation);
     } catch (err) {

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -6,6 +6,8 @@ import path from 'path';
 import toc from 'markdown-toc';
 import { Worker } from 'worker_threads';
 
+// TODO convert graph to use URLs
+// https://github.com/ProjectEvergreen/greenwood/issues/952
 const generateGraph = async (compilation) => {
 
   return new Promise(async (resolve, reject) => {
@@ -35,7 +37,7 @@ const generateGraph = async (compilation) => {
             const extension = path.extname(filename);
             const isStatic = extension === '.md' || extension === '.html';
             const isDynamic = extension === '.js';
-            const relativePagePath = fullPath.substring(pagesDir.length - 1, fullPath.length);
+            const relativePagePath = fullPath.substring(pagesDir.pathname.length - 1, fullPath.length);
             const relativeWorkspacePath = directory.replace(process.cwd(), '').replace(path.sep, '');
             let route = relativePagePath
               .replace(extension, '')

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -132,10 +132,10 @@ const generateGraph = async (compilation) => {
 
                 worker.on('message', (result) => {
                   if (result.frontmatter) {
-                    const resources = (result.frontmatter.imports || []).map((resource) => {
+                    const resources = (result.frontmatter.imports || []).map(async (resource) => {
                       const type = resource.split('.').pop() === 'js' ? 'script' : 'link';
 
-                      return modelResource(compilation.context, type, resource);
+                      return await modelResource(compilation.context, type, resource);
                     });
 
                     result.frontmatter.imports = resources;

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -85,7 +85,7 @@ async function servePage(url, request, plugins) {
 
 async function interceptPage(url, request, plugins, body) {
   const headers = new Headers();
-  headers.append('content-type', 'text/html');
+  headers.append('Content-Type', 'text/html');
 
   let response = new Response(body, { headers });
 
@@ -158,6 +158,7 @@ async function preRenderCompilationWorker(compilation, workerPrerender) {
 async function preRenderCompilationCustom(compilation, customPrerender) {
   const { scratchDir } = compilation.context;
   const renderer = (await import(customPrerender.customUrl)).default;
+  // const plugins = getPluginInstances(compilation);
 
   console.info('pages to generate', `\n ${compilation.graph.map(page => page.route).join('\n ')}`);
 
@@ -165,12 +166,17 @@ async function preRenderCompilationCustom(compilation, customPrerender) {
     const { route, outputPath } = page;
     const outputDirUrl = new URL(`./${route}`, scratchDir);
     const outputPathUrl = new URL(`./${outputPath}`, scratchDir);
+    // const url = new URL(`http://localhost:${compilation.config.port}${route}`);
+    // const request = new Request(url);
 
     // clean up special Greenwood dev only assets that would come through if prerendering with a headless browser
     body = body.replace(/<script src="(.*lit\/polyfill-support.js)"><\/script>/, '');
     body = body.replace(/<script type="importmap-shim">.*?<\/script>/s, '');
     body = body.replace(/<script defer="" src="(.*es-module-shims.js)"><\/script>/, '');
     body = body.replace(/type="module-shim"/g, 'type="module"');
+
+    // TODO no intercept needed?
+    // body = await (await interceptPage(url, request, plugins, body)).text();
 
     // clean this up here to avoid sending webcomponents-bundle to rollup
     body = body.replace(/<script src="(.*webcomponents-bundle.js)"><\/script>/, '');

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -203,7 +203,7 @@ async function staticRenderCompilation(compilation) {
     const request = new Request(url);
 
     let body = await (await servePage(url, request, plugins)).text();
-    body = await (await interceptPage(url, request, plugins, html)).text();
+    body = await (await interceptPage(url, request, plugins, body)).text();
 
     trackResourcesForRoute(body, compilation, route);
     createOutputDirectory(route, outputDirUrl);

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -77,6 +77,7 @@ async function servePage(url, request, plugins) {
   for (const plugin of plugins) {
     if (plugin.shouldServe && await plugin.shouldServe(url, request)) {
       response = await plugin.serve(url, request);
+      break;
     }
   }
 
@@ -84,10 +85,9 @@ async function servePage(url, request, plugins) {
 }
 
 async function interceptPage(url, request, plugins, body) {
-  const headers = new Headers();
-  headers.append('Content-Type', 'text/html');
-
-  let response = new Response(body, { headers });
+  let response = new Response(body, {
+    headers: new Headers({ 'Content-Type': 'text/html' })
+  });
 
   for (const plugin of plugins) {
     if (plugin.shouldIntercept && await plugin.shouldIntercept(url, request, response)) {

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -1,6 +1,6 @@
 import fs from 'fs/promises';
 import htmlparser from 'node-html-parser';
-import { modelResource } from '../lib/resource-utils.js';
+import { checkResourceExists, modelResource } from '../lib/resource-utils.js';
 import os from 'os';
 import { WorkerPool } from '../lib/threadpool.js';
 
@@ -9,11 +9,7 @@ function isLocalLink(url = '') {
 }
 
 async function createOutputDirectory(route, outputDir) {
-  try {
-    if (route !== '/404/') {
-      await fs.access(outputDir);
-    }
-  } catch (e) {
+  if (route !== '/404/' && !await checkResourceExists(outputDir)) {
     await fs.mkdir(outputDir, {
       recursive: true
     });

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -158,7 +158,6 @@ async function preRenderCompilationWorker(compilation, workerPrerender) {
 async function preRenderCompilationCustom(compilation, customPrerender) {
   const { scratchDir } = compilation.context;
   const renderer = (await import(customPrerender.customUrl)).default;
-  // const plugins = getPluginInstances(compilation);
 
   console.info('pages to generate', `\n ${compilation.graph.map(page => page.route).join('\n ')}`);
 
@@ -166,17 +165,12 @@ async function preRenderCompilationCustom(compilation, customPrerender) {
     const { route, outputPath } = page;
     const outputDirUrl = new URL(`./${route}`, scratchDir);
     const outputPathUrl = new URL(`./${outputPath}`, scratchDir);
-    // const url = new URL(`http://localhost:${compilation.config.port}${route}`);
-    // const request = new Request(url);
 
     // clean up special Greenwood dev only assets that would come through if prerendering with a headless browser
     body = body.replace(/<script src="(.*lit\/polyfill-support.js)"><\/script>/, '');
     body = body.replace(/<script type="importmap-shim">.*?<\/script>/s, '');
     body = body.replace(/<script defer="" src="(.*es-module-shims.js)"><\/script>/, '');
     body = body.replace(/type="module-shim"/g, 'type="module"');
-
-    // TODO no intercept needed?
-    // body = await (await interceptPage(url, request, plugins, body)).text();
 
     // clean this up here to avoid sending webcomponents-bundle to rollup
     body = body.replace(/<script src="(.*webcomponents-bundle.js)"><\/script>/, '');

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { hashString } from '../lib/hashing-utils.js';
 import Koa from 'koa';
 import { mergeResponse } from '../lib/resource-utils.js';
@@ -166,7 +166,7 @@ async function getStaticServer(compilation, composable) {
 
     if ((matchingRoute && !matchingRoute.isSSR) || url.pathname.split('.').pop() === 'html') {
       const pathname = matchingRoute ? matchingRoute.outputPath : url.pathname;
-      const body = await fs.promises.readFile(new URL(`./${pathname}`, outputDir), 'utf-8');
+      const body = await fs.readFile(new URL(`./${pathname}`, outputDir), 'utf-8');
 
       ctx.set('Content-Type', 'text/html');
       ctx.body = body;

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -250,7 +250,6 @@ async function getHybridServer(compilation) {
       }).provider(compilation);
       let response = await standardHtmlResource.serve(url, request);
 
-      // TODO no intercept???
       response = await standardHtmlResource.optimize(url, response);
 
       ctx.body = Readable.from(response.body);

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -34,6 +34,7 @@ async function getDevServer(compilation) {
   app.use(async (ctx, next) => {
     try {
       const url = new URL(`http://localhost:${compilation.config.port}${ctx.url}`);
+
       let request = new Request(url, {
         method: ctx.request.method,
         headers: ctx.request.header
@@ -105,6 +106,8 @@ async function getDevServer(compilation) {
         }
       }
 
+      // TODO would be nice if Koa (or other framework) could just a Response object directly
+      // not sure why we have to use `Readable.from`, does this couple us to NodeJS?
       ctx.body = response.body ? Readable.from(response.body) : '';
       ctx.set('Content-Type', response.headers.get('content-type'));
     } catch (e) {

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -102,7 +102,6 @@ async function getDevServer(compilation) {
 
       ctx.set('Content-Type', response.headers.get('content-type'));
       ctx.body = await response.text();
-      ctx.body = t;
     } catch (e) {
       console.error(e);
     }

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -70,8 +70,6 @@ async function getDevServer(compilation) {
         }
       }
 
-      // TODO would be nice if Koa (or other framework) could just a Response object directly
-      // not sure why we have to use `Readable.from`, does this couple us to NodeJS?
       ctx.body = response.body ? Readable.from(response.body) : '';
       ctx.type = response.headers.get('Content-Type');
       ctx.status = response.status;
@@ -107,8 +105,6 @@ async function getDevServer(compilation) {
         }
       }, Promise.resolve(initResponse.clone()));
 
-      // TODO would be nice if Koa (or other framework) could just a Response object directly
-      // not sure why we have to use `Readable.from`, does this couple us to NodeJS?
       ctx.body = response.body ? Readable.from(response.body) : '';
       ctx.set('Content-Type', response.headers.get('Content-Type'));
     } catch (e) {

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -62,8 +62,8 @@ async function getDevServer(compilation) {
       const initResponse = new Response(null, { status });
       const request = new Request(url.href, { method, headers: header });
       const response = await resourcePlugins.reduce(async (responsePromise, plugin) => {
-        return plugin.shouldServe && await plugin.shouldServe(url, request.clone())
-          ? Promise.resolve(await plugin.serve(url, request.clone()))
+        return plugin.shouldServe && await plugin.shouldServe(url, request)
+          ? Promise.resolve(await plugin.serve(url, request))
           : Promise.resolve(await responsePromise);
       }, Promise.resolve(initResponse.clone()));
 
@@ -94,8 +94,8 @@ async function getDevServer(compilation) {
       });
       const response = await resourcePlugins.reduce(async (responsePromise, plugin) => {
         const intermediateResponse = await responsePromise;
-        return plugin.shouldIntercept && await plugin.shouldIntercept(url, request.clone(), intermediateResponse.clone())
-          ? Promise.resolve(await plugin.intercept(url, request.clone(), await intermediateResponse.clone()))
+        return plugin.shouldIntercept && await plugin.shouldIntercept(url, request, intermediateResponse.clone())
+          ? Promise.resolve(await plugin.intercept(url, request, await intermediateResponse.clone()))
           : Promise.resolve(responsePromise);
       }, Promise.resolve(initResponse.clone()));
 
@@ -180,8 +180,8 @@ async function getStaticServer(compilation, composable) {
         .find((plugin) => plugin.name === 'plugin-dev-proxy')
         .provider(compilation);
 
-      if (await proxyPlugin.shouldServe(url, request.clone())) {
-        const response = await proxyPlugin.serve(url, request.clone());
+      if (await proxyPlugin.shouldServe(url, request)) {
+        const response = await proxyPlugin.serve(url, request);
 
         ctx.body = Readable.from(response.body);
         ctx.set('Content-Type', response.headers.get('Content-Type'));
@@ -202,8 +202,8 @@ async function getStaticServer(compilation, composable) {
       headers: new Headers(ctx.response.header)
     });
     const response = await resourcePlugins.reduce(async (responsePromise, plugin) => {
-      return plugin.shouldServe && await plugin.shouldServe(url, request.clone())
-        ? Promise.resolve(await plugin.serve(url, request.clone()))
+      return plugin.shouldServe && await plugin.shouldServe(url, request)
+        ? Promise.resolve(await plugin.serve(url, request))
         : responsePromise;
     }, Promise.resolve(initResponse));
 

--- a/packages/cli/src/loader.js
+++ b/packages/cli/src/loader.js
@@ -19,21 +19,21 @@ async function getCustomLoaderResponse(url, body = '', checkOnly = false) {
 
   // TODO should this use the reduce pattern too?
   for (const plugin of resourcePlugins) {
-    if (plugin.shouldServe && await plugin.shouldServe(url, request.clone())) {
+    if (plugin.shouldServe && await plugin.shouldServe(url, request)) {
       shouldHandle = true;
   
       if (!checkOnly) {
-        response = await plugin.serve(url, request.clone());
+        response = await plugin.serve(url, request);
       }
     }
   }
 
   for (const plugin of resourcePlugins) {
-    if (plugin.shouldIntercept && await plugin.shouldIntercept(url, request.clone(), response.clone())) {
+    if (plugin.shouldIntercept && await plugin.shouldIntercept(url, request, response.clone())) {
       shouldHandle = true;
 
       if (!checkOnly) {
-        response = await plugin.intercept(url, request.clone(), response.clone());
+        response = await plugin.intercept(url, request, response.clone());
       }
     }
   }

--- a/packages/cli/src/loader.js
+++ b/packages/cli/src/loader.js
@@ -9,7 +9,6 @@ const resourcePlugins = config.plugins.filter(plugin => plugin.type === 'resourc
 }));
 
 async function getCustomLoaderResponse(url, body = '', checkOnly = false) {
-  console.debug('getCustomLoaderResponse', { url, body, checkOnly });
   const headers = new Headers({
     'Content-Type': 'text/javascript'
   });
@@ -66,19 +65,13 @@ export async function resolve(specifier, context, defaultResolve) {
 
 // https://nodejs.org/docs/latest-v18.x/api/esm.html#loadurl-context-nextload
 export async function load(source, context, defaultLoad) {
-  console.debug('my load', { source, context });
   const extension = source.split('.').pop();
   const url = new URL('', `${source}?type=${extension}`);
   const { shouldHandle } = await getCustomLoaderResponse(url, null, true);
 
-  console.debug({ url, shouldHandle, extension });
-
   if (shouldHandle) {
-    console.log('we have a hit for !!!!!', { source });
     const contents = await fs.readFile(new URL(source), 'utf-8');
-    console.debug('what goes in???????', { contents });
     const { response } = await getCustomLoaderResponse(url, contents);
-    console.debug('$$$$$', { response });
     const body = await response.text();
 
     // TODO better way to handle remove export default?

--- a/packages/cli/src/plugins/copy/plugin-copy-assets.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-assets.js
@@ -1,18 +1,17 @@
 import fs from 'fs';
-import path from 'path';
 
 const greenwoodPluginCopyAssets = [{
   type: 'copy',
   name: 'plugin-copy-assets',
   provider: (compilation) => {
-    const { context } = compilation;
-    const fromAssetsDir = path.join(context.userWorkspace, 'assets');
+    const { outputDir, userWorkspace } = compilation.context;
+    const fromAssetsDirUrl = new URL('./assets/', userWorkspace);
     const assets = [];
 
-    if (fs.existsSync(fromAssetsDir)) {
+    if (fs.existsSync(fromAssetsDirUrl.pathname)) {
       assets.push({
-        from: fromAssetsDir,
-        to: path.join(context.outputDir, 'assets')
+        from: fromAssetsDirUrl,
+        to: new URL('./assets/', outputDir)
       });
     }
 

--- a/packages/cli/src/plugins/copy/plugin-copy-assets.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-assets.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import { checkResourceExists } from '../../lib/resource-utils.js';
 
 const greenwoodPluginCopyAssets = [{
   type: 'copy',
@@ -8,15 +8,11 @@ const greenwoodPluginCopyAssets = [{
     const fromAssetsDirUrl = new URL('./assets/', userWorkspace);
     const assets = [];
 
-    try {
-      await fs.access(fromAssetsDirUrl);
-
+    if (await checkResourceExists(fromAssetsDirUrl)) {
       assets.push({
         from: fromAssetsDirUrl,
         to: new URL('./assets/', outputDir)
       });
-    } catch (e) {
-
     }
 
     return assets;

--- a/packages/cli/src/plugins/copy/plugin-copy-assets.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-assets.js
@@ -1,18 +1,22 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 const greenwoodPluginCopyAssets = [{
   type: 'copy',
   name: 'plugin-copy-assets',
-  provider: (compilation) => {
+  provider: async (compilation) => {
     const { outputDir, userWorkspace } = compilation.context;
     const fromAssetsDirUrl = new URL('./assets/', userWorkspace);
     const assets = [];
 
-    if (fs.existsSync(fromAssetsDirUrl.pathname)) {
+    try {
+      await fs.access(fromAssetsDirUrl);
+
       assets.push({
         from: fromAssetsDirUrl,
         to: new URL('./assets/', outputDir)
       });
+    } catch (e) {
+
     }
 
     return assets;

--- a/packages/cli/src/plugins/copy/plugin-copy-favicon.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-favicon.js
@@ -17,7 +17,7 @@ const greenwoodPluginCopyFavicon = [{
         to: new URL(`./${fileName}`, outputDir)
       });
     } catch (error) {
-      console.log('copy favion', { error });
+
     }
 
     return assets;

--- a/packages/cli/src/plugins/copy/plugin-copy-favicon.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-favicon.js
@@ -1,19 +1,23 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 const greenwoodPluginCopyFavicon = [{
   type: 'copy',
   name: 'plugin-copy-favicon',
-  provider: (compilation) => {
+  provider: async (compilation) => {
     const fileName = 'favicon.ico';
     const { outputDir, userWorkspace } = compilation.context;
     const robotsPathUrl = new URL(`./${fileName}`, userWorkspace);
     const assets = [];
 
-    if (fs.existsSync(robotsPathUrl.pathname)) {
+    try {
+      await fs.access(robotsPathUrl);
+
       assets.push({
         from: robotsPathUrl,
         to: new URL(`./${fileName}`, outputDir)
       });
+    } catch (error) {
+      console.log('copy favion', { error });
     }
 
     return assets;

--- a/packages/cli/src/plugins/copy/plugin-copy-favicon.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-favicon.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import { checkResourceExists } from '../../lib/resource-utils.js';
 
 const greenwoodPluginCopyFavicon = [{
   type: 'copy',
@@ -6,18 +6,14 @@ const greenwoodPluginCopyFavicon = [{
   provider: async (compilation) => {
     const fileName = 'favicon.ico';
     const { outputDir, userWorkspace } = compilation.context;
-    const robotsPathUrl = new URL(`./${fileName}`, userWorkspace);
+    const faviconPathUrl = new URL(`./${fileName}`, userWorkspace);
     const assets = [];
 
-    try {
-      await fs.access(robotsPathUrl);
-
+    if (await checkResourceExists(faviconPathUrl)) {
       assets.push({
-        from: robotsPathUrl,
+        from: faviconPathUrl,
         to: new URL(`./${fileName}`, outputDir)
       });
-    } catch (error) {
-
     }
 
     return assets;

--- a/packages/cli/src/plugins/copy/plugin-copy-favicon.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-favicon.js
@@ -1,19 +1,18 @@
 import fs from 'fs';
-import path from 'path';
 
 const greenwoodPluginCopyFavicon = [{
   type: 'copy',
   name: 'plugin-copy-favicon',
   provider: (compilation) => {
     const fileName = 'favicon.ico';
-    const { context } = compilation;
-    const robotsPath = path.join(context.userWorkspace, fileName);
+    const { outputDir, userWorkspace } = compilation.context;
+    const robotsPathUrl = new URL(`./${fileName}`, userWorkspace);
     const assets = [];
 
-    if (fs.existsSync(robotsPath)) {
+    if (fs.existsSync(robotsPathUrl.pathname)) {
       assets.push({
-        from: robotsPath,
-        to: path.join(context.outputDir, fileName)
+        from: robotsPathUrl,
+        to: new URL(`./${fileName}`, outputDir)
       });
     }
 

--- a/packages/cli/src/plugins/copy/plugin-copy-graph-json.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-graph-json.js
@@ -1,14 +1,12 @@
-import path from 'path';
-
 const greenwoodPluginCopyGraphJson = [{
   type: 'copy',
   name: 'plugin-copy-graph-json',
   provider: (compilation) => {
-    const { context } = compilation;
+    const { scratchDir, outputDir } = compilation.context;
 
     return [{
-      from: path.join(context.scratchDir, 'graph.json'),
-      to: path.join(context.outputDir, 'graph.json')
+      from: new URL('./graph.json', scratchDir),
+      to: new URL('./graph.json', outputDir)
     }];
   }
 }];

--- a/packages/cli/src/plugins/copy/plugin-copy-robots.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-robots.js
@@ -1,19 +1,18 @@
 import fs from 'fs';
-import path from 'path';
 
 const greenwoodPluginCopyRobots = [{
   type: 'copy',
   name: 'plugin-copy-robots',
   provider: (compilation) => {
     const fileName = 'robots.txt';
-    const { context } = compilation;
-    const robotsPath = path.join(context.userWorkspace, fileName);
+    const { outputDir, userWorkspace } = compilation.context;
+    const robotsPathUrl = new URL(`./${fileName}`, userWorkspace);
     const assets = [];
 
-    if (fs.existsSync(robotsPath)) {
+    if (fs.existsSync(robotsPathUrl.pathname)) {
       assets.push({
-        from: robotsPath,
-        to: path.join(context.outputDir, fileName)
+        from: robotsPathUrl,
+        to: new URL(`./${fileName}`, outputDir)
       });
     }
 

--- a/packages/cli/src/plugins/copy/plugin-copy-robots.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-robots.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import { checkResourceExists } from '../../lib/resource-utils.js';
 
 const greenwoodPluginCopyRobots = [{
   type: 'copy',
@@ -9,15 +9,11 @@ const greenwoodPluginCopyRobots = [{
     const robotsPathUrl = new URL(`./${fileName}`, userWorkspace);
     const assets = [];
 
-    try {
-      await fs.access(robotsPathUrl);
-
+    if (await checkResourceExists(robotsPathUrl)) {
       assets.push({
         from: robotsPathUrl,
         to: new URL(`./${fileName}`, outputDir)
       });
-    } catch (e) {
-
     }
 
     return assets;

--- a/packages/cli/src/plugins/copy/plugin-copy-robots.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-robots.js
@@ -1,19 +1,23 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 const greenwoodPluginCopyRobots = [{
   type: 'copy',
   name: 'plugin-copy-robots',
-  provider: (compilation) => {
+  provider: async (compilation) => {
     const fileName = 'robots.txt';
     const { outputDir, userWorkspace } = compilation.context;
     const robotsPathUrl = new URL(`./${fileName}`, userWorkspace);
     const assets = [];
 
-    if (fs.existsSync(robotsPathUrl.pathname)) {
+    try {
+      await fs.access(robotsPathUrl);
+
       assets.push({
         from: robotsPathUrl,
         to: new URL(`./${fileName}`, outputDir)
       });
+    } catch (e) {
+
     }
 
     return assets;

--- a/packages/cli/src/plugins/resource/plugin-api-routes.js
+++ b/packages/cli/src/plugins/resource/plugin-api-routes.js
@@ -18,13 +18,13 @@ class ApiRoutesResource extends ResourceInterface {
     try {
       // TODO Could this existence check be derived from the graph instead, like pages are?
       // https://github.com/ProjectEvergreen/greenwood/issues/946
-      if (protocol.startsWith('http') === 0 && pathname.startsWith('/api')) {
+      if (protocol.startsWith('http') && pathname.startsWith('/api')) {
         await fs.access(apiPathUrl);
 
         return true;
       }
     } catch (error) {
-      
+
     }
   }
 

--- a/packages/cli/src/plugins/resource/plugin-api-routes.js
+++ b/packages/cli/src/plugins/resource/plugin-api-routes.js
@@ -3,7 +3,7 @@
  * Manages routing to API routes.
  *
  */
-import fs from 'fs/promises';
+import { checkResourceExists } from '../../lib/resource-utils.js';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class ApiRoutesResource extends ResourceInterface {
@@ -15,16 +15,8 @@ class ApiRoutesResource extends ResourceInterface {
     const { protocol, pathname } = url;
     const apiPathUrl = new URL(`.${pathname.replace('/api', '')}.js`, this.compilation.context.apisDir);
 
-    try {
-      // TODO Could this existence check be derived from the graph instead, like pages are?
-      // https://github.com/ProjectEvergreen/greenwood/issues/946
-      if (protocol.startsWith('http') && pathname.startsWith('/api')) {
-        await fs.access(apiPathUrl);
-
-        return true;
-      }
-    } catch (error) {
-
+    if (protocol.startsWith('http') && pathname.startsWith('/api') && await checkResourceExists(apiPathUrl)) {
+      return true;
     }
   }
 

--- a/packages/cli/src/plugins/resource/plugin-api-routes.js
+++ b/packages/cli/src/plugins/resource/plugin-api-routes.js
@@ -12,15 +12,17 @@ class ApiRoutesResource extends ResourceInterface {
   }
 
   async shouldServe(url) {
+    const apiPathUrl = new URL(`.${url.pathname.replace('/api', '')}.js`, this.compilation.context.apisDir);
+
     // TODO Could this existence check be derived from the graph instead, like pages are?
     // https://github.com/ProjectEvergreen/greenwood/issues/946
     return url.protocol.indexOf('http') === 0
       && url.pathname.startsWith('/api')
-      && fs.existsSync(this.compilation.context.apisDir, url.pathname.replace('/api/', ''));
+      && fs.existsSync(apiPathUrl.pathname);
   }
 
   async serve(url, request) {
-    let href = new URL(`./${url.pathname.replace('/api/', '')}.js`, `file://${this.compilation.context.apisDir}`).href;
+    let href = new URL(`./${url.pathname.replace('/api/', '')}.js`, `file://${this.compilation.context.apisDir.pathname}`).href;
 
     // https://github.com/nodejs/modules/issues/307#issuecomment-1165387383
     if (process.env.__GWD_COMMAND__ === 'develop') { // eslint-disable-line no-underscore-dangle
@@ -31,9 +33,8 @@ class ApiRoutesResource extends ResourceInterface {
     const req = new Request(new URL(`${request.url.origin}${url}`), {
       ...request
     });
-    const resp = await handler(req);
 
-    return resp;
+    return await handler(req);
   }
 }
 

--- a/packages/cli/src/plugins/resource/plugin-dev-proxy.js
+++ b/packages/cli/src/plugins/resource/plugin-dev-proxy.js
@@ -20,28 +20,9 @@ class DevProxyResource extends ResourceInterface {
   }
 
   async serve(url, request) {
-    // const baseUrl = request.url.pathname.replace(this.compilation.context.userWorkspace, '');
-    // const proxies = this.compilation.config.devServer.proxy;
-    // // const proxyBaseUrl = Object.entries(proxies).reduce((acc, entry) => {
-    // //   return url.indexOf(entry[0]) >= 0
-    // //     ? `${entry[1]}${baseUrl}`
-    // //     : acc;
-    // // }, baseUrl);
-
     return fetch(request, {
       ...request
     });
-    // return new Response(JSON.stringify(body), {
-    //   headers: {
-    //     'Content-Type': 'application/json'
-    //   }
-    // });
-    // const response = await fetch(proxyBaseUrl)
-    //   .then(res => res.json());
-
-    // return Promise.resolve({
-    //   body: response
-    // });
   }
 }
 

--- a/packages/cli/src/plugins/resource/plugin-dev-proxy.js
+++ b/packages/cli/src/plugins/resource/plugin-dev-proxy.js
@@ -20,9 +20,19 @@ class DevProxyResource extends ResourceInterface {
   }
 
   async serve(url, request) {
-    return fetch(request, {
-      ...request
+    const { pathname } = url;
+    const proxies = this.compilation.config.devServer.proxy;
+    const proxyBaseUrl = Object.entries(proxies).reduce((acc, entry) => {
+      return pathname.indexOf(entry[0]) >= 0
+        ? `${entry[1]}${pathname}`
+        : acc;
+    }, pathname);
+    const requestProxied = new Request(`${proxyBaseUrl}${url.search}`, {
+      method: request.method,
+      headers: request.header
     });
+
+    return await fetch(requestProxied);
   }
 }
 

--- a/packages/cli/src/plugins/resource/plugin-dev-proxy.js
+++ b/packages/cli/src/plugins/resource/plugin-dev-proxy.js
@@ -13,27 +13,35 @@ class DevProxyResource extends ResourceInterface {
   async shouldServe(url) {
     const proxies = this.compilation.config.devServer.proxy || {};
     const hasMatches = Object.entries(proxies).reduce((acc, entry) => {
-      return acc || url.indexOf(entry[0]) >= 0;
+      return acc || url.pathname.indexOf(entry[0]) >= 0;
     }, false);
 
-    return hasMatches;
+    return url.protocol.startsWith('http:') && hasMatches;
   }
 
-  async serve(url) {
-    const baseUrl = url.replace(this.compilation.context.userWorkspace, '');
-    const proxies = this.compilation.config.devServer.proxy;
-    const proxyBaseUrl = Object.entries(proxies).reduce((acc, entry) => {
-      return url.indexOf(entry[0]) >= 0
-        ? `${entry[1]}${baseUrl}`
-        : acc;
-    }, baseUrl);
+  async serve(url, request) {
+    // const baseUrl = request.url.pathname.replace(this.compilation.context.userWorkspace, '');
+    // const proxies = this.compilation.config.devServer.proxy;
+    // // const proxyBaseUrl = Object.entries(proxies).reduce((acc, entry) => {
+    // //   return url.indexOf(entry[0]) >= 0
+    // //     ? `${entry[1]}${baseUrl}`
+    // //     : acc;
+    // // }, baseUrl);
 
-    const response = await fetch(proxyBaseUrl)
-      .then(res => res.json());
-
-    return Promise.resolve({
-      body: response
+    return fetch(request, {
+      ...request
     });
+    // return new Response(JSON.stringify(body), {
+    //   headers: {
+    //     'Content-Type': 'application/json'
+    //   }
+    // });
+    // const response = await fetch(proxyBaseUrl)
+    //   .then(res => res.json());
+
+    // return Promise.resolve({
+    //   body: response
+    // });
   }
 }
 

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -26,6 +26,7 @@ class NodeModulesResource extends ResourceInterface {
   }
 
   // TODO convert node modules util to URL
+  // https://github.com/ProjectEvergreen/greenwood/issues/953v
   async resolve(url) {
     const { projectDirectory } = this.compilation.context;
     const { pathname } = url;

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -41,7 +41,6 @@ class NodeModulesResource extends ResourceInterface {
   async shouldServe(url) {
     const extension = url.pathname.split('.').pop();
 
-    // TODO return this.hasExtension(url) && url.pathname.startsWith('/node_modules/');
     return extension === 'mjs'
       || extension === '' && fs.existsSync(`${url}.js`)
       || extension === 'js' && url.pathname.startsWith('/node_modules/');

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -39,7 +39,12 @@ class NodeModulesResource extends ResourceInterface {
   }
 
   async shouldServe(url) {
-    return this.hasExtension(url) && url.pathname.startsWith('/node_modules/');
+    const extension = url.pathname.split('.').pop();
+
+    // TODO return this.hasExtension(url) && url.pathname.startsWith('/node_modules/');
+    return extension === 'mjs'
+      || extension === '' && fs.existsSync(`${url}.js`)
+      || extension === 'js' && url.pathname.startsWith('/node_modules/');
   }
 
   async serve(url) {

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -55,14 +55,14 @@ class NodeModulesResource extends ResourceInterface {
     const body = await fs.promises.readFile(pathnameExtended, 'utf-8');
 
     return new Response(body, {
-      headers: {
+      headers: new Headers({
         'Content-Type': this.contentType
-      }
+      })
     });
   }
 
   async shouldIntercept(url, request, response) {
-    return response.headers.get('content-type').indexOf('text/html') >= 0;
+    return response.headers.get('Content-Type').indexOf('text/html') >= 0;
   }
 
   async intercept(url, request, response) {

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -103,10 +103,7 @@ class NodeModulesResource extends ResourceInterface {
         </script>
     `);
 
-    // TODO avoid having to rebuild response each time?
-    return new Response(body, {
-      headers: response.headers
-    });
+    return new Response(body);
   }
 }
 

--- a/packages/cli/src/plugins/resource/plugin-source-maps.js
+++ b/packages/cli/src/plugins/resource/plugin-source-maps.js
@@ -4,7 +4,6 @@
  *
  */
 import fs from 'fs';
-import path from 'path';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class SourceMapsResource extends ResourceInterface {
@@ -14,20 +13,15 @@ class SourceMapsResource extends ResourceInterface {
   }
 
   async shouldServe(url) {
-    return Promise.resolve(path.extname(url) === this.extensions[0] && fs.existsSync(url));
+    return `.${url.pathname.split('.').pop()}` === this.extensions[0] && fs.existsSync(url.pathname);
   }
 
   async serve(url) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const sourceMap = fs.readFileSync(url, 'utf-8');
-        
-        resolve({
-          body: sourceMap,
-          contentType: 'application/json'
-        });
-      } catch (e) {
-        reject(e);
+    const body = await fs.promises.readFile(url, 'utf-8');
+
+    return new Response(body, {
+      headers: {
+        'Content-Type': 'text/javascript'
       }
     });
   }

--- a/packages/cli/src/plugins/resource/plugin-source-maps.js
+++ b/packages/cli/src/plugins/resource/plugin-source-maps.js
@@ -3,6 +3,7 @@
  * Detects and fully resolve requests to source map (.map) files.
  *
  */
+import { checkResourceExists } from '../../lib/resource-utils.js';
 import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
@@ -14,14 +15,7 @@ class SourceMapsResource extends ResourceInterface {
   }
 
   async shouldServe(url) {
-    try {
-      if (url.pathname.split('.').pop() === this.extensions[0]) {
-        await fs.access(url);
-        return true;
-      }
-    } catch (e) {
-
-    }
+    return url.pathname.split('.').pop() === this.extensions[0] && await checkResourceExists(url);
   }
 
   async serve(url) {

--- a/packages/cli/src/plugins/resource/plugin-source-maps.js
+++ b/packages/cli/src/plugins/resource/plugin-source-maps.js
@@ -9,11 +9,12 @@ import { ResourceInterface } from '../../lib/resource-interface.js';
 class SourceMapsResource extends ResourceInterface {
   constructor(compilation, options) {
     super(compilation, options);
-    this.extensions = ['.map'];
+    this.extensions = ['map'];
+    this.contentType = 'application/json';
   }
 
   async shouldServe(url) {
-    return `.${url.pathname.split('.').pop()}` === this.extensions[0] && fs.existsSync(url.pathname);
+    return url.pathname.split('.').pop() === this.extensions[0] && fs.existsSync(url.pathname);
   }
 
   async serve(url) {
@@ -21,7 +22,7 @@ class SourceMapsResource extends ResourceInterface {
 
     return new Response(body, {
       headers: {
-        'Content-Type': 'text/javascript'
+        'content-type': this.contentType
       }
     });
   }

--- a/packages/cli/src/plugins/resource/plugin-source-maps.js
+++ b/packages/cli/src/plugins/resource/plugin-source-maps.js
@@ -21,9 +21,9 @@ class SourceMapsResource extends ResourceInterface {
     const body = await fs.promises.readFile(url, 'utf-8');
 
     return new Response(body, {
-      headers: {
-        'content-type': this.contentType
-      }
+      headers: new Headers({
+        'Content-Type': this.contentType
+      })
     });
   }
 }

--- a/packages/cli/src/plugins/resource/plugin-source-maps.js
+++ b/packages/cli/src/plugins/resource/plugin-source-maps.js
@@ -3,7 +3,7 @@
  * Detects and fully resolve requests to source map (.map) files.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class SourceMapsResource extends ResourceInterface {
@@ -14,11 +14,18 @@ class SourceMapsResource extends ResourceInterface {
   }
 
   async shouldServe(url) {
-    return url.pathname.split('.').pop() === this.extensions[0] && fs.existsSync(url.pathname);
+    try {
+      if (url.pathname.split('.').pop() === this.extensions[0]) {
+        fs.access(url);
+        return true;
+      }
+    } catch (error) {
+      
+    }
   }
 
   async serve(url) {
-    const body = await fs.promises.readFile(url, 'utf-8');
+    const body = await fs.readFile(url, 'utf-8');
 
     return new Response(body, {
       headers: new Headers({

--- a/packages/cli/src/plugins/resource/plugin-source-maps.js
+++ b/packages/cli/src/plugins/resource/plugin-source-maps.js
@@ -16,11 +16,11 @@ class SourceMapsResource extends ResourceInterface {
   async shouldServe(url) {
     try {
       if (url.pathname.split('.').pop() === this.extensions[0]) {
-        fs.access(url);
+        await fs.access(url);
         return true;
       }
-    } catch (error) {
-      
+    } catch (e) {
+
     }
   }
 

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -4,7 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
-import fs from 'fs/promises';
+import fs from 'fs';
 import { parse, walk } from 'css-tree';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
@@ -27,7 +27,8 @@ function bundleCss(body, url, projectDirectory) {
           const resolvedUrl = value.startsWith('/node_modules')
             ? new URL(`.${value}`, projectDirectory)
             : new URL(value, url);
-          const importContents = fs.readFile(resolvedUrl, 'utf-8');
+          // TODO intentionally using sync, unless csstree can support an async walk?
+          const importContents = fs.readFileSync(resolvedUrl, 'utf-8');
 
           optimizedCss += bundleCss(importContents, url, projectDirectory);
         } else {
@@ -214,7 +215,7 @@ class StandardCssResource extends ResourceInterface {
   }
 
   async serve(url) {
-    const body = await fs.readFile(url, 'utf-8');
+    const body = await fs.promises.readFile(url, 'utf-8');
 
     return new Response(body, {
       headers: {

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -4,7 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { parse, walk } from 'css-tree';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
@@ -27,7 +27,7 @@ function bundleCss(body, url, projectDirectory) {
           const resolvedUrl = value.startsWith('/node_modules')
             ? new URL(`.${value}`, projectDirectory)
             : new URL(value, url);
-          const importContents = fs.readFileSync(resolvedUrl.pathname, 'utf-8');
+          const importContents = fs.readFile(resolvedUrl, 'utf-8');
 
           optimizedCss += bundleCss(importContents, url, projectDirectory);
         } else {
@@ -214,7 +214,7 @@ class StandardCssResource extends ResourceInterface {
   }
 
   async serve(url) {
-    const body = await fs.promises.readFile(url, 'utf-8');
+    const body = await fs.readFile(url, 'utf-8');
 
     return new Response(body, {
       headers: {

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -206,21 +206,20 @@ function bundleCss(body, url, projectDirectory) {
 class StandardCssResource extends ResourceInterface {
   constructor(compilation, options) {
     super(compilation, options);
-    this.extensions = ['.css'];
+    this.extensions = ['css'];
     this.contentType = 'text/css';
   }
 
-  async serve(url) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const css = await fs.promises.readFile(url, 'utf-8');
+  async shouldServe(url) {
+    return url.protocol === 'file:' && this.extensions.indexOf(url.pathname.split('.').pop()) >= 0;
+  }
 
-        resolve({
-          body: css,
-          contentType: this.contentType
-        });
-      } catch (e) {
-        reject(e);
+  async serve(url) {
+    const body = await fs.promises.readFile(url, 'utf-8');
+
+    return new Response(body, {
+      headers: {
+        'Content-Type': this.contentType
       }
     });
   }

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -218,7 +218,7 @@ class StandardCssResource extends ResourceInterface {
 
     return new Response(body, {
       headers: {
-        'content-type': this.contentType
+        'Content-Type': this.contentType
       }
     });
   }
@@ -227,7 +227,7 @@ class StandardCssResource extends ResourceInterface {
     const { protocol, pathname } = url;
     const isValidCss = pathname.split('.').pop() === this.extensions[0]
       && protocol === 'file:'
-      && response.headers.get('content-type').indexOf(this.contentType) >= 0;
+      && response.headers.get('Content-Type').indexOf(this.contentType) >= 0;
 
     return this.compilation.config.optimization !== 'none' && isValidCss;
   }

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -236,9 +236,7 @@ class StandardCssResource extends ResourceInterface {
     const body = await response.text();
     const optimizedBody = bundleCss(body, url, this.compilation.context.projectDirectory);
 
-    return new Response(optimizedBody, {
-      headers: response.headers
-    });
+    return new Response(optimizedBody);
   }
 }
 

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -27,7 +27,6 @@ function bundleCss(body, url, projectDirectory) {
           const resolvedUrl = value.startsWith('/node_modules')
             ? new URL(`.${value}`, projectDirectory)
             : new URL(value, url);
-          // TODO intentionally using sync, unless csstree can support an async walk?
           const importContents = fs.readFileSync(resolvedUrl, 'utf-8');
 
           optimizedCss += bundleCss(importContents, url, projectDirectory);

--- a/packages/cli/src/plugins/resource/plugin-standard-font.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-font.js
@@ -5,7 +5,6 @@
  *
  */
 import fs from 'fs';
-import path from 'path';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class StandardFontResource extends ResourceInterface {
@@ -13,24 +12,37 @@ class StandardFontResource extends ResourceInterface {
     super(compilation, options);
 
     // https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Web_fonts
-    this.extensions = ['.woff2', '.woff', '.ttf', '.eot'];
+    this.extensions = ['woff2', 'woff', 'ttf', 'eot'];
+  }
+
+  async shouldServe(url) {
+    return this.extensions.indexOf(url.pathname.split('.').pop()) >= 0;
   }
 
   async serve(url) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const ext = path.extname(url).replace('.', '');
-        const contentType = ext === 'eot' ? 'application/vnd.ms-fontobject' : ext;
-        const body = await fs.promises.readFile(url);
+    const extension = url.pathname.split('.').pop();
+    const contentType = extension === 'eot' ? 'application/vnd.ms-fontobject' : extension;
+    const body = await fs.promises.readFile(url);
 
-        resolve({
-          body,
-          contentType
-        });
-      } catch (e) {
-        reject(e);
+    return new Response(body, {
+      headers: {
+        'Content-Type': contentType
       }
     });
+    // return new Promise(async (resolve, reject) => {
+    //   try {
+    //     const ext = path.extname(url).replace('.', '');
+    //     const contentType = ext === 'eot' ? 'application/vnd.ms-fontobject' : ext;
+    //     const body = await fs.promises.readFile(url);
+
+    //     resolve({
+    //       body,
+    //       contentType
+    //     });
+    //   } catch (e) {
+    //     reject(e);
+    //   }
+    // });
   }
 }
 

--- a/packages/cli/src/plugins/resource/plugin-standard-font.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-font.js
@@ -29,20 +29,6 @@ class StandardFontResource extends ResourceInterface {
         'Content-Type': contentType
       }
     });
-    // return new Promise(async (resolve, reject) => {
-    //   try {
-    //     const ext = path.extname(url).replace('.', '');
-    //     const contentType = ext === 'eot' ? 'application/vnd.ms-fontobject' : ext;
-    //     const body = await fs.promises.readFile(url);
-
-    //     resolve({
-    //       body,
-    //       contentType
-    //     });
-    //   } catch (e) {
-    //     reject(e);
-    //   }
-    // });
   }
 }
 

--- a/packages/cli/src/plugins/resource/plugin-standard-font.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-font.js
@@ -4,7 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class StandardFontResource extends ResourceInterface {
@@ -22,7 +22,7 @@ class StandardFontResource extends ResourceInterface {
   async serve(url) {
     const extension = url.pathname.split('.').pop();
     const contentType = extension === 'eot' ? 'application/vnd.ms-fontobject' : extension;
-    const body = await fs.promises.readFile(url);
+    const body = await fs.readFile(url);
 
     return new Response(body, {
       headers: new Headers({

--- a/packages/cli/src/plugins/resource/plugin-standard-font.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-font.js
@@ -25,9 +25,9 @@ class StandardFontResource extends ResourceInterface {
     const body = await fs.promises.readFile(url);
 
     return new Response(body, {
-      headers: {
+      headers: new Headers({
         'Content-Type': contentType
-      }
+      })
     });
   }
 }

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -378,7 +378,6 @@ class StandardHtmlResource extends ResourceInterface {
       `);
     }
 
-    // TODO avoid having to rebuild response each time?
     return new Response(body, {
       headers: new Headers({
         'Content-Type': this.contentType

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -207,8 +207,6 @@ class StandardHtmlResource extends ResourceInterface {
     const pathname = url.pathname;
     // const relativeUrl = this.getRelativeUserworkspaceUrl(url).replace(/\\/g, '/'); // and handle for windows
     const isClientSideRoute = this.compilation.graph[0].isSPA && pathname.split('.').pop() === '' && (request.headers?.accept || '').indexOf(this.contentType) >= 0;
-    console.debug('StandardHtmlResource.shouldServe', url.pathname);
-    console.debug('HEADERS', request.headers);
     const hasMatchingRoute = this.compilation.graph.filter((node) => {
       return node.route === pathname;
     }).length === 1;
@@ -216,9 +214,7 @@ class StandardHtmlResource extends ResourceInterface {
     return hasMatchingRoute || isClientSideRoute;
   }
 
-  async serve(url, request) {
-    console.debug('StandardHtmlResource.serve', url.pathname);
-    console.debug('HEADERS', request.headers);
+  async serve(url) {
     const { config } = this.compilation;
     const { pagesDir, userTemplatesDir } = this.compilation.context;
     const { interpolateFrontmatter } = config;
@@ -392,7 +388,7 @@ class StandardHtmlResource extends ResourceInterface {
       `);
     }
 
-    console.debug({ body });
+    // TODO avoid having to rebuild response each time?
     return new Response(body, {
       headers: {
         'Content-Type': this.contentType

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -215,7 +215,7 @@ class StandardHtmlResource extends ResourceInterface {
     const isSpaRoute = this.compilation.graph[0].isSPA;
     const matchingRoute = this.compilation.graph.find((node) => node.route === pathname);
     const filePath = !matchingRoute.external ? matchingRoute.path : '';
-    const isMarkdownContent = matchingRoute.filename.split('.').pop() === 'md';
+    const isMarkdownContent = (matchingRoute?.filename || '').split('.').pop() === 'md';
 
     let customImports = [];
     let body = '';

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -32,6 +32,7 @@ const getPageTemplate = async (filePath, templatesDir, template, contextPlugins 
   const customPluginDefaultPageTemplates = getCustomPageTemplates(contextPlugins, 'page');
   const customPluginPageTemplates = getCustomPageTemplates(contextPlugins, template);
   const extension = filePath.split('.').pop();
+  console.debug({ filePath, extension, template });
   const is404Page = path.basename(filePath).indexOf('404') === 0 && extension === 'html';
   let contents;
 
@@ -43,12 +44,12 @@ const getPageTemplate = async (filePath, templatesDir, template, contextPlugins 
   } else if (extension === 'html' && fs.existsSync(filePath)) {
     // if the page is already HTML, use that as the template, NOT accounting for 404 pages
     contents = await fs.promises.readFile(filePath, 'utf-8');
-  } else if (customPluginDefaultPageTemplates.length > 0 || (!is404Page && fs.existsSync(`${templatesDir}/page.html`))) {
+  } else if (customPluginDefaultPageTemplates.length > 0 || (!is404Page && fs.existsSync(new URL('./page.html', templatesDir).pathname))) {
     // else look for default page template from the user
     // and 404 pages should be their own "top level" template
     contents = customPluginDefaultPageTemplates.length > 0
       ? await fs.promises.readFile(`${customPluginDefaultPageTemplates[0]}/page.html`, 'utf-8')
-      : await fs.promises.readFile(new URL('./page.html', templatesDir).pathname);
+      : await fs.promises.readFile(new URL('./page.html', templatesDir), 'utf-8');
   } else if (is404Page && !fs.existsSync(new URL('./404.html', pagesDir).pathname)) {
     contents = await fs.promises.readFile(new URL('../../templates/404.html', import.meta.url).pathname, 'utf-8');
   } else {

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -463,9 +463,7 @@ class StandardHtmlResource extends ResourceInterface {
     // TODO clean up lit-polyfill as part of https://github.com/ProjectEvergreen/greenwood/issues/728
     body = body.replace(/<script src="(.*lit\/polyfill-support.js)"><\/script>/, '');
 
-    return new Response(body, {
-      headers: response.headers
-    });
+    return new Response(body);
   }
 }
 

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -471,7 +471,8 @@ class StandardHtmlResource extends ResourceInterface {
       }
     }
 
-    // TODO clean up lit-polyfill as part of https://github.com/ProjectEvergreen/greenwood/issues/728
+    // TODO clean up lit-polyfill
+    // https://github.com/ProjectEvergreen/greenwood/issues/728
     body = body.replace(/<script src="(.*lit\/polyfill-support.js)"><\/script>/, '');
 
     return new Response(body);

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -32,7 +32,6 @@ const getPageTemplate = async (filePath, templatesDir, template, contextPlugins 
   const customPluginDefaultPageTemplates = getCustomPageTemplates(contextPlugins, 'page');
   const customPluginPageTemplates = getCustomPageTemplates(contextPlugins, template);
   const extension = filePath.split('.').pop();
-  console.debug({ filePath, extension, template });
   const is404Page = path.basename(filePath).indexOf('404') === 0 && extension === 'html';
   let contents;
 

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -27,10 +27,7 @@ function getCustomPageTemplatesFromPlugins(contextPlugins, templateName) {
         if (templateName) {
           fs.access(new URL(`./${templateName}.html`, templateDirUrl)).then(() => true);
         }
-        // await fs.access(new URL(`./${templateName}.html`, templateDirUrl));
-
-        // return true;
-      } catch(e) {
+      } catch (e) {
         return false;
       }
     });
@@ -51,19 +48,19 @@ const getPageTemplate = async (filePath, { userTemplatesDir, pagesDir, projectDi
   try {
     await fs.access(new URL(`./${template}.html`, userTemplatesDir));
     hasCustomTemplate = true;
-  } catch(e) {
-    console.debug('111', { e })
+  } catch (e) {
+    console.debug('111', { e });
   }
 
   // check page is already HTML
   try {
     await fs.access(new URL(`./${filePath}`, projectDirectory));
 
-    if(extension === 'html') {
+    if (extension === 'html') {
       isHtmlPage = true;
     }
-  } catch(e) {
-    console.debug('222', { e })
+  } catch (e) {
+    console.debug('222', { e });
   }
 
   // check for default page template
@@ -71,8 +68,8 @@ const getPageTemplate = async (filePath, { userTemplatesDir, pagesDir, projectDi
     // fs.existsSync(new URL('./page.html', templatesDir).pathname))
     await fs.access(new URL('./page.html', userTemplatesDir));
     hasPageTemplate = true;
-  } catch(e) {
-    console.debug('333', { e })
+  } catch (e) {
+    console.debug('333', { e });
   }
 
   // check for custom 404 page
@@ -80,7 +77,7 @@ const getPageTemplate = async (filePath, { userTemplatesDir, pagesDir, projectDi
     // fs.existsSync(new URL('./404.html', pagesDir).pathname)
     await fs.access(new URL('./404.html', pagesDir));
     hasCustom404Page = true;
-  } catch(e) {
+  } catch (e) {
     console.debug('444', { e })
   }
 
@@ -120,7 +117,7 @@ const getAppTemplate = async (pageTemplateContents, templatesDir, customImports 
   try {
     await fs.access(userAppTemplateUrl);
     hasCustomUserAppTemplate = true;
-  } catch(e) {
+  } catch (e) {
     console.debug('userAPpTemplatePAtj', { e });
   }
 
@@ -245,7 +242,7 @@ const getUserScripts = async (contents, context) => {
       // fs.existsSync(new URL('./package.json', userWorkspace).pathname
       await fs.access(monorepoPackageJsonUrl);
       hasMonorepoPackageJson = true;
-    } catch(e) {
+    } catch (e) {
 
     }
 
@@ -254,7 +251,7 @@ const getUserScripts = async (contents, context) => {
       // fs.existsSync(new URL('./package.json', projectDirectory).pathname)
       await fs.access(topLevelPackageJsonUrl);
       hasTopLevelPackageJson = true;
-    } catch(e) {
+    } catch (e) {
 
     }
 

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -22,10 +22,10 @@ function getCustomPageTemplatesFromPlugins(contextPlugins, templateName) {
   return contextPlugins
     .map(plugin => plugin.templates)
     .flat()
-    .filter((templateDirUrl) => {
+    .filter(async(templateDirUrl) => {
       try {
         if (templateName) {
-          fs.access(new URL(`./${templateName}.html`, templateDirUrl)).then(() => true);
+          await fs.access(new URL(`./${templateName}.html`, templateDirUrl)).then(() => true);
         }
       } catch (e) {
         return false;

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -380,14 +380,14 @@ class StandardHtmlResource extends ResourceInterface {
 
     // TODO avoid having to rebuild response each time?
     return new Response(body, {
-      headers: {
-        'content-type': this.contentType
-      }
+      headers: new Headers({
+        'Content-Type': this.contentType
+      })
     });
   }
 
   async shouldOptimize(url, response) {
-    return response.headers.get('content-type').indexOf(this.contentType) >= 0;
+    return response.headers.get('Content-Type').indexOf(this.contentType) >= 0;
   }
 
   async optimize(url, response) {

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -103,10 +103,10 @@ const getPageTemplate = async (filePath, { userTemplatesDir, pagesDir, projectDi
       ? await fs.readFile(new URL('./page.html', customPluginDefaultPageTemplates[0]), 'utf-8')
       : await fs.readFile(new URL('./page.html', userTemplatesDir), 'utf-8');
   } else if (is404Page && !hasCustom404Page) {
-    contents = await fs.readFile(new URL('../../templates/404.html', import.meta.url).pathname, 'utf-8');
+    contents = await fs.readFile(new URL('../../templates/404.html', import.meta.url), 'utf-8');
   } else {
     // fallback to using Greenwood's stock page template
-    contents = await fs.readFile(new URL('../../templates/page.html', import.meta.url).pathname, 'utf-8');
+    contents = await fs.readFile(new URL('../../templates/page.html', import.meta.url), 'utf-8');
   }
 
   return contents;

--- a/packages/cli/src/plugins/resource/plugin-standard-image.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-image.js
@@ -22,29 +22,15 @@ class StandardFontResource extends ResourceInterface {
   async serve(url) {
     const extension = url.pathname.split('.').pop();
     const type = extension === 'svg' ? `${extension}+xml` : extension;
-    const exts = [...this.extensions];
-    const isIco = extension === 'ico';
-    let body = '';
-    let contentType = '';
-
-    if (exts.includes(extension)) {
-      contentType = `image/${type}`;
-
-      if (extension === 'svg') {
-        body = await fs.promises.readFile(url, 'utf-8');
-      } else {
-        // TODO this doesn't seem to work
-        body = await fs.promises.readFile(url); 
-      }
-    } else if (isIco) {
-      contentType = 'image/x-icon';
-      body = await fs.promises.readFile(url);
-    }
+    const body = await fs.promises.readFile(url);
+    const contentType = extension === 'ico'
+      ? 'x-icon'
+      : type;
 
     // TODO avoid having to rebuild response each time?
     return new Response(body, {
       headers: {
-        'content-type': contentType
+        'content-type': `image/${contentType}`
       }
     });
   }

--- a/packages/cli/src/plugins/resource/plugin-standard-image.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-image.js
@@ -27,7 +27,6 @@ class StandardFontResource extends ResourceInterface {
       ? 'x-icon'
       : type;
 
-    // TODO avoid having to rebuild response each time?
     return new Response(body, {
       headers: new Headers({
         'Content-Type': `image/${contentType}`

--- a/packages/cli/src/plugins/resource/plugin-standard-image.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-image.js
@@ -21,7 +21,7 @@ class StandardFontResource extends ResourceInterface {
 
   async serve(url) {
     const extension = url.pathname.split('.').pop();
-    const type = extension === 'svg' ? `${ext}+xml` : extension;
+    const type = extension === 'svg' ? `${extension}+xml` : extension;
     const exts = [...this.extensions];
     const isIco = extension === 'ico';
     let body = '';
@@ -33,6 +33,7 @@ class StandardFontResource extends ResourceInterface {
       if (extension === 'svg') {
         body = await fs.promises.readFile(url, 'utf-8');
       } else {
+        // TODO this doesn't seem to work
         body = await fs.promises.readFile(url); 
       }
     } else if (isIco) {
@@ -40,9 +41,10 @@ class StandardFontResource extends ResourceInterface {
       body = await fs.promises.readFile(url);
     }
 
+    // TODO avoid having to rebuild response each time?
     return new Response(body, {
       headers: {
-        'Content-Type': contentType
+        'content-type': contentType
       }
     });
   }

--- a/packages/cli/src/plugins/resource/plugin-standard-image.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-image.js
@@ -5,7 +5,6 @@
  *
  */
 import fs from 'fs';
-import path from 'path';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class StandardFontResource extends ResourceInterface {
@@ -13,38 +12,37 @@ class StandardFontResource extends ResourceInterface {
     super(compilation, options);
 
     // https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types
-    this.extensions = ['.avif', '.webp', '.jpg', '.jpeg', '.png', '.gif', '.svg', '.ico'];
+    this.extensions = ['avif', 'webp', 'jpg', 'jpeg', 'png', 'gif', 'svg', 'ico'];
+  }
+
+  async shouldServe(url) {
+    return url.protocol === 'file:' && this.extensions.indexOf(url.pathname.split('.').pop()) >= 0;
   }
 
   async serve(url) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        let body = '';
-        let contentType = '';
-        const ext = path.extname(url);
-        const type = ext === '.svg'
-          ? `${ext.replace('.', '')}+xml`
-          : ext.replace('.', '');
+    const extension = url.pathname.split('.').pop();
+    const type = extension === 'svg' ? `${ext}+xml` : extension;
+    const exts = [...this.extensions];
+    const isIco = extension === 'ico';
+    let body = '';
+    let contentType = '';
 
-        if (['.avif', '.webp', '.jpg', '.jpeg', '.png', '.gif', '.svg'].includes(ext)) {
-          contentType = `image/${type}`;
+    if (exts.includes(extension)) {
+      contentType = `image/${type}`;
 
-          if (ext === '.svg') {
-            body = await fs.promises.readFile(url, 'utf-8');
-          } else {
-            body = await fs.promises.readFile(url); 
-          }
-        } else if (['.ico'].includes(ext)) {
-          contentType = 'image/x-icon';
-          body = await fs.promises.readFile(url);
-        }
+      if (extension === 'svg') {
+        body = await fs.promises.readFile(url, 'utf-8');
+      } else {
+        body = await fs.promises.readFile(url); 
+      }
+    } else if (isIco) {
+      contentType = 'image/x-icon';
+      body = await fs.promises.readFile(url);
+    }
 
-        resolve({
-          body,
-          contentType
-        });
-      } catch (e) {
-        reject(e);
+    return new Response(body, {
+      headers: {
+        'Content-Type': contentType
       }
     });
   }

--- a/packages/cli/src/plugins/resource/plugin-standard-image.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-image.js
@@ -4,7 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class StandardFontResource extends ResourceInterface {
@@ -22,7 +22,7 @@ class StandardFontResource extends ResourceInterface {
   async serve(url) {
     const extension = url.pathname.split('.').pop();
     const type = extension === 'svg' ? `${extension}+xml` : extension;
-    const body = await fs.promises.readFile(url);
+    const body = await fs.readFile(url);
     const contentType = extension === 'ico'
       ? 'x-icon'
       : type;

--- a/packages/cli/src/plugins/resource/plugin-standard-image.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-image.js
@@ -29,9 +29,9 @@ class StandardFontResource extends ResourceInterface {
 
     // TODO avoid having to rebuild response each time?
     return new Response(body, {
-      headers: {
-        'content-type': `image/${contentType}`
-      }
+      headers: new Headers({
+        'Content-Type': `image/${contentType}`
+      })
     });
   }
 }

--- a/packages/cli/src/plugins/resource/plugin-standard-javascript.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-javascript.js
@@ -11,21 +11,20 @@ import terser from '@rollup/plugin-terser';
 class StandardJavaScriptResource extends ResourceInterface {
   constructor(compilation, options) {
     super(compilation, options);
-    this.extensions = ['.js'];
+    this.extensions = ['js'];
     this.contentType = 'text/javascript';
   }
 
+  async shouldServe(url) {
+    return url.protocol === 'file:' && this.extensions.indexOf(url.pathname.split('.').pop()) >= 0;
+  }
+
   async serve(url) {
-    return new Promise(async(resolve, reject) => {
-      try {
-        const body = await fs.promises.readFile(url, 'utf-8');
+    const body = await fs.promises.readFile(url, 'utf-8');
     
-        resolve({
-          body,
-          contentType: this.contentType
-        });
-      } catch (e) {
-        reject(e);
+    return new Response(body, {
+      headers: {
+        'Content-Type': this.contentType
       }
     });
   }

--- a/packages/cli/src/plugins/resource/plugin-standard-javascript.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-javascript.js
@@ -4,7 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 import terser from '@rollup/plugin-terser';
 
@@ -20,8 +20,8 @@ class StandardJavaScriptResource extends ResourceInterface {
   }
 
   async serve(url) {
-    const body = await fs.promises.readFile(url, 'utf-8');
-    
+    const body = await fs.readFile(url, 'utf-8');
+
     return new Response(body, {
       headers: {
         'Content-Type': this.contentType

--- a/packages/cli/src/plugins/resource/plugin-standard-javascript.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-javascript.js
@@ -16,7 +16,7 @@ class StandardJavaScriptResource extends ResourceInterface {
   }
 
   async shouldServe(url) {
-    return url.protocol === 'file:' && this.extensions.indexOf(url.pathname.split('.').pop()) >= 0;
+    return url.protocol === 'file:' && this.extensions.includes(url.pathname.split('.').pop());
   }
 
   async serve(url) {

--- a/packages/cli/src/plugins/resource/plugin-standard-json.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-json.js
@@ -32,9 +32,9 @@ class StandardJsonResource extends ResourceInterface {
     const contents = await fs.promises.readFile(finalUrl, 'utf-8');
 
     return new Response(contents, {
-      headers: {
+      headers: new Headers({
         'Content-Type': this.contentType
-      }
+      })
     });
   }
 }

--- a/packages/cli/src/plugins/resource/plugin-standard-json.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-json.js
@@ -18,7 +18,7 @@ class StandardJsonResource extends ResourceInterface {
     const { protocol, pathname } = url;
     const isJson = pathname.split('.').pop() === this.extensions[0];
     const isGraphJson = pathname === '/graph.json';
-    const isWorkspaceFile = false;
+    let isWorkspaceFile = false;
     
     try {
       if (protocol === 'file:') {
@@ -26,7 +26,7 @@ class StandardJsonResource extends ResourceInterface {
         isWorkspaceFile = true;
       }
     } catch (error) {
-      
+
     }
 
     return isJson && (isWorkspaceFile || isGraphJson);

--- a/packages/cli/src/plugins/resource/plugin-standard-json.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-json.js
@@ -4,7 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class StandardJsonResource extends ResourceInterface {
@@ -18,7 +18,16 @@ class StandardJsonResource extends ResourceInterface {
     const { protocol, pathname } = url;
     const isJson = pathname.split('.').pop() === this.extensions[0];
     const isGraphJson = pathname === '/graph.json';
-    const isWorkspaceFile = protocol === 'file:' && fs.existsSync(url);
+    const isWorkspaceFile = false;
+    
+    try {
+      if (protocol === 'file:') {
+        await fs.access(url);
+        isWorkspaceFile = true;
+      }
+    } catch (error) {
+      
+    }
 
     return isJson && (isWorkspaceFile || isGraphJson);
   }
@@ -29,7 +38,7 @@ class StandardJsonResource extends ResourceInterface {
     const finalUrl = pathname.startsWith('/graph.json')
       ? new URL('./graph.json', scratchDir)
       : url;
-    const contents = await fs.promises.readFile(finalUrl, 'utf-8');
+    const contents = await fs.readFile(finalUrl, 'utf-8');
 
     return new Response(contents, {
       headers: new Headers({

--- a/packages/cli/src/plugins/resource/plugin-standard-json.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-json.js
@@ -5,38 +5,35 @@
  *
  */
 import fs from 'fs';
-import path from 'path';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class StandardJsonResource extends ResourceInterface {
   constructor(compilation, options) {
     super(compilation, options);
-    this.extensions = ['.json'];
+    this.extensions = ['json'];
     this.contentType = 'application/json';
   }
 
   async shouldServe(url) {
-    return Promise.resolve(
-      url.indexOf('graph.json') >= 0 ||
-      path.extname(url) === '.json' && fs.existsSync(url)
-    );
+    const { protocol, pathname } = url;
+    const isJson = pathname.split('.').pop() === this.extensions[0];
+    const isGraphJson = pathname === '/graph.json';
+    const isWorkspaceFile = protocol === 'file:' && fs.existsSync(url);
+
+    return isJson && (isWorkspaceFile || isGraphJson);
   }
 
   async serve(url) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const { scratchDir } = this.compilation.context;
-        const filePath = url.indexOf('graph.json') >= 0
-          ? `${scratchDir}/graph.json`
-          : url;
-        const contents = await fs.promises.readFile(filePath, 'utf-8');
+    const { pathname } = url;
+    const { scratchDir } = this.compilation.context;
+    const finalUrl = pathname.startsWith('/graph.json')
+      ? new URL('./graph.json', scratchDir)
+      : url;
+    const contents = await fs.promises.readFile(finalUrl, 'utf-8');
 
-        resolve({
-          body: JSON.parse(contents),
-          contentType: this.contentType
-        });
-      } catch (e) {
-        reject(e);
+    return new Response(contents, {
+      headers: {
+        'Content-Type': this.contentType
       }
     });
   }

--- a/packages/cli/src/plugins/resource/plugin-standard-json.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-json.js
@@ -4,6 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
+import { checkResourceExists } from '../../lib/resource-utils.js';
 import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
@@ -18,16 +19,7 @@ class StandardJsonResource extends ResourceInterface {
     const { protocol, pathname } = url;
     const isJson = pathname.split('.').pop() === this.extensions[0];
     const isGraphJson = pathname === '/graph.json';
-    let isWorkspaceFile = false;
-    
-    try {
-      if (protocol === 'file:') {
-        await fs.access(url);
-        isWorkspaceFile = true;
-      }
-    } catch (error) {
-
-    }
+    const isWorkspaceFile = protocol === 'file:' && await checkResourceExists(url);
 
     return isJson && (isWorkspaceFile || isGraphJson);
   }

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -30,11 +30,10 @@ class StaticRouterResource extends ResourceInterface {
     const { pathname, protocol } = url;
     const contentType = response.headers.get('Content-Type') || '';
 
-    // TODO should this also happen during development too?
     return process.env.__GWD_COMMAND__ === 'build' // eslint-disable-line no-underscore-dangle
       && this.compilation.config.staticRouter
       && !pathname.startsWith('/404')
-      && protocol === 'http:' || contentType.indexOf(this.contentType) >= 0;
+      && (protocol === 'http:' && contentType.indexOf(this.contentType) >= 0);
   }
 
   async intercept(url, request, response) {

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -60,7 +60,7 @@ class StaticRouterResource extends ResourceInterface {
     const { outputDir } = this.compilation.context;
     const partial = body.match(/<body>(.*)<\/body>/s)[0].replace('<body>', '').replace('</body>', '');
     const outputPartialDirUrl = new URL(`./_routes${url.pathname}`, outputDir);
-    const outputPartialDirPathUrl = new URL(`file://${outputPartialDirUrl.pathname.split('/').slice(0, -1).join('/')}`);
+    const outputPartialDirPathUrl = new URL(`file://${outputPartialDirUrl.pathname.split('/').slice(0, -1).join('/').concat('/')}`);
     let currentTemplate;
 
     const routeTags = this.compilation.graph
@@ -90,12 +90,6 @@ class StaticRouterResource extends ResourceInterface {
           recursive: true
         });
       }
-      
-      // if (!fs.existsSync(outputPartialDirPath)) {
-      //   fs.mkdirSync(outputPartialDirPath, {
-      //     recursive: true
-      //   });
-      // }
 
       await fs.writeFile(new URL('./index.html', outputPartialDirUrl), partial);
     }

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -51,7 +51,7 @@ class StaticRouterResource extends ResourceInterface {
   async shouldOptimize(url, response) {
     return this.compilation.config.staticRouter
       && !url.pathname.startsWith('/404')
-      && (response.headers.get('Content-Type') || response.headers.get('content-type')).indexOf(this.contentType) >= 0;
+      && response.headers.get('Content-Type').indexOf(this.contentType) >= 0;
   }
 
   async optimize(url, response) {

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -35,7 +35,7 @@ class StaticRouterResource extends ResourceInterface {
     return process.env.__GWD_COMMAND__ === 'build' // eslint-disable-line no-underscore-dangle
       && this.compilation.config.staticRouter
       && !pathname.startsWith('/404')
-      && pathname.split('.').pop() === 'html' || (contentType && contentType.indexOf('text/html') >= 0);
+      && pathname.split('.').pop() === 'html' || (contentType && contentType.indexOf(this.contentType) >= 0);
   }
 
   async intercept(url, request, response) {

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -28,7 +28,7 @@ class StaticRouterResource extends ResourceInterface {
 
   async shouldIntercept(url, request, response) {
     const { pathname, protocol } = url;
-    const contentType = response.headers.get['content-type'] || '';
+    const contentType = response.headers.get['Content-Type'] || '';
 
     // TODO should this also happen during development too?
     return process.env.__GWD_COMMAND__ === 'build' // eslint-disable-line no-underscore-dangle
@@ -54,7 +54,7 @@ class StaticRouterResource extends ResourceInterface {
   async shouldOptimize(url, response) {
     return this.compilation.config.staticRouter
       && !url.pathname.startsWith('/404')
-      && response.headers.get('content-type').indexOf(this.contentType) >= 0;
+      && response.headers.get('Content-Type').indexOf(this.contentType) >= 0;
   }
 
   async optimize(url, response) {

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -28,7 +28,7 @@ class StaticRouterResource extends ResourceInterface {
 
   async shouldIntercept(url, request, response) {
     const { pathname, protocol } = url;
-    const contentType = response.headers.get['Content-Type'] || '';
+    const contentType = response.headers.get('Content-Type') || '';
 
     // TODO should this also happen during development too?
     return process.env.__GWD_COMMAND__ === 'build' // eslint-disable-line no-underscore-dangle
@@ -45,16 +45,13 @@ class StaticRouterResource extends ResourceInterface {
       </head>
     `);
 
-    // TODO avoid having to rebuild response each time?
-    return new Response(body, {
-      headers: response.headers
-    });
+    return new Response(body);
   }
 
   async shouldOptimize(url, response) {
     return this.compilation.config.staticRouter
       && !url.pathname.startsWith('/404')
-      && response.headers.get('Content-Type').indexOf(this.contentType) >= 0;
+      && (response.headers.get('Content-Type') || response.headers.get('content-type')).indexOf(this.contentType) >= 0;
   }
 
   async optimize(url, response) {
@@ -114,10 +111,7 @@ class StaticRouterResource extends ResourceInterface {
         </body>
       `);
 
-    // TODO avoid having to rebuild response each time?
-    return new Response(body, {
-      headers: response.headers
-    });
+    return new Response(body);
   }
 }
 

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -8,7 +8,6 @@
 import fs from 'fs';
 import path from 'path';
 import { ResourceInterface } from '../../lib/resource-interface.js';
-import { fileURLToPath, URL } from 'url';
 
 class StaticRouterResource extends ResourceInterface {
   constructor(compilation, options) {
@@ -18,20 +17,16 @@ class StaticRouterResource extends ResourceInterface {
     this.libPath = '@greenwood/router/router.js';
   }
 
-  async shouldResolve(url) {
-    return Promise.resolve(url.indexOf(this.libPath) >= 0);
+  async shouldResolve(request) {
+    const url = new URL(request.url);
+
+    return url.pathname.indexOf(this.libPath) >= 0;
   }
 
   async resolve() {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const routerUrl = fileURLToPath(new URL('../../lib/router.js', import.meta.url));
-
-        resolve(routerUrl);
-      } catch (e) {
-        reject(e);
-      }
-    });
+    const routerUrl = new URL('../../lib/router.js', import.meta.url);
+    
+    return new Request(`file://${routerUrl.pathname}`);
   }
 
   async shouldIntercept(url, body, headers = { request: {} }) {

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -5,6 +5,7 @@
  * This is a Greenwood default plugin.
  *
  */
+import { checkResourceExists } from '../../lib/resource-utils.js';
 import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
@@ -83,9 +84,7 @@ class StaticRouterResource extends ResourceInterface {
       });
 
     if (isStaticRoute) {
-      try {
-        await fs.access(outputPartialDirPathUrl);
-      } catch (e) {
+      if (!await checkResourceExists(outputPartialDirPathUrl)) {
         await fs.mkdir(outputPartialDirPathUrl, {
           recursive: true
         });

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -34,7 +34,7 @@ class StaticRouterResource extends ResourceInterface {
     // TODO should this also happen during development too?
     return process.env.__GWD_COMMAND__ === 'build' // eslint-disable-line no-underscore-dangle
       && this.compilation.config.staticRouter
-      && pathname.startsWith('/404')
+      && !pathname.startsWith('/404')
       && pathname.split('.').pop() === 'html' || (contentType && contentType.indexOf('text/html') >= 0);
   }
 

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -6,13 +6,12 @@
  *
  */
 import fs from 'fs';
-import path from 'path';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class StaticRouterResource extends ResourceInterface {
   constructor(compilation, options) {
     super(compilation, options);
-    this.extensions = ['.html'];
+    this.extensions = ['html'];
     this.contentType = 'text/html';
     this.libPath = '@greenwood/router/router.js';
   }
@@ -50,74 +49,72 @@ class StaticRouterResource extends ResourceInterface {
     });
   }
 
-  async shouldOptimize(url, body, headers = { request: {} }) {
-    const contentType = headers.request['content-type'];
-
-    return Promise.resolve(this.compilation.config.staticRouter
-      && url !== '404.html'
-      && (path.extname(url) === '.html' || (contentType && contentType.indexOf('text/html') >= 0)));
+  async shouldOptimize(url, response) {
+    return this.compilation.config.staticRouter
+      && !url.pathname.startsWith('/404')
+      && response.headers.get('content-type').indexOf(this.contentType) >= 0;
   }
 
-  async optimize(url, body) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        let currentTemplate;
-        const isStaticRoute = this.compilation.graph.filter(page => page.outputPath === url && url !== '/404/' && !page.isSSR).length === 1;
-        const { outputDir } = this.compilation.context;
-        const bodyContents = body.match(/<body>(.*)<\/body>/s)[0].replace('<body>', '').replace('</body>', '');
-        const outputBundlePath = path.join(`${outputDir}/_routes${url}`);
+  async optimize(url, response) {
+    const { pathname } = url;
+    let body = await response.text();
+    const isStaticRoute = this.compilation.graph.find(page => page.route === pathname && !page.isSSR);
+    const { outputDir } = this.compilation.context;
+    const partial = body.match(/<body>(.*)<\/body>/s)[0].replace('<body>', '').replace('</body>', '');
+    const outputPartialDirUrl = new URL(`./_routes${url.pathname}`, outputDir);
+    const outputPartialDirPath = outputPartialDirUrl.pathname.split('/').slice(0, -1).join('/');
+    let currentTemplate;
 
-        const routeTags = this.compilation.graph
-          .filter(page => !page.isSSR)
-          .filter(page => page.route !== '/404/')
-          .map((page) => {
-            const template = page.filename && path.extname(page.filename) === '.html'
-              ? page.route
-              : page.template;
-            const key = page.route === '/'
-              ? ''
-              : page.route.slice(0, page.route.lastIndexOf('/'));
+    const routeTags = this.compilation.graph
+      .filter(page => !page.isSSR)
+      .filter(page => page.route !== '/404/')
+      .map((page) => {
+        const template = page.filename && page.filename.split('.').pop() === this.extensions[0]
+          ? page.route
+          : page.template;
+        const key = page.route === '/'
+          ? ''
+          : page.route.slice(0, page.route.lastIndexOf('/'));
 
-            if (url === page.outputPath) {
-              currentTemplate = template;
-            }
-            return `
-              <greenwood-route data-route="${page.route}" data-template="${template}" data-key="/_routes${key}/index.html"></greenwood-route>
-            `;
-          });
-
-        if (isStaticRoute) {
-          if (!fs.existsSync(path.dirname(outputBundlePath))) {
-            fs.mkdirSync(path.dirname(outputBundlePath), {
-              recursive: true
-            });
-          }
-
-          await fs.promises.writeFile(outputBundlePath, bodyContents);
+        if (url === page.outputPath) {
+          currentTemplate = template;
         }
+        return `
+          <greenwood-route data-route="${page.route}" data-template="${template}" data-key="/_routes${key}/index.html"></greenwood-route>
+        `;
+      });
 
-        body = body.replace('</head>', `
-          <script>
-            window.__greenwood = window.__greenwood || {};
-            window.__greenwood.currentTemplate = "${currentTemplate}";
-          </script>
-          </head>
-        `.replace(/\n/g, '').replace(/ /g, ''))
-          .replace(/<body>(.*)<\/body>/s, `
-            <body>\n
-
-              <router-outlet>
-                ${bodyContents.replace(/\$/g, '$$$')}\n
-              </router-outlet>
-
-              ${routeTags.join('\n')}
-            </body>
-          `);
-
-        resolve(body);
-      } catch (e) {
-        reject(e);
+    if (isStaticRoute) {
+      if (!fs.existsSync(outputPartialDirPath)) {
+        fs.mkdirSync(outputPartialDirPath, {
+          recursive: true
+        });
       }
+
+      await fs.promises.writeFile(new URL('./index.html', outputPartialDirUrl), partial);
+    }
+
+    body = body.replace('</head>', `
+      <script>
+        window.__greenwood = window.__greenwood || {};
+        window.__greenwood.currentTemplate = "${currentTemplate}";
+      </script>
+      </head>
+    `.replace(/\n/g, '').replace(/ /g, ''))
+      .replace(/<body>(.*)<\/body>/s, `
+        <body>\n
+
+          <router-outlet>
+            ${partial.replace(/\$/g, '$$$')}\n
+          </router-outlet>
+
+          ${routeTags.join('\n')}
+        </body>
+      `);
+
+    // TODO avoid having to rebuild response each time?
+    return new Response(body, {
+      headers: response.headers
     });
   }
 }

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -17,9 +17,7 @@ class StaticRouterResource extends ResourceInterface {
     this.libPath = '@greenwood/router/router.js';
   }
 
-  async shouldResolve(request) {
-    const url = new URL(request.url);
-
+  async shouldResolve(url) {
     return url.pathname.indexOf(this.libPath) >= 0;
   }
 

--- a/packages/cli/src/plugins/resource/plugin-user-workspace.js
+++ b/packages/cli/src/plugins/resource/plugin-user-workspace.js
@@ -24,7 +24,6 @@ class UserWorkspaceResource extends ResourceInterface {
     const { userWorkspace } = this.compilation.context;
     const workspaceUrl = await this.resolveForRelativeUrl(url, userWorkspace);
 
-    console.debug({ workspaceUrl });
     return new Request(workspaceUrl);
   }
 }

--- a/packages/cli/src/plugins/resource/plugin-user-workspace.js
+++ b/packages/cli/src/plugins/resource/plugin-user-workspace.js
@@ -4,7 +4,6 @@
  * This sets the default value for requests in Greenwood.
  *
  */
-import fs from 'fs';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class UserWorkspaceResource extends ResourceInterface {
@@ -15,19 +14,15 @@ class UserWorkspaceResource extends ResourceInterface {
 
   async shouldResolve(url) {
     const { userWorkspace } = this.compilation.context;
-    const pathname = url.pathname;
-    const isWorkspaceFile = pathname !== '/'
-      && pathname.split('.').pop() !== ''
-      && fs.existsSync(new URL(`.${pathname}`, userWorkspace).pathname);
 
-    return !pathname.startsWith('/node_modules/') && isWorkspaceFile;
+    return this.hasExtension(url) && this.resolveForRelativeUrl(url, userWorkspace);
   }
 
   async resolve(url) {
     const { userWorkspace } = this.compilation.context;
-    const workspaceUrl = new URL(`.${url.pathname}`, userWorkspace);
+    const workspaceUrl = this.resolveForRelativeUrl(url, userWorkspace);
 
-    return new Request(`file://${workspaceUrl.pathname}`);
+    return new Request(workspaceUrl);
   }
 }
 

--- a/packages/cli/src/plugins/resource/plugin-user-workspace.js
+++ b/packages/cli/src/plugins/resource/plugin-user-workspace.js
@@ -13,22 +13,19 @@ class UserWorkspaceResource extends ResourceInterface {
     this.extensions = ['*'];
   }
 
-  async shouldResolve(request) {
-    const url = new URL(request.url);
+  async shouldResolve(url) {
     const { userWorkspace } = this.compilation.context;
-    const barePath = url.pathname;
-    const isWorkspaceFile = barePath !== '/'
-      && barePath.split('.').pop() !== ''
-      && fs.existsSync(new URL(`.${barePath}`, userWorkspace).pathname);
+    const pathname = url.pathname;
+    const isWorkspaceFile = pathname !== '/'
+      && pathname.split('.').pop() !== ''
+      && fs.existsSync(new URL(`.${pathname}`, userWorkspace).pathname);
 
-    return barePath.indexOf('node_modules') < 0 && isWorkspaceFile;
+    return !pathname.startsWith('/node_modules/') && isWorkspaceFile;
   }
 
-  async resolve(request) {
+  async resolve(url) {
     const { userWorkspace } = this.compilation.context;
-    const url = new URL(request.url);
-    const barePath = url.pathname;
-    const workspaceUrl = new URL(`.${barePath}`, userWorkspace);
+    const workspaceUrl = new URL(`.${url.pathname}`, userWorkspace);
 
     return new Request(`file://${workspaceUrl.pathname}`);
   }

--- a/packages/cli/src/plugins/resource/plugin-user-workspace.js
+++ b/packages/cli/src/plugins/resource/plugin-user-workspace.js
@@ -15,7 +15,9 @@ class UserWorkspaceResource extends ResourceInterface {
   async shouldResolve(url) {
     const { userWorkspace } = this.compilation.context;
 
-    return this.hasExtension(url) && this.resolveForRelativeUrl(url, userWorkspace);
+    return this.hasExtension(url)
+      && !url.pathname.startsWith('/node_modules')
+      && this.resolveForRelativeUrl(url, userWorkspace);
   }
 
   async resolve(url) {

--- a/packages/cli/src/plugins/resource/plugin-user-workspace.js
+++ b/packages/cli/src/plugins/resource/plugin-user-workspace.js
@@ -17,13 +17,14 @@ class UserWorkspaceResource extends ResourceInterface {
 
     return this.hasExtension(url)
       && !url.pathname.startsWith('/node_modules')
-      && this.resolveForRelativeUrl(url, userWorkspace);
+      && await this.resolveForRelativeUrl(url, userWorkspace);
   }
 
   async resolve(url) {
     const { userWorkspace } = this.compilation.context;
-    const workspaceUrl = this.resolveForRelativeUrl(url, userWorkspace);
+    const workspaceUrl = await this.resolveForRelativeUrl(url, userWorkspace);
 
+    console.debug({ workspaceUrl });
     return new Request(workspaceUrl);
   }
 }

--- a/packages/cli/src/plugins/resource/plugin-user-workspace.js
+++ b/packages/cli/src/plugins/resource/plugin-user-workspace.js
@@ -4,25 +4,27 @@
  * This sets the default value for requests in Greenwood.
  *
  */
+import { resolveForRelativeUrl } from '../../lib/resource-utils.js';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class UserWorkspaceResource extends ResourceInterface {
   constructor(compilation, options) {
     super(compilation, options);
-    this.extensions = ['*'];
   }
 
   async shouldResolve(url) {
     const { userWorkspace } = this.compilation.context;
+    const extension = url.pathname.split('.').pop();
+    const hasExtension = extension !== '' && !extension.startsWith('/');
 
-    return this.hasExtension(url)
+    return hasExtension
       && !url.pathname.startsWith('/node_modules')
-      && await this.resolveForRelativeUrl(url, userWorkspace);
+      && await resolveForRelativeUrl(url, userWorkspace);
   }
 
   async resolve(url) {
     const { userWorkspace } = this.compilation.context;
-    const workspaceUrl = await this.resolveForRelativeUrl(url, userWorkspace);
+    const workspaceUrl = await resolveForRelativeUrl(url, userWorkspace);
 
     return new Request(workspaceUrl);
   }

--- a/packages/cli/src/plugins/server/plugin-livereload.js
+++ b/packages/cli/src/plugins/server/plugin-livereload.js
@@ -65,10 +65,7 @@ class LiveReloadResource extends ResourceInterface {
       </head>
     `);
 
-    // TODO avoid having to rebuild response each time?
-    return new Response(body, {
-      headers: response.headers
-    });
+    return new Response(body);
   }
 }
 

--- a/packages/cli/src/plugins/server/plugin-livereload.js
+++ b/packages/cli/src/plugins/server/plugin-livereload.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import livereload from 'livereload';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 import { ServerInterface } from '../../lib/server-interface.js';
@@ -11,7 +11,7 @@ class LiveReloadServer extends ServerInterface {
   async start() {
     const { userWorkspace } = this.compilation.context;
     const standardPluginsDirectoryPath = new URL('../resource/', import.meta.url);
-    const standardPluginsNames = fs.readdirSync(standardPluginsDirectoryPath)
+    const standardPluginsNames = (await fs.readdir(standardPluginsDirectoryPath))
       .filter(filename => filename.indexOf('plugin-standard') === 0);
     const standardPluginsExtensions = (await Promise.all(standardPluginsNames.map(async (filename) => {
       const pluginImport = await import(new URL(`./${filename}`, standardPluginsDirectoryPath));

--- a/packages/cli/src/plugins/server/plugin-livereload.js
+++ b/packages/cli/src/plugins/server/plugin-livereload.js
@@ -2,7 +2,6 @@ import fs from 'fs';
 import livereload from 'livereload';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 import { ServerInterface } from '../../lib/server-interface.js';
-import { fileURLToPath, pathToFileURL } from 'url';
 
 class LiveReloadServer extends ServerInterface {
   constructor(compilation, options = {}) {
@@ -11,23 +10,17 @@ class LiveReloadServer extends ServerInterface {
 
   async start() {
     const { userWorkspace } = this.compilation.context;
-    const standardPluginsPath = fileURLToPath(new URL('../resource', import.meta.url));
-    const standardPluginsNames = fs.readdirSync(standardPluginsPath)
+    const standardPluginsDirectoryPath = new URL('../resource/', import.meta.url);
+    const standardPluginsNames = fs.readdirSync(standardPluginsDirectoryPath)
       .filter(filename => filename.indexOf('plugin-standard') === 0);
     const standardPluginsExtensions = (await Promise.all(standardPluginsNames.map(async (filename) => {
-      const pluginImport = await import(pathToFileURL(`${standardPluginsPath}/${filename}`));
+      const pluginImport = await import(new URL(`./${filename}`, standardPluginsDirectoryPath));
       const plugin = pluginImport[Object.keys(pluginImport)[0]];
       
       return plugin;
     })))
-      .map((plugin) => {
-        // assume that if it is an array, the second item is a rollup plugin
-        const instance = plugin.length
-          ? plugin[0].provider(this.compilation)
-          : plugin.provider(this.compilation);
-
-        return instance.extensions.flat();
-      })
+      .filter(plugin => plugin.type === 'resource')
+      .map((plugin) => plugin.provider(this.compilation).extensions.flat())
       .flat();
     const customPluginsExtensions = this.compilation.config.plugins
       .filter((plugin) => plugin.type === 'resource')
@@ -49,7 +42,7 @@ class LiveReloadServer extends ServerInterface {
       applyCSSLive: false // https://github.com/napcs/node-livereload/issues/33#issuecomment-693707006
     });
 
-    liveReloadServer.watch(userWorkspace, () => {
+    liveReloadServer.watch(userWorkspace.pathname, () => {
       console.info(`Now watching directory "${userWorkspace}" for changes.`);
       return Promise.resolve(true);
     });

--- a/packages/cli/src/plugins/server/plugin-livereload.js
+++ b/packages/cli/src/plugins/server/plugin-livereload.js
@@ -52,7 +52,7 @@ class LiveReloadServer extends ServerInterface {
 class LiveReloadResource extends ResourceInterface {
   
   async shouldIntercept(url, request, response) {
-    const contentType = response.headers.get('content-type');
+    const contentType = response.headers.get('Content-Type');
 
     return contentType.indexOf('text/html') >= 0 && process.env.__GWD_COMMAND__ === 'develop'; // eslint-disable-line no-underscore-dangle
   }

--- a/packages/cli/test/cases/build.config.error-workspace-absolute/greenwood.config.js
+++ b/packages/cli/test/cases/build.config.error-workspace-absolute/greenwood.config.js
@@ -1,5 +1,3 @@
-import { fileURLToPath, URL } from 'url';
-
 export default {
-  workspace: fileURLToPath(new URL('./noop', import.meta.url))
+  workspace: new URL('./noop', import.meta.url)
 };

--- a/packages/cli/test/cases/build.config.error-workspace/build.config.error-workspace.spec.js
+++ b/packages/cli/test/cases/build.config.error-workspace/build.config.error-workspace.spec.js
@@ -36,12 +36,12 @@ describe('Build Greenwood With: ', function() {
   });
 
   describe('Custom Configuration with a bad value for Workspace', function() {
-    it('should throw an error that workspace path must be a string', async function() {
+    it('should throw an error that workspace path must be a URL', async function() {
       try {
         await runner.setup(outputPath);
         await runner.runCommand(cliPath, 'build');
       } catch (err) {
-        expect(err).to.contain('greenwood.config.js workspace path must be a string');
+        expect(err).to.contain('Error: greenwood.config.js workspace must be an instance of URL');
       }
     });
   });

--- a/packages/cli/test/cases/build.config.workspace-custom/greenwood.config.js
+++ b/packages/cli/test/cases/build.config.workspace-custom/greenwood.config.js
@@ -1,5 +1,3 @@
-import { fileURLToPath, URL } from 'url';
-
 export default {
-  workspace: fileURLToPath(new URL('./www', import.meta.url))
+  workspace: new URL('./www/', import.meta.url)
 };

--- a/packages/cli/test/cases/build.default.ssr/build.default.ssr.spec.js
+++ b/packages/cli/test/cases/build.default.ssr/build.default.ssr.spec.js
@@ -86,7 +86,7 @@ describe('Build Greenwood With: ', function() {
     before(async function() {
       const graph = JSON.parse(await fs.promises.readFile(path.join(outputPath, 'public/graph.json'), 'utf-8'));
       
-      artistsPageGraphData = graph.filter(page => page.route === '/artists/')[0];
+      artistsPageGraphData = graph.find(page => page.route === '/artists/');
 
       return new Promise((resolve, reject) => {
         request.get(`${hostname}/artists/`, (err, res, body) => {

--- a/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
+++ b/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
@@ -1,8 +1,6 @@
 import fs from 'fs';
 import os from 'os';
-import path from 'path';
 import { spawnSync } from 'child_process';
-import { fileURLToPath, URL } from 'url';
 
 const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
 const myThemePackPlugin = () => [{
@@ -10,14 +8,13 @@ const myThemePackPlugin = () => [{
   name: 'my-theme-pack:context',
   provider: () => {
     const { name } = packageJson;
-    const baseDistDir = `node_modules/${name}/dist`;
     const command = os.platform() === 'win32' ? 'npm.cmd' : 'npm';
     const ls = spawnSync(command, ['ls', name]);
     
     const isInstalled = ls.stdout.toString().indexOf('(empty)') < 0;
     const templateLocation = isInstalled
-      ? fileURLToPath(new URL(`${baseDistDir}/layouts`, import.meta.url))
-      : path.join(process.cwd(), 'fixtures/layouts');
+      ? new URL(`./node_modules/${name}/dist/layouts/`, import.meta.url)
+      : new URL('./fixtures/layouts/', import.meta.url);
 
     return {
       templates: [

--- a/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
+++ b/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import os from 'os';
 import { spawnSync } from 'child_process';
 

--- a/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
+++ b/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import { spawnSync } from 'child_process';
 
-const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
+const packageJson = JSON.parse(await fs.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
 const myThemePackPlugin = () => [{
   type: 'context',
   name: 'my-theme-pack:context',

--- a/packages/cli/test/cases/build.plugins.copy/greenwood.config.js
+++ b/packages/cli/test/cases/build.plugins.copy/greenwood.config.js
@@ -1,19 +1,14 @@
-import path from 'path';
-
 export default {
   plugins: [{
     type: 'copy',
     name: 'plugin-copy-prismjs',
     provider: (compilation) => {
       const { projectDirectory, outputDir } = compilation.context;
-      const prismThemeDir = 'node_modules/prismjs/themes';
-      const from = path.join(projectDirectory, prismThemeDir);
-      const to = path.join(outputDir, prismThemeDir);
+      const prismThemeDir = '/node_modules/prismjs/themes/';
+      const from = new URL(`.${prismThemeDir}`, projectDirectory);
+      const to = new URL(`.${prismThemeDir}`, outputDir);
 
-      return [{
-        from,
-        to
-      }];
+      return [{ from, to }];
     }
   }]
 };

--- a/packages/cli/test/cases/build.plugins.resource/greenwood.config.js
+++ b/packages/cli/test/cases/build.plugins.resource/greenwood.config.js
@@ -19,9 +19,9 @@ class FooResource extends ResourceInterface {
     body = body.replace(/interface (.*){(.*)}/s, '');
 
     return new Response(body, {
-      headers: {
-        'content-type': this.contentType
-      }
+      headers: new Headers({
+        'Content-Type': this.contentType
+      })
     });
   }
 }

--- a/packages/cli/test/cases/build.plugins.resource/greenwood.config.js
+++ b/packages/cli/test/cases/build.plugins.resource/greenwood.config.js
@@ -1,27 +1,26 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '../../../src/lib/resource-interface.js';
 
 class FooResource extends ResourceInterface {
   constructor(compilation, options) {
     super(compilation, options);
     
-    this.extensions = ['.foo'];
+    this.extensions = ['foo'];
     this.contentType = 'text/javascript';
   }
 
-  async serve(url) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        let body = await fs.promises.readFile(url, 'utf-8');
-        
-        body = body.replace(/interface (.*){(.*)}/s, '');
+  async shouldServe(url) {
+    return url.pathname.split('.').pop() === this.extensions[0];
+  }
 
-        resolve({
-          body,
-          contentType: this.contentType
-        });
-      } catch (e) {
-        reject(e);
+  async serve(url) {
+    let body = await fs.readFile(url, 'utf-8');
+
+    body = body.replace(/interface (.*){(.*)}/s, '');
+
+    return new Response(body, {
+      headers: {
+        'content-type': this.contentType
       }
     });
   }

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -91,7 +91,7 @@ describe('Develop Greenwood With: ', function() {
     this.context = {
       hostname: `${hostname}:${port}`
     };
-    runner = new Runner(true);
+    runner = new Runner();
   });
 
   describe(LABEL, function() {

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -47,6 +47,7 @@ import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
+// TODO good first issue, to abstract along with copy plugin
 async function rreaddir (dir, allFiles = []) {
   const files = (await fs.promises.readdir(dir)).map(f => path.join(dir, f));
 
@@ -90,7 +91,7 @@ describe('Develop Greenwood With: ', function() {
     this.context = {
       hostname: `${hostname}:${port}`
     };
-    runner = new Runner();
+    runner = new Runner(true);
   });
 
   describe(LABEL, function() {

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -640,7 +640,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/javascript');
+        expect(response.headers['content-type']).to.contain('text/javascript');
         done();
       });
 
@@ -674,7 +674,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/css');
+        expect(response.headers['content-type']).to.contain('text/css');
         done();
       });
 
@@ -710,7 +710,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal(`image/${ext}`);
+        expect(response.headers['content-type']).to.contain(`image/${ext}`);
         done();
       });
 
@@ -744,7 +744,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('image/x-icon');
+        expect(response.headers['content-type']).to.contain('image/x-icon');
         done();
       });
 
@@ -778,7 +778,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('image/webp');
+        expect(response.headers['content-type']).to.contain('image/webp');
         done();
       });
 
@@ -812,7 +812,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('image/avif');
+        expect(response.headers['content-type']).to.contain('image/avif');
         done();
       });
 
@@ -847,7 +847,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal(`image/${ext}+xml`);
+        expect(response.headers['content-type']).to.contain(`image/${ext}+xml`);
         done();
       });
 
@@ -882,7 +882,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal(ext);
+        expect(response.headers['content-type']).to.contain(ext);
         done();
       });
 
@@ -984,7 +984,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/javascript');
+        expect(response.headers['content-type']).to.contain('text/javascript');
         done();
       });
 
@@ -1020,7 +1020,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/css');
+        expect(response.headers['content-type']).to.contain('text/css');
         done();
       });
 
@@ -1032,7 +1032,7 @@ describe('Develop Greenwood With: ', function() {
 
     // if things work correctly, this workspace file should never resolve to the equivalent node_modules file
     // https://github.com/ProjectEvergreen/greenwood/pull/687
-    describe('Develop command specific workspace resolution when matching node_modules', function() {
+    describe('Develop command specific workspace resolution when local file matches a file also in node_modules', function() {
       let response = {};
 
       before(async function() {
@@ -1056,7 +1056,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/javascript');
+        expect(response.headers['content-type']).to.contain('text/javascript');
         done();
       });
 
@@ -1091,7 +1091,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/javascript');
+        expect(response.headers['content-type']).to.contain('text/javascript');
         done();
       });
 
@@ -1127,7 +1127,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/javascript');
+        expect(response.headers['content-type']).to.contain('text/javascript');
         done();
       });
 
@@ -1167,7 +1167,12 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct response body', function(done) {
-        expect(response.body).to.contain('Not Found');
+        expect(response.body).to.contain('');
+        done();
+      });
+
+      it('should return the correct status message body', function(done) {
+        expect(response.statusMessage).to.contain('Not Found');
         done();
       });
     });
@@ -1214,6 +1219,7 @@ describe('Develop Greenwood With: ', function() {
 
       before(async function() {
         response = await fetch(`${hostname}:${port}/api/greeting?name=${name}`);
+
         data = await response.json();
       });
 

--- a/packages/cli/test/cases/develop.default/src/api/greeting.js
+++ b/packages/cli/test/cases/develop.default/src/api/greeting.js
@@ -4,8 +4,8 @@ export async function handler(request) {
   const body = { message: `Hello ${name}!!!` };
 
   return new Response(JSON.stringify(body), {
-    headers: {
+    headers: new Headers({
       'Content-Type': 'application/json'
-    }
+    })
   });
 }

--- a/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
+++ b/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
@@ -141,7 +141,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/css');
+        expect(response.headers['content-type']).to.contain('text/css');
         done();
       });
 
@@ -179,7 +179,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/javascript');
+        expect(response.headers['content-type']).to.contain('text/javascript');
         done();
       });
 

--- a/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
+++ b/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
@@ -8,7 +8,6 @@ const packageName = JSON.parse(await fs.readFile(new URL('./package.json', impor
 class MyThemePackDevelopmentResource extends ResourceInterface {
   constructor(compilation, options) {
     super(compilation, options);
-    this.extensions = ['*'];
   }
 
   async shouldResolve(url) {

--- a/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
+++ b/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
@@ -1,11 +1,9 @@
 // shared from another test
-import fs from 'fs';
-import path from 'path';
+import fs from 'fs/promises';
 import { myThemePackPlugin } from '../build.plugins.context/theme-pack-context-plugin.js';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
-import { URL } from 'url';
 
-const packageName = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8')).name;
+const packageName = JSON.parse(await fs.readFile(new URL('./package.json', import.meta.url), 'utf-8')).name;
 
 class MyThemePackDevelopmentResource extends ResourceInterface {
   constructor(compilation, options) {
@@ -14,11 +12,14 @@ class MyThemePackDevelopmentResource extends ResourceInterface {
   }
 
   async shouldResolve(url) {
-    return Promise.resolve(url.indexOf(`node_modules${path.sep}${packageName}`) >= 0);
+    return url.pathname.indexOf(`node_modules/${packageName}`) >= 0;
   }
 
   async resolve(url) {
-    return Promise.resolve(path.normalize(url).replace(`node_modules${path.sep}${packageName}${path.sep}dist`, 'fixtures'));
+    const themePackPathname = url.pathname.replace(`/node_modules/${packageName}/dist`, '/fixtures');
+    const themePackUrl = new URL(`.${themePackPathname}`, import.meta.url);
+
+    return new Request(themePackUrl);
   }
 }
 

--- a/packages/cli/test/cases/serve.default.api/serve.default.api.spec.js
+++ b/packages/cli/test/cases/serve.default.api/serve.default.api.spec.js
@@ -83,7 +83,7 @@ describe('Serve Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('application/json; charset=utf-8');
+        expect(response.headers['content-type']).to.contain('application/json');
         done();
       });
 

--- a/packages/cli/test/cases/serve.default.api/src/api/greeting.js
+++ b/packages/cli/test/cases/serve.default.api/src/api/greeting.js
@@ -4,8 +4,8 @@ export async function handler(request) {
   const body = { message: `Hello ${name}!!!` };
 
   return new Response(JSON.stringify(body), {
-    headers: {
+    headers: new Headers({
       'Content-Type': 'application/json'
-    }
+    })
   });
 }

--- a/packages/cli/test/cases/serve.default/serve.default.spec.js
+++ b/packages/cli/test/cases/serve.default/serve.default.spec.js
@@ -226,7 +226,7 @@ describe('Serve Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal(ext);
+        expect(response.headers['content-type']).to.equal(`font/${ext}`);
         done();
       });
 

--- a/packages/cli/test/cases/theme-pack/greenwood.config.js
+++ b/packages/cli/test/cases/theme-pack/greenwood.config.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import path from 'path';
 import { myThemePack } from './my-theme-pack.js';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import { URL } from 'url';
@@ -14,11 +13,13 @@ class MyThemePackDevelopmentResource extends ResourceInterface {
 
   async shouldResolve(url) {
     // eslint-disable-next-line no-underscore-dangle
-    return Promise.resolve(process.env.__GWD_COMMAND__ === 'develop' && url.indexOf(`node_modules${path.sep}${packageName}/`) >= 0);
+    return process.env.__GWD_COMMAND__ === 'develop' && url.pathname.startsWith(`/node_modules/${packageName}/`);
   }
 
   async resolve(url) {
-    return Promise.resolve(path.normalize(this.getBareUrlPath(url)).replace(`node_modules${path.sep}${packageName}${path.sep}dist`, 'src'));
+    const themePackUrl = url.pathname.replace(`/node_modules/${packageName}/dist`, 'src');
+
+    return new Request(`${this.compilation.context.projectDirectory}${themePackUrl}`); 
   }
 }
 

--- a/packages/cli/test/cases/theme-pack/greenwood.config.js
+++ b/packages/cli/test/cases/theme-pack/greenwood.config.js
@@ -1,9 +1,8 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { myThemePack } from './my-theme-pack.js';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
-import { URL } from 'url';
 
-const packageName = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8')).name;
+const packageName = JSON.parse(await fs.readFile(new URL('./package.json', import.meta.url), 'utf-8')).name;
 
 class MyThemePackDevelopmentResource extends ResourceInterface {
   constructor(compilation, options) {

--- a/packages/cli/test/cases/theme-pack/greenwood.config.js
+++ b/packages/cli/test/cases/theme-pack/greenwood.config.js
@@ -7,7 +7,6 @@ const packageName = JSON.parse(await fs.readFile(new URL('./package.json', impor
 class MyThemePackDevelopmentResource extends ResourceInterface {
   constructor(compilation, options) {
     super(compilation, options);
-    this.extensions = ['*'];
   }
 
   async shouldResolve(url) {

--- a/packages/cli/test/cases/theme-pack/my-theme-pack.js
+++ b/packages/cli/test/cases/theme-pack/my-theme-pack.js
@@ -1,6 +1,4 @@
 import fs from 'fs';
-import path from 'path';
-import { fileURLToPath, URL } from 'url';
 
 const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
 const myThemePack = (options = {}) => [{
@@ -8,8 +6,8 @@ const myThemePack = (options = {}) => [{
   name: `${packageJson.name}:context`,
   provider: (compilation) => {
     const templateLocation = options.__isDevelopment // eslint-disable-line no-underscore-dangle
-      ? path.join(compilation.context.userWorkspace, 'layouts')
-      : fileURLToPath(new URL('./dist/layouts', import.meta.url));
+      ? new URL('./layouts/', compilation.context.userWorkspace)
+      : new URL('./dist/layouts/', import.meta.url);
 
     return {
       templates: [

--- a/packages/cli/test/cases/theme-pack/my-theme-pack.js
+++ b/packages/cli/test/cases/theme-pack/my-theme-pack.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
-const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
+const packageJson = JSON.parse(await fs.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
 const myThemePack = (options = {}) => [{
   type: 'context',
   name: `${packageJson.name}:context`,

--- a/packages/cli/test/cases/theme-pack/theme-pack.build.spec.js
+++ b/packages/cli/test/cases/theme-pack/theme-pack.build.spec.js
@@ -131,13 +131,13 @@ describe('Build Greenwood With: ', function() {
         expect(await glob.promise(path.join(this.context.publicDir, '**/header.*.js'))).to.have.lengthOf(1);
       });
 
-      it('should have expected link tag in the head', function() {
-        const scriptTag = Array.from(dom.window.document.querySelectorAll('head script'))
-          .filter((linkTag) => {
-            return linkTag.getAttribute('src').indexOf('/header.') === 0;
+      it('should have expected script tag in the head', function() {
+        const scriptTags = Array.from(dom.window.document.querySelectorAll('head script'))
+          .filter((scriptTag) => {
+            return scriptTag.getAttribute('src').indexOf('/header.') === 0;
           });
 
-        expect(scriptTag.length).to.equal(1);
+        expect(scriptTags.length).to.equal(1);
       });
 
       it('should have expected <x-header> component', function() {

--- a/packages/cli/test/cases/theme-pack/theme-pack.develop.spec.js
+++ b/packages/cli/test/cases/theme-pack/theme-pack.develop.spec.js
@@ -141,7 +141,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/css');
+        expect(response.headers['content-type']).to.contain('text/css');
         done();
       });
 
@@ -179,7 +179,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/javascript');
+        expect(response.headers['content-type']).to.contain('text/javascript');
         done();
       });
 

--- a/packages/init/test/cases/develop.default/develop.default.spec.js
+++ b/packages/init/test/cases/develop.default/develop.default.spec.js
@@ -113,7 +113,7 @@ xdescribe('Scaffold Greenwood and Run Develop command: ', function() {
           });
 
           it('should return the correct content type', function(done) {
-            expect(response.headers['Content-Type']).to.contain('text/html');
+            expect(response.headers['content-type']).to.contain('text/html');
             done();
           });
 

--- a/packages/init/test/cases/develop.default/develop.default.spec.js
+++ b/packages/init/test/cases/develop.default/develop.default.spec.js
@@ -113,7 +113,7 @@ xdescribe('Scaffold Greenwood and Run Develop command: ', function() {
           });
 
           it('should return the correct content type', function(done) {
-            expect(response.headers['content-type']).to.contain('text/html');
+            expect(response.headers['Content-Type']).to.contain('text/html');
             done();
           });
 

--- a/packages/plugin-babel/src/index.js
+++ b/packages/plugin-babel/src/index.js
@@ -4,7 +4,7 @@
  *
  */
 import babel from '@babel/core';
-import fs from 'fs/promises';
+import { checkResourceExists } from '@greenwood/cli/src/lib/resource-utils.js';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import rollupBabelPlugin from '@rollup/plugin-babel';
 
@@ -12,17 +12,10 @@ async function getConfig(compilation, extendConfig = false) {
   const { projectDirectory } = compilation.context;
   const configFile = 'babel.config.mjs';
   const defaultConfig = (await import(new URL(`./${configFile}`, import.meta.url))).default;
-  let userConfig = {};
-  try {
-    await fs.access(new URL(`./${configFile}`, projectDirectory))
-    userConfig = (await import(`${projectDirectory}/${configFile}`)).default;
-  } catch (error) {
-
-  }
-  // const userConfig = fs.existsSync(new URL(`./${configFile}`, projectDirectory).pathname)
-  //   ? (await import(`${projectDirectory}/${configFile}`)).default
-  //   : {};
-  let finalConfig = Object.assign({}, userConfig);
+  const userConfig = await checkResourceExists(new URL(`./${configFile}`, projectDirectory))
+    ? (await import(`${projectDirectory}/${configFile}`)).default
+    : {};
+  const finalConfig = Object.assign({}, userConfig);
 
   if (extendConfig) {    
     finalConfig.presets = Array.isArray(userConfig.presets)

--- a/packages/plugin-babel/src/index.js
+++ b/packages/plugin-babel/src/index.js
@@ -14,7 +14,7 @@ async function getConfig(compilation, extendConfig = false) {
   const defaultConfig = (await import(new URL(`./${configFile}`, import.meta.url))).default;
   let userConfig = {};
   try {
-    fs.access(new URL(`./${configFile}`, projectDirectory))
+    await fs.access(new URL(`./${configFile}`, projectDirectory))
     userConfig = (await import(`${projectDirectory}/${configFile}`)).default;
   } catch (error) {
 

--- a/packages/plugin-babel/src/index.js
+++ b/packages/plugin-babel/src/index.js
@@ -4,7 +4,7 @@
  *
  */
 import babel from '@babel/core';
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import rollupBabelPlugin from '@rollup/plugin-babel';
 
@@ -12,9 +12,16 @@ async function getConfig(compilation, extendConfig = false) {
   const { projectDirectory } = compilation.context;
   const configFile = 'babel.config.mjs';
   const defaultConfig = (await import(new URL(`./${configFile}`, import.meta.url))).default;
-  const userConfig = fs.existsSync(new URL(`./${configFile}`, projectDirectory).pathname)
-    ? (await import(`${projectDirectory}/${configFile}`)).default
-    : {};
+  let userConfig = {};
+  try {
+    fs.access(new URL(`./${configFile}`, projectDirectory))
+    userConfig = (await import(`${projectDirectory}/${configFile}`)).default;
+  } catch (error) {
+
+  }
+  // const userConfig = fs.existsSync(new URL(`./${configFile}`, projectDirectory).pathname)
+  //   ? (await import(`${projectDirectory}/${configFile}`)).default
+  //   : {};
   let finalConfig = Object.assign({}, userConfig);
 
   if (extendConfig) {    

--- a/packages/plugin-babel/src/index.js
+++ b/packages/plugin-babel/src/index.js
@@ -5,24 +5,23 @@
  */
 import babel from '@babel/core';
 import fs from 'fs';
-import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import rollupBabelPlugin from '@rollup/plugin-babel';
 
-async function getConfig (compilation, extendConfig = false) {
+async function getConfig(compilation, extendConfig = false) {
   const { projectDirectory } = compilation.context;
   const configFile = 'babel.config.mjs';
-  const defaultConfig = (await import(new URL(configFile, import.meta.url).pathname)).default;
-  const userConfig = fs.existsSync(path.join(projectDirectory, configFile))
+  const defaultConfig = (await import(new URL(`./${configFile}`, import.meta.url))).default;
+  const userConfig = fs.existsSync(new URL(`./${configFile}`, projectDirectory).pathname)
     ? (await import(`${projectDirectory}/${configFile}`)).default
     : {};
   let finalConfig = Object.assign({}, userConfig);
-  
+
   if (extendConfig) {    
     finalConfig.presets = Array.isArray(userConfig.presets)
       ? [...defaultConfig.presets, ...userConfig.presets]
       : [...defaultConfig.presets];
-    
+
     finalConfig.plugins = Array.isArray(userConfig.plugins)
       ? [...defaultConfig.plugins, ...userConfig.plugins]
       : [...defaultConfig.plugins];
@@ -34,26 +33,21 @@ async function getConfig (compilation, extendConfig = false) {
 class BabelResource extends ResourceInterface {
   constructor(compilation, options) {
     super(compilation, options);
-    this.extensions = ['.js'];
+    this.extensions = ['js'];
     this.contentType = ['text/javascript'];
   }
 
   async shouldIntercept(url) {
-    return Promise.resolve(path.extname(url) === this.extensions[0] && url.indexOf('node_modules/') < 0);
+    return url.pathname.split('.').pop() === this.extensions[0] && !url.pathname.startsWith('/node_modules/');
   }
 
-  async intercept(url, body) {
-    return new Promise(async(resolve, reject) => {
-      try {
-        const config = await getConfig(this.compilation, this.options.extendConfig);
-        const result = await babel.transform(body, config);
-        
-        resolve({
-          body: result.code
-        });
-      } catch (e) {
-        reject(e);
-      }
+  async intercept(url, request, response) {
+    const config = await getConfig(this.compilation, this.options.extendConfig);
+    const body = await response.text();
+    const result = await babel.transform(body, config);
+    
+    return new Response(result.code, {
+      headers: response.headers
     });
   }
 }

--- a/packages/plugin-google-analytics/src/index.js
+++ b/packages/plugin-google-analytics/src/index.js
@@ -13,39 +13,36 @@ class GoogleAnalyticsResource extends ResourceInterface {
     this.contentType = 'text/html';
   }
 
-  async shouldIntercept(url, body, headers) {
-    return Promise.resolve((headers.request.accept || '').indexOf(this.contentType) >= 0);
+  async shouldIntercept(url, request, response) {    
+    return response.headers.get('Content-Type').indexOf(this.contentType) >= 0;
   }
 
-  async intercept(url, body) {
+  async intercept(url, request, response) {
     const { analyticsId, anonymous } = this.options;
     const trackAnon = typeof anonymous === 'boolean' ? anonymous : true;
+    let body = await response.text();
 
-    return new Promise((resolve, reject) => {
-      try {
-        const newHtml = body.replace('</head>', `
-          <link rel="preconnect" href="https://www.google-analytics.com/">
-          <script async src="https://www.googletagmanager.com/gtag/js?id=${analyticsId}"></script>
-          <script data-gwd-opt="none">
-            var getOutboundLink = function(url) {
-              gtag('event', 'click', {
-                'event_category': 'outbound',
-                'event_label': url,
-                'transport_type': 'beacon'
-              });
-            }
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', '${analyticsId}', { 'anonymize_ip': ${trackAnon} });
-          </script>
-        </head>
-        `);
+    body = body.replace('</head>', `
+      <link rel="preconnect" href="https://www.google-analytics.com/">
+      <script async src="https://www.googletagmanager.com/gtag/js?id=${analyticsId}"></script>
+      <script data-gwd-opt="none">
+        var getOutboundLink = function(url) {
+          gtag('event', 'click', {
+            'event_category': 'outbound',
+            'event_label': url,
+            'transport_type': 'beacon'
+          });
+        }
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '${analyticsId}', { 'anonymize_ip': ${trackAnon} });
+      </script>
+    </head>
+    `);
 
-        resolve({ body: newHtml });
-      } catch (e) {
-        reject(e);
-      }
+    return new Response(body, {
+      headers: response.headers
     });
   }
 }

--- a/packages/plugin-google-analytics/test/cases/default/default.spec.js
+++ b/packages/plugin-google-analytics/test/cases/default/default.spec.js
@@ -79,20 +79,20 @@ describe('Build Greenwood With: ', function() {
 
       it('should have the expected code with users analyticsId', function() {
         const expectedContent = `
-            var getOutboundLink = function(url) {
-              gtag('event', 'click', {
-                'event_category': 'outbound',
-                'event_label': url,
-                'transport_type': 'beacon'
-              });
-            }
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', '${mockAnalyticsId}', { 'anonymize_ip': true });
+          var getOutboundLink = function(url) {
+            gtag('event', 'click', {
+              'event_category': 'outbound',
+              'event_label': url,
+              'transport_type': 'beacon'
+            });
+          }
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${mockAnalyticsId}', { 'anonymize_ip': true });
         `;
 
-        expect(inlineScript[0].textContent).to.contain(expectedContent);
+        expect(inlineScript[0].textContent.trim().replace(/\n/g, '').replace(/ /g, '')).to.contain(expectedContent.trim().replace(/\n/g, '').replace(/ /g, ''));
       });
 
       it('should only have one external Google script tag', function() {

--- a/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
+++ b/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
@@ -15,7 +15,7 @@
  *   plugins: [{
  *     greenwoodPluginGoogleAnalytics({
  *       analyticsId: 'UA-123456-1',
- *       anonymouse: false
+ *       anonymous: false
  *     })
  *  }]
  *
@@ -81,7 +81,7 @@ describe('Build Greenwood With: ', function() {
             gtag('config', '${mockAnalyticsId}', { 'anonymize_ip': false });
         `;
 
-        expect(inlineScript[0].textContent).to.contain(expectedContent);
+        expect(inlineScript[0].textContent.trim().replace(/\n/g, '').replace(/ /g, '')).to.contain(expectedContent.trim().replace(/\n/g, '').replace(/ /g, ''));
       });
     });
 

--- a/packages/plugin-graphql/src/core/cache.js
+++ b/packages/plugin-graphql/src/core/cache.js
@@ -1,4 +1,5 @@
 import ApolloCore from '@apollo/client/core/core.cjs.js';
+import { checkResourceExists } from '@greenwood/cli/src/lib/resource-utils.js';
 import fs from 'fs/promises';
 import { gql } from 'apollo-server';
 import { getQueryHash } from './common.js';
@@ -30,16 +31,12 @@ const createCache = async (req, context) => {
         const hashFilename = `${queryHash}-cache.json`;
         const cachePath = new URL(`./${hashFilename}`, outputDir);
 
-        try {
-          await fs.access(outputDir);
-        } catch(e) {
-          fs.mkdir(outputDir);
+        if (!await checkResourceExists(outputDir)) {
+          await fs.mkdir(outputDir);
         }
 
-        try {
-          await fs.access(cachePath);
-        } catch(e) {
-          fs.writeFile(cachePath, cache, 'utf-8');
+        if (!await checkResourceExists(cachePath)) {
+          await fs.writeFile(cachePath, cache, 'utf-8');
         }
       }
       

--- a/packages/plugin-graphql/src/core/cache.js
+++ b/packages/plugin-graphql/src/core/cache.js
@@ -28,14 +28,14 @@ const createCache = async (req, context) => {
         const cache = JSON.stringify(data);
         const queryHash = getQueryHash(query, variables);
         const hashFilename = `${queryHash}-cache.json`;
-        const cachePath = `${outputDir}/${hashFilename}`;
+        const cachePath = new URL(`./${hashFilename}`, outputDir);
 
-        if (!fs.existsSync(outputDir)) {
-          fs.mkdirSync(outputDir);
+        if (!fs.existsSync(outputDir.pathname)) {
+          fs.mkdirSync(outputDir.pathname);
         }
 
-        if (!fs.existsSync(cachePath)) {
-          fs.writeFileSync(cachePath, cache, 'utf8');
+        if (!fs.existsSync(cachePath.pathname)) {
+          fs.writeFileSync(cachePath.pathname, cache, 'utf8');
         }
       }
       

--- a/packages/plugin-graphql/src/core/cache.js
+++ b/packages/plugin-graphql/src/core/cache.js
@@ -1,5 +1,5 @@
 import ApolloCore from '@apollo/client/core/core.cjs.js';
-import fs from 'fs';
+import fs from 'fs/promises';
 import { gql } from 'apollo-server';
 import { getQueryHash } from './common.js';
 
@@ -30,12 +30,16 @@ const createCache = async (req, context) => {
         const hashFilename = `${queryHash}-cache.json`;
         const cachePath = new URL(`./${hashFilename}`, outputDir);
 
-        if (!fs.existsSync(outputDir.pathname)) {
-          fs.mkdirSync(outputDir.pathname);
+        try {
+          await fs.access(outputDir);
+        } catch(e) {
+          fs.mkdir(outputDir);
         }
 
-        if (!fs.existsSync(cachePath.pathname)) {
-          fs.writeFileSync(cachePath.pathname, cache, 'utf8');
+        try {
+          await fs.access(cachePath);
+        } catch(e) {
+          fs.writeFile(cachePath, cache, 'utf-8');
         }
       }
       

--- a/packages/plugin-graphql/src/index.js
+++ b/packages/plugin-graphql/src/index.js
@@ -51,7 +51,7 @@ class GraphQLResource extends ResourceInterface {
   }
 
   async shouldOptimize(url, response) {
-    return (response.headers.get('Content-Type') || response.headers.get('content-type')).indexOf(this.contentType[1]) >= 0;
+    return response.headers.get('Content-Type').indexOf(this.contentType[1]) >= 0;
   }
 
   async optimize(url, response) {

--- a/packages/plugin-graphql/src/index.js
+++ b/packages/plugin-graphql/src/index.js
@@ -42,7 +42,7 @@ class GraphQLResource extends ResourceInterface {
   }
   
   async shouldIntercept(url, request, response) {
-    return response.headers.get('content-type').indexOf('text/html') >= 0;
+    return response.headers.get('content-type').indexOf(this.contentType[1]) >= 0;
   }
 
   async intercept(url, request, response) {

--- a/packages/plugin-graphql/src/index.js
+++ b/packages/plugin-graphql/src/index.js
@@ -32,11 +32,10 @@ class GraphQLResource extends ResourceInterface {
       export default \`${js}\`;
     `;
 
-    // TODO avoid having to rebuild response each time?
     return new Response(body, {
-      headers: {
+      headers: new Headers({
         'Content-Type': this.contentType[0]
-      }
+      })
     });
   }
   
@@ -48,14 +47,11 @@ class GraphQLResource extends ResourceInterface {
     const body = await response.text();
     const newBody = mergeImportMap(body, importMap);
 
-    // TODO avoid having to rebuild response each time?
-    return new Response(newBody, {
-      headers: response.headers
-    });
+    return new Response(newBody);
   }
 
   async shouldOptimize(url, response) {
-    return response.headers.get('Content-Type').indexOf(this.contentType[1]) >= 0;
+    return (response.headers.get('Content-Type') || response.headers.get('content-type')).indexOf(this.contentType[1]) >= 0;
   }
 
   async optimize(url, response) {
@@ -68,10 +64,7 @@ class GraphQLResource extends ResourceInterface {
       <head>
     `);
 
-    // TODO avoid having to rebuild response each time?
-    return new Response(body, {
-      headers: response.headers
-    });
+    return new Response(body);
   }
 }
 

--- a/packages/plugin-graphql/src/index.js
+++ b/packages/plugin-graphql/src/index.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { graphqlServer } from './core/server.js';
 import { mergeImportMap } from '@greenwood/cli/src/lib/walker-package-ranger.js';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
@@ -27,7 +27,7 @@ class GraphQLResource extends ResourceInterface {
   }
 
   async serve(url) {
-    const js = await fs.promises.readFile(url, 'utf-8');
+    const js = await fs.readFile(url, 'utf-8');
     const body = `
       export default \`${js}\`;
     `;

--- a/packages/plugin-graphql/src/index.js
+++ b/packages/plugin-graphql/src/index.js
@@ -35,13 +35,13 @@ class GraphQLResource extends ResourceInterface {
     // TODO avoid having to rebuild response each time?
     return new Response(body, {
       headers: {
-        'content-type': this.contentType[0]
+        'Content-Type': this.contentType[0]
       }
     });
   }
   
   async shouldIntercept(url, request, response) {
-    return response.headers.get('content-type').indexOf(this.contentType[1]) >= 0;
+    return response.headers.get('Content-Type').indexOf(this.contentType[1]) >= 0;
   }
 
   async intercept(url, request, response) {
@@ -55,7 +55,7 @@ class GraphQLResource extends ResourceInterface {
   }
 
   async shouldOptimize(url, response) {
-    return response.headers.get('content-type').indexOf(this.contentType[1]) >= 0;
+    return response.headers.get('Content-Type').indexOf(this.contentType[1]) >= 0;
   }
 
   async optimize(url, response) {

--- a/packages/plugin-graphql/src/schema/schema.js
+++ b/packages/plugin-graphql/src/schema/schema.js
@@ -1,3 +1,4 @@
+import { checkResourceExists } from '@greenwood/cli/src/lib/resource-utils.js';
 import { makeExecutableSchema } from 'apollo-server-express';
 import { configTypeDefs, configResolvers } from './config.js';
 import { graphTypeDefs, graphResolvers } from './graph.js';
@@ -34,9 +35,7 @@ const createSchema = async (compilation) => {
       }
     `;
 
-    try {
-      await fs.access(customSchemasUrl);
-
+    if (await checkResourceExists(customSchemasUrl)) {
       console.log('custom schemas directory detected, scanning...');
       const schemaPaths = (await fs.readdir(customSchemasUrl))
         .filter(file => file.split('.').pop() === 'js');
@@ -47,21 +46,7 @@ const createSchema = async (compilation) => {
         customUserDefs.push(customTypeDefs);
         customUserResolvers.push(customResolvers);
       }
-    } catch (error) {
-      
     }
-    // if (fs.existsSync(customSchemasUrl.pathname)) {
-    //   console.log('custom schemas directory detected, scanning...');
-    //   const schemaPaths = (await fs.readdir(customSchemasUrl))
-    //     .filter(file => file.split('.').pop() === 'js');
-
-    //   for (const schemaPath of schemaPaths) {
-    //     const { customTypeDefs, customResolvers } = await import(new URL(`./${schemaPath}`, customSchemasUrl));
-        
-    //     customUserDefs.push(customTypeDefs);
-    //     customUserResolvers.push(customResolvers);
-    //   }
-    // }
   
     const mergedResolvers = Object.assign({}, {
       Query: {

--- a/packages/plugin-graphql/src/schema/schema.js
+++ b/packages/plugin-graphql/src/schema/schema.js
@@ -1,7 +1,7 @@
 import { makeExecutableSchema } from 'apollo-server-express';
 import { configTypeDefs, configResolvers } from './config.js';
 import { graphTypeDefs, graphResolvers } from './graph.js';
-import fs from 'fs';
+import fs from 'fs/promises';
 import gql from 'graphql-tag';
 
 const createSchema = async (compilation) => {
@@ -34,9 +34,11 @@ const createSchema = async (compilation) => {
       }
     `;
 
-    if (fs.existsSync(customSchemasUrl.pathname)) {
+    try {
+      await fs.access(customSchemasUrl);
+
       console.log('custom schemas directory detected, scanning...');
-      const schemaPaths = (await fs.promises.readdir(customSchemasUrl))
+      const schemaPaths = (await fs.readdir(customSchemasUrl))
         .filter(file => file.split('.').pop() === 'js');
 
       for (const schemaPath of schemaPaths) {
@@ -45,7 +47,21 @@ const createSchema = async (compilation) => {
         customUserDefs.push(customTypeDefs);
         customUserResolvers.push(customResolvers);
       }
+    } catch (error) {
+      
     }
+    // if (fs.existsSync(customSchemasUrl.pathname)) {
+    //   console.log('custom schemas directory detected, scanning...');
+    //   const schemaPaths = (await fs.readdir(customSchemasUrl))
+    //     .filter(file => file.split('.').pop() === 'js');
+
+    //   for (const schemaPath of schemaPaths) {
+    //     const { customTypeDefs, customResolvers } = await import(new URL(`./${schemaPath}`, customSchemasUrl));
+        
+    //     customUserDefs.push(customTypeDefs);
+    //     customUserResolvers.push(customResolvers);
+    //   }
+    // }
   
     const mergedResolvers = Object.assign({}, {
       Query: {

--- a/packages/plugin-graphql/src/schema/schema.js
+++ b/packages/plugin-graphql/src/schema/schema.js
@@ -3,13 +3,11 @@ import { configTypeDefs, configResolvers } from './config.js';
 import { graphTypeDefs, graphResolvers } from './graph.js';
 import fs from 'fs';
 import gql from 'graphql-tag';
-import path from 'path';
-import { pathToFileURL } from 'url';
 
 const createSchema = async (compilation) => {
   const { graph } = compilation;
   const uniqueCustomDataDefKeys = {};
-  const customSchemasPath = `${compilation.context.userWorkspace}/data/schema`;
+  const customSchemasUrl = new URL('./data/schema/', compilation.context.userWorkspace);
   const customUserResolvers = [];
   const customUserDefs = [];
   let customDataDefsString = '';
@@ -36,13 +34,13 @@ const createSchema = async (compilation) => {
       }
     `;
 
-    if (fs.existsSync(customSchemasPath)) {
+    if (fs.existsSync(customSchemasUrl.pathname)) {
       console.log('custom schemas directory detected, scanning...');
-      const schemaPaths = (await fs.promises.readdir(customSchemasPath))
-        .filter(file => path.extname(file) === '.js');
+      const schemaPaths = (await fs.promises.readdir(customSchemasUrl))
+        .filter(file => file.split('.').pop() === 'js');
 
       for (const schemaPath of schemaPaths) {
-        const { customTypeDefs, customResolvers } = await import(pathToFileURL(`${customSchemasPath}/${schemaPath}`));
+        const { customTypeDefs, customResolvers } = await import(new URL(`./${schemaPath}`, customSchemasUrl));
         
         customUserDefs.push(customTypeDefs);
         customUserResolvers.push(customResolvers);

--- a/packages/plugin-graphql/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-graphql/test/cases/develop.default/develop.default.spec.js
@@ -89,7 +89,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['Content-Type']).to.contain('text/html');
+        expect(response.headers['content-type']).to.contain('text/html');
         done();
       });
 
@@ -134,7 +134,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['Content-Type']).to.equal('text/javascript');
+        expect(response.headers['content-type']).to.contain('text/javascript');
         done();
       });
 
@@ -170,7 +170,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['Content-Type']).to.equal('text/javascript');
+        expect(response.headers['content-type']).to.contain('text/javascript');
         done();
       });
 

--- a/packages/plugin-graphql/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-graphql/test/cases/develop.default/develop.default.spec.js
@@ -89,7 +89,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.contain('text/html');
+        expect(response.headers['Content-Type']).to.contain('text/html');
         done();
       });
 
@@ -134,7 +134,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/javascript');
+        expect(response.headers['Content-Type']).to.equal('text/javascript');
         done();
       });
 
@@ -170,7 +170,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/javascript');
+        expect(response.headers['Content-Type']).to.equal('text/javascript');
         done();
       });
 

--- a/packages/plugin-graphql/test/cases/qraphql-server/graphql-server.spec.js
+++ b/packages/plugin-graphql/test/cases/qraphql-server/graphql-server.spec.js
@@ -81,7 +81,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['Content-Type']).to.contain('text/html');
+        expect(response.headers['content-type']).to.contain('text/html');
         done();
       });
     });
@@ -125,12 +125,12 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['Content-Type']).to.contain('application/json');
+        expect(response.headers['content-type']).to.contain('application/json');
         done();
       });
 
       it('should return the expected query response', function(done) {
-        expect(response.body.data.config.workspace).to.equal(path.join(outputPath, 'src'));
+        expect(response.body.data.config.workspace).to.equal(new URL('./src/', import.meta.url).href);
         done();
       });
     });

--- a/packages/plugin-graphql/test/cases/qraphql-server/graphql-server.spec.js
+++ b/packages/plugin-graphql/test/cases/qraphql-server/graphql-server.spec.js
@@ -81,7 +81,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.contain('text/html');
+        expect(response.headers['Content-Type']).to.contain('text/html');
         done();
       });
     });
@@ -125,7 +125,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.contain('application/json');
+        expect(response.headers['Content-Type']).to.contain('application/json');
         done();
       });
 

--- a/packages/plugin-import-commonjs/src/index.js
+++ b/packages/plugin-import-commonjs/src/index.js
@@ -4,7 +4,7 @@
  *
  */
 import commonjs from '@rollup/plugin-commonjs';
-import fs from 'fs';
+import fs from 'fs/promises';
 import { parse, init } from 'cjs-module-lexer';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import rollupStream from '@rollup/stream';
@@ -18,7 +18,7 @@ const testForCjsModule = async(url) => {
   if (pathname.split('.').pop() === '.js' && pathname.startsWith('/node_modules/') && pathname.indexOf('es-module-shims.js') < 0) {
     try {
       await init();
-      const body = await fs.promises.readFile(url, 'utf-8');
+      const body = await fs.readFile(url, 'utf-8');
       await parse(body);
 
       isCommonJs = true;

--- a/packages/plugin-import-commonjs/src/index.js
+++ b/packages/plugin-import-commonjs/src/index.js
@@ -5,7 +5,6 @@
  */
 import commonjs from '@rollup/plugin-commonjs';
 import fs from 'fs';
-import path from 'path';
 import { parse, init } from 'cjs-module-lexer';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import rollupStream from '@rollup/stream';
@@ -13,9 +12,10 @@ import rollupStream from '@rollup/stream';
 // bit of a workaround for now, but maybe this could be supported by cjs-module-lexar natively?
 // https://github.com/guybedford/cjs-module-lexer/issues/35
 const testForCjsModule = async(url) => {
+  const { pathname } = url;
   let isCommonJs = false;
 
-  if (path.extname(url) === '.js' && (/node_modules/).test(url) && url.indexOf('es-module-shims.js') < 0) {
+  if (pathname.split('.').pop() === '.js' && pathname.startsWith('/node_modules/') && pathname.indexOf('es-module-shims.js') < 0) {
     try {
       await init();
       const body = await fs.promises.readFile(url, 'utf-8');
@@ -26,7 +26,7 @@ const testForCjsModule = async(url) => {
       const { message } = e;
       const isProbablyLexarErrorSoIgnore = message.indexOf('Unexpected import statement in CJS module.') >= 0 
         || message.indexOf('Unexpected export statement in CJS module.') >= 0;
-      
+
       if (!isProbablyLexarErrorSoIgnore) {
         // we probably _shouldn't_ ignore this, so let's log it since we don't want to swallow all errors
         console.error(e);
@@ -34,7 +34,7 @@ const testForCjsModule = async(url) => {
     }
   }
 
-  return Promise.resolve(isCommonJs);
+  return isCommonJs;
 };
 
 class ImportCommonJsResource extends ResourceInterface {
@@ -43,23 +43,16 @@ class ImportCommonJsResource extends ResourceInterface {
   }
 
   async shouldIntercept(url) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const isCommonJs = await testForCjsModule(url);
-
-        return resolve(isCommonJs);
-      } catch (e) {
-        console.error(e);
-        reject(e);
-      }
-    });
+    return await testForCjsModule(url);
   }
 
   async intercept(url) {
+    const { pathname } = url;
+    
     return new Promise(async(resolve, reject) => {
       try {
         const options = {
-          input: url,
+          input: pathname,
           output: { format: 'esm' },
           plugins: [
             commonjs()
@@ -70,10 +63,10 @@ class ImportCommonJsResource extends ResourceInterface {
 
         stream.on('data', (data) => (bundle += data));
         stream.on('end', () => {
-          console.debug(`proccessed module "${url}" as a CommonJS module type.`);
-          resolve({
-            body: bundle
-          });
+          console.debug(`processed module "${pathname}" as a CommonJS module type.`);
+          resolve(new Response(bundle, {
+            headers: response.headers
+          }));
         });
       } catch (e) {
         reject(e);

--- a/packages/plugin-import-css/src/index.js
+++ b/packages/plugin-import-css/src/index.js
@@ -3,7 +3,7 @@
  * Enables using JavaScript to import CSS files, using ESM syntax.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
 class ImportCssResource extends ResourceInterface {
@@ -15,7 +15,14 @@ class ImportCssResource extends ResourceInterface {
 
   // https://github.com/ProjectEvergreen/greenwood/issues/700
   async shouldResolve(url) {
-    return url.pathname.endsWith(`.${this.extensions[0]}`) && fs.existsSync(`${url.pathname}.js`);
+    try {
+      if (url.pathname.endsWith(`.${this.extensions[0]}`)) {
+        await fs.access(url);
+        return true;
+      }      
+    } catch (error) {
+      
+    }
   }
 
   async resolve(url) {

--- a/packages/plugin-import-css/src/index.js
+++ b/packages/plugin-import-css/src/index.js
@@ -42,9 +42,9 @@ class ImportCssResource extends ResourceInterface {
     const cssInJsBody = `const css = \`${body.replace(/\r?\n|\r/g, ' ').replace(/\\/g, '\\\\')}\`;\nexport default css;`;
     
     return new Response(cssInJsBody, {
-      headers: {
-        'content-type': this.contentType
-      }
+      headers: new Headers({
+        'Content-Type': this.contentType
+      })
     });
   }
 }

--- a/packages/plugin-import-css/src/index.js
+++ b/packages/plugin-import-css/src/index.js
@@ -3,7 +3,7 @@
  * Enables using JavaScript to import CSS files, using ESM syntax.
  *
  */
-import fs from 'fs/promises';
+import { checkResourceExists } from '@greenwood/cli/src/lib/resource-utils.js';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
 class ImportCssResource extends ResourceInterface {
@@ -15,14 +15,7 @@ class ImportCssResource extends ResourceInterface {
 
   // https://github.com/ProjectEvergreen/greenwood/issues/700
   async shouldResolve(url) {
-    try {
-      if (url.pathname.endsWith(`.${this.extensions[0]}`)) {
-        await fs.access(url);
-        return true;
-      }      
-    } catch (error) {
-      
-    }
+    return url.pathname.endsWith(`.${this.extensions[0]}`) && await checkResourceExists(url);
   }
 
   async resolve(url) {

--- a/packages/plugin-import-css/src/index.js
+++ b/packages/plugin-import-css/src/index.js
@@ -37,8 +37,7 @@ class ImportCssResource extends ResourceInterface {
   }
 
   async intercept(url, request, response) {
-    // TODO why do we need to check for body first?
-    const body = await response.text(); // => body || await fs.promises.readFile(pathToFileURL(url), 'utf-8');
+    const body = await response.text();
     const cssInJsBody = `const css = \`${body.replace(/\r?\n|\r/g, ' ').replace(/\\/g, '\\\\')}\`;\nexport default css;`;
     
     return new Response(cssInJsBody, {

--- a/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
@@ -89,7 +89,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/javascript');
+        expect(response.headers['Content-Type']).to.equal('text/javascript');
         done();
       });
 
@@ -132,7 +132,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/javascript');
+        expect(response.headers['Content-Type']).to.equal('text/javascript');
         done();
       });
 

--- a/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
@@ -89,7 +89,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['Content-Type']).to.equal('text/javascript');
+        expect(response.headers['content-type']).to.contain('text/javascript');
         done();
       });
 
@@ -132,7 +132,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['Content-Type']).to.equal('text/javascript');
+        expect(response.headers['content-type']).to.contain('text/javascript');
         done();
       });
 

--- a/packages/plugin-import-json/src/index.js
+++ b/packages/plugin-import-json/src/index.js
@@ -16,7 +16,7 @@ class ImportJsonResource extends ResourceInterface {
   async shouldIntercept(url) {
     const { pathname } = url;
 
-    return pathname.split('.').pop() === this.extensions[0] || (url.searchParams.has('type') && url.searchParams.get('type') === this.extensions[0]);
+    return pathname.split('.').pop() === this.extensions[0] && (url.searchParams.has('type') && url.searchParams.get('type') === this.extensions[0]);
   }
 
   async intercept(url, request, response) {

--- a/packages/plugin-import-json/src/index.js
+++ b/packages/plugin-import-json/src/index.js
@@ -27,9 +27,9 @@ class ImportJsonResource extends ResourceInterface {
       : await response.text();
 
     return new Response(`export default ${JSON.stringify(body)}`, {
-      headers: {
-        'content-type': this.contentType
-      }
+      headers: new Headers({
+        'Content-Type': this.contentType
+      })
     });
   }
 }

--- a/packages/plugin-import-json/src/index.js
+++ b/packages/plugin-import-json/src/index.js
@@ -4,7 +4,6 @@
  * This is a Greenwood default plugin.
  *
  */
-// import fs from 'fs';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
 class ImportJsonResource extends ResourceInterface {

--- a/packages/plugin-import-json/src/index.js
+++ b/packages/plugin-import-json/src/index.js
@@ -4,7 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
-import fs from 'fs';
+// import fs from 'fs';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
 class ImportJsonResource extends ResourceInterface {
@@ -16,17 +16,21 @@ class ImportJsonResource extends ResourceInterface {
 
   // TODO handle it from node_modules too, when without `?type=json`
   async shouldIntercept(url) {
-    return url.searchParams.has('type') && url.searchParams.get('type') === this.extensions[0];
+    const { pathname } = url;
+
+    return pathname.split('.').pop() === this.extensions[0] || (url.searchParams.has('type') && url.searchParams.get('type') === this.extensions[0]);
   }
 
   async intercept(url, request, response) {
     // TODO better way to handle this?
     // https://github.com/ProjectEvergreen/greenwood/issues/948
-    const body = await response.text() === ''
-      ? await fs.promises.readFile(url, 'utf-8')
-      : await response.text();
+    const body = await response.text();
+    // TODO need to support an empty body to read from disc?
+    // const json = body === ''
+    //   ? await fs.promises.readFile(url, 'utf-8')
+    //   : body;
 
-    return new Response(`export default ${JSON.stringify(body)}`, {
+    return new Response(`export default ${body}`, {
       headers: new Headers({
         'Content-Type': this.contentType
       })

--- a/packages/plugin-import-json/src/index.js
+++ b/packages/plugin-import-json/src/index.js
@@ -16,10 +16,6 @@ class ImportJsonResource extends ResourceInterface {
 
   // TODO handle it from node_modules too, when without `?type=json`
   async shouldIntercept(url) {
-    // const { originalUrl } = headers.request;
-    // const type = this.extensions[0].replace('.', '');
-
-    // return Promise.resolve(originalUrl && originalUrl.indexOf(`?type=${type}`) >= 0);
     return url.searchParams.has('type') && url.searchParams.get('type') === this.extensions[0];
   }
 
@@ -35,26 +31,6 @@ class ImportJsonResource extends ResourceInterface {
         'content-type': this.contentType
       }
     });
-    // resolve({
-    //   body: `export default ${JSON.stringify(raw)}`,
-    //   contentType: this.contentType
-    // });
-    // return new Promise(async (resolve, reject) => {
-    //   try {
-    //     // TODO better way to handle this?
-    //     // https://github.com/ProjectEvergreen/greenwood/issues/948
-    //     const raw = body === ''
-    //       ? await fs.promises.readFile(url, 'utf-8')
-    //       : body;
-
-    //     resolve({
-    //       body: `export default ${JSON.stringify(raw)}`,
-    //       contentType: this.contentType
-    //     });
-    //   } catch (e) {
-    //     reject(e);
-    //   }
-    // });
   }
 }
 

--- a/packages/plugin-import-json/src/index.js
+++ b/packages/plugin-import-json/src/index.js
@@ -22,15 +22,18 @@ class ImportJsonResource extends ResourceInterface {
   }
 
   async intercept(url, request, response) {
+    console.log('JSON intercept!?!?!?!', { url });
     // TODO better way to handle this?
     // https://github.com/ProjectEvergreen/greenwood/issues/948
-    const body = await response.text();
+    const json = await response.json();
+    const body = `export default ${JSON.stringify(json)}`;
     // TODO need to support an empty body to read from disc?
     // const json = body === ''
     //   ? await fs.promises.readFile(url, 'utf-8')
     //   : body;
+    console.log('JSON return', { body });
 
-    return new Response(`export default ${body}`, {
+    return new Response(body, {
       headers: new Headers({
         'Content-Type': this.contentType
       })

--- a/packages/plugin-import-json/src/index.js
+++ b/packages/plugin-import-json/src/index.js
@@ -22,16 +22,8 @@ class ImportJsonResource extends ResourceInterface {
   }
 
   async intercept(url, request, response) {
-    console.log('JSON intercept!?!?!?!', { url });
-    // TODO better way to handle this?
-    // https://github.com/ProjectEvergreen/greenwood/issues/948
     const json = await response.json();
     const body = `export default ${JSON.stringify(json)}`;
-    // TODO need to support an empty body to read from disc?
-    // const json = body === ''
-    //   ? await fs.promises.readFile(url, 'utf-8')
-    //   : body;
-    console.log('JSON return', { body });
 
     return new Response(body, {
       headers: new Headers({

--- a/packages/plugin-import-json/src/index.js
+++ b/packages/plugin-import-json/src/index.js
@@ -14,7 +14,6 @@ class ImportJsonResource extends ResourceInterface {
     this.contentType = 'text/javascript';
   }
 
-  // TODO handle it from node_modules too, when without `?type=json`
   async shouldIntercept(url) {
     const { pathname } = url;
 

--- a/packages/plugin-import-json/src/index.js
+++ b/packages/plugin-import-json/src/index.js
@@ -10,40 +10,51 @@ import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js'
 class ImportJsonResource extends ResourceInterface {
   constructor(compilation, options) {
     super(compilation, options);
-    this.extensions = ['.json'];
+    this.extensions = ['json'];
     this.contentType = 'text/javascript';
   }
 
-  // TODO resolve as part of https://github.com/ProjectEvergreen/greenwood/issues/952
-  async shouldServe() {
-    return false;
-  }
-
   // TODO handle it from node_modules too, when without `?type=json`
-  async shouldIntercept(url, body, headers) {
-    const { originalUrl } = headers.request;
-    const type = this.extensions[0].replace('.', '');
+  async shouldIntercept(url) {
+    // const { originalUrl } = headers.request;
+    // const type = this.extensions[0].replace('.', '');
 
-    return Promise.resolve(originalUrl && originalUrl.indexOf(`?type=${type}`) >= 0);
+    // return Promise.resolve(originalUrl && originalUrl.indexOf(`?type=${type}`) >= 0);
+    return url.searchParams.has('type') && url.searchParams.get('type') === this.extensions[0];
   }
 
-  async intercept(url, body = '') {
-    return new Promise(async (resolve, reject) => {
-      try {
-        // TODO better way to handle this?
-        // https://github.com/ProjectEvergreen/greenwood/issues/948
-        const raw = body === ''
-          ? await fs.promises.readFile(url, 'utf-8')
-          : body;
+  async intercept(url, request, response) {
+    // TODO better way to handle this?
+    // https://github.com/ProjectEvergreen/greenwood/issues/948
+    const body = await response.text() === ''
+      ? await fs.promises.readFile(url, 'utf-8')
+      : await response.text();
 
-        resolve({
-          body: `export default ${JSON.stringify(raw)}`,
-          contentType: this.contentType
-        });
-      } catch (e) {
-        reject(e);
+    return new Response(`export default ${JSON.stringify(body)}`, {
+      headers: {
+        'content-type': this.contentType
       }
     });
+    // resolve({
+    //   body: `export default ${JSON.stringify(raw)}`,
+    //   contentType: this.contentType
+    // });
+    // return new Promise(async (resolve, reject) => {
+    //   try {
+    //     // TODO better way to handle this?
+    //     // https://github.com/ProjectEvergreen/greenwood/issues/948
+    //     const raw = body === ''
+    //       ? await fs.promises.readFile(url, 'utf-8')
+    //       : body;
+
+    //     resolve({
+    //       body: `export default ${JSON.stringify(raw)}`,
+    //       contentType: this.contentType
+    //     });
+    //   } catch (e) {
+    //     reject(e);
+    //   }
+    // });
   }
 }
 

--- a/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
@@ -89,7 +89,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/javascript');
+        expect(response.headers['Content-Type']).to.equal('text/javascript');
         done();
       });
 

--- a/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
@@ -13,8 +13,8 @@
  *
  * {
  *   plugins: [{
- *      ...greenwoodPluginImportJson()
- *  }]
+ *     greenwoodPluginImportJson()
+ *   }]
  * }
  *
  *
@@ -89,7 +89,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['Content-Type']).to.equal('text/javascript');
+        expect(response.headers['content-type']).to.equal('text/javascript');
         done();
       });
 

--- a/packages/plugin-import-json/test/cases/develop.default/src/main.json
+++ b/packages/plugin-import-json/test/cases/develop.default/src/main.json
@@ -1,4 +1,1 @@
-{
-  "status": 200,
-  "message": "got json"
-}
+{"status":200,"message":"got json"}

--- a/packages/plugin-include-html/src/index.js
+++ b/packages/plugin-include-html/src/index.js
@@ -22,7 +22,8 @@ class IncludeHtmlResource extends ResourceInterface {
 
       for (const link of htmlIncludeLinks) {
         const href = link.match(/href="(.*)"/)[1];
-        const includeContents = await fs.readFile(new URL(href, this.compilation.context.userWorkspace), 'utf-8');
+        const prefix = href.startsWith('/') ? '.' : '';
+        const includeContents = await fs.promises.readFile(new URL(`${prefix}${href}`, this.compilation.context.userWorkspace), 'utf-8');
 
         body = body.replace(link, includeContents);
       }

--- a/packages/plugin-include-html/src/index.js
+++ b/packages/plugin-include-html/src/index.js
@@ -9,7 +9,7 @@ class IncludeHtmlResource extends ResourceInterface {
   }
 
   async shouldIntercept(url, request, response) {
-    return response.headers.get('content-type').indexOf(this.contentType) >= 0;
+    return response.headers.get('Content-Type').indexOf(this.contentType) >= 0;
   }
 
   async intercept(url, request, response) {

--- a/packages/plugin-include-html/src/index.js
+++ b/packages/plugin-include-html/src/index.js
@@ -1,7 +1,5 @@
 import fs from 'fs';
-import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
-import { pathToFileURL } from 'url';
 
 class IncludeHtmlResource extends ResourceInterface {
   constructor(compilation, options) {
@@ -10,44 +8,41 @@ class IncludeHtmlResource extends ResourceInterface {
     this.contentType = 'text/html';
   }
 
-  async shouldIntercept(url, body, headers) {
-    return Promise.resolve(headers.response['content-type'] === this.contentType);
+  async shouldIntercept(url, request, response) {
+    return response.headers.get('content-type').indexOf(this.contentType) >= 0;
   }
 
-  async intercept(url, body) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const includeLinksRegexMatches = body.match(/<link (.*)>/g);
-        const includeCustomElementssRegexMatches = body.match(/<[a-zA-Z]*-[a-zA-Z](.*)>(.*)<\/[a-zA-Z]*-[a-zA-Z](.*)>/g);
+  async intercept(url, request, response) {
+    let body = await response.text();
+    const includeLinksRegexMatches = body.match(/<link (.*)>/g);
+    const includeCustomElementsRegexMatches = body.match(/<[a-zA-Z]*-[a-zA-Z](.*)>(.*)<\/[a-zA-Z]*-[a-zA-Z](.*)>/g);
 
-        if (includeLinksRegexMatches) {
-          includeLinksRegexMatches
-            .filter(link => link.indexOf('rel="html"') > 0)
-            .forEach((link) => {
-              const href = link.match(/href="(.*)"/)[1];
-              const includeContents = fs.readFileSync(path.join(this.compilation.context.userWorkspace, href), 'utf-8');
+    if (includeLinksRegexMatches) {
+      const htmlIncludeLinks = includeLinksRegexMatches.filter(link => link.indexOf('rel="html"') > 0);
 
-              body = body.replace(link, includeContents);
-            });
-        }
+      for (const link of htmlIncludeLinks) {
+        const href = link.match(/href="(.*)"/)[1];
+        const includeContents = await fs.readFile(new URL(href, this.compilation.context.userWorkspace), 'utf-8');
 
-        if (includeCustomElementssRegexMatches) {
-          const customElementTags = includeCustomElementssRegexMatches.filter(customElementTag => customElementTag.indexOf('src=') > 0);
-
-          for (const tag of customElementTags) {
-            const src = tag.match(/src="(.*)"/)[1];
-            const filepath = path.join(this.compilation.context.userWorkspace, this.getBareUrlPath(src.replace(/\.\.\//g, '')));
-            const { getData, getTemplate } = await import(pathToFileURL(filepath));
-            const includeContents = await getTemplate(await getData());
-
-            body = body.replace(tag, includeContents);
-          }
-        }
-
-        resolve({ body });
-      } catch (e) {
-        reject(e);
+        body = body.replace(link, includeContents);
       }
+    }
+
+    if (includeCustomElementsRegexMatches) {
+      const customElementTags = includeCustomElementsRegexMatches.filter(customElementTag => customElementTag.indexOf('src=') > 0);
+
+      for (const tag of customElementTags) {
+        const src = tag.match(/src="(.*)"/)[1];
+        const srcUrl = new URL(`./${src.replace(/\.\.\//g, '')}`, this.compilation.context.userWorkspace);
+        const { getData, getTemplate } = await import(srcUrl);
+        const includeContents = await getTemplate(await getData());
+
+        body = body.replace(tag, includeContents);
+      }
+    }
+
+    return new Response(body, {
+      headers: response.headers
     });
   }
 }

--- a/packages/plugin-include-html/src/index.js
+++ b/packages/plugin-include-html/src/index.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
 class IncludeHtmlResource extends ResourceInterface {
@@ -23,7 +23,7 @@ class IncludeHtmlResource extends ResourceInterface {
       for (const link of htmlIncludeLinks) {
         const href = link.match(/href="(.*)"/)[1];
         const prefix = href.startsWith('/') ? '.' : '';
-        const includeContents = await fs.promises.readFile(new URL(`${prefix}${href}`, this.compilation.context.userWorkspace), 'utf-8');
+        const includeContents = await fs.readFile(new URL(`${prefix}${href}`, this.compilation.context.userWorkspace), 'utf-8');
 
         body = body.replace(link, includeContents);
       }

--- a/packages/plugin-include-html/test/cases/build.default-custom-element/src/components/footer.js
+++ b/packages/plugin-include-html/test/cases/build.default-custom-element/src/components/footer.js
@@ -1,5 +1,4 @@
-import fs from 'fs';
-import { fileURLToPath, URL } from 'url';
+import fs from 'fs/promises';
 
 const getTemplate = async (data) => {
   return `
@@ -12,9 +11,8 @@ const getTemplate = async (data) => {
 };
 
 const getData = async () => {
-  const dataPath = fileURLToPath(new URL('../../package.json', import.meta.url));
-  const data = JSON.parse(await fs.promises.readFile(dataPath, 'utf-8'));
-
+  const dataUrl = new URL('../../package.json', import.meta.url);
+  const data = JSON.parse(await fs.readFile(dataUrl, 'utf-8'));
   const { version } = data;
 
   return { version };

--- a/packages/plugin-include-html/test/cases/build.default-link-tag/build.default.link-tag.spec.js
+++ b/packages/plugin-include-html/test/cases/build.default-link-tag/build.default.link-tag.spec.js
@@ -36,7 +36,7 @@ import { fileURLToPath, URL } from 'url';
 const expect = chai.expect;
 
 describe('Build Greenwood With HTML Include Plugin: ', function() {
-  const LABEL = 'Using Custom Element feature';
+  const LABEL = 'Using Link Tag feature';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;

--- a/packages/plugin-polyfills/src/index.js
+++ b/packages/plugin-polyfills/src/index.js
@@ -21,7 +21,7 @@ class PolyfillsResource extends ResourceInterface {
 
     return isEnabled
       && protocol.startsWith('http')
-      && response.headers.get('content-type').indexOf(this.contentType) >= 0;
+      && response.headers.get('Content-Type').indexOf(this.contentType) >= 0;
   }
 
   async intercept(url, request, response) {

--- a/packages/plugin-polyfills/src/index.js
+++ b/packages/plugin-polyfills/src/index.js
@@ -1,5 +1,4 @@
 import { getNodeModulesLocationForPackage } from '@greenwood/cli/src/lib/node-modules-utils.js';
-import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
 class PolyfillsResource extends ResourceInterface {
@@ -80,21 +79,21 @@ const greenwoodPluginPolyfills = (options = {}) => {
     type: 'copy',
     name: 'plugin-copy-polyfills',
     provider: async (compilation) => {
-      // TODO convert this and node utils to use URL
       const { outputDir } = compilation.context;
       const polyfillPackageName = '@webcomponents/webcomponentsjs';
       const polyfillNodeModulesLocation = await getNodeModulesLocationForPackage(polyfillPackageName);
       const litNodeModulesLocation = await getNodeModulesLocationForPackage('lit');
+
       const standardPolyfills = [{
-        from: path.join(polyfillNodeModulesLocation, 'webcomponents-loader.js'),
-        to: path.join(outputDir.pathname, 'webcomponents-loader.js')
+        from: new URL('./webcomponents-loader.js', new URL(`file://${polyfillNodeModulesLocation}/`)),
+        to: new URL('./webcomponents-loader.js', outputDir)
       }, {
-        from: path.join(polyfillNodeModulesLocation, 'bundles'),
-        to: path.join(outputDir.pathname, 'bundles')
+        from: new URL('./bundles/', new URL(`file://${polyfillNodeModulesLocation}/`)),
+        to: new URL('./bundles/', outputDir)
       }];
       const litPolyfills = [{
-        from: path.join(litNodeModulesLocation, 'polyfill-support.js'),
-        to: path.join(outputDir.pathname, 'polyfill-support.js')
+        from: new URL('./polyfill-support.js', new URL(`file://${litNodeModulesLocation}/`)),
+        to: new URL('./polyfill-support.js', outputDir)
       }];
 
       return [

--- a/packages/plugin-polyfills/src/index.js
+++ b/packages/plugin-polyfills/src/index.js
@@ -64,9 +64,7 @@ class PolyfillsResource extends ResourceInterface {
       `);
     }
 
-    return new Response(body, {
-      headers: response.headers
-    });
+    return new Response(body);
   }
 }
 

--- a/packages/plugin-postcss/src/index.js
+++ b/packages/plugin-postcss/src/index.js
@@ -10,13 +10,13 @@ import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js'
 async function getConfig (compilation, extendConfig = false) {
   const { projectDirectory } = compilation.context;
   const configFile = 'postcss.config';
-  const defaultConfig = (await import(new URL(`${configFile}.js`, import.meta.url))).default;
+  const defaultConfig = (await import(new URL(`./${configFile}.js`, import.meta.url))).default;
   const userConfig = fs.existsSync(new URL(`./${configFile}.mjs`, projectDirectory).pathname)
     ? (await import(new URL(`./${configFile}.mjs`, projectDirectory))).default
     : {};
   let finalConfig = Object.assign({}, userConfig);
 
-  if (userConfig && extendConfig) {    
+  if (userConfig && extendConfig) {
     finalConfig.plugins = Array.isArray(userConfig.plugins)
       ? [...defaultConfig.plugins, ...userConfig.plugins]
       : [...defaultConfig.plugins];
@@ -43,7 +43,7 @@ class PostCssResource extends ResourceInterface {
     const css = plugins.length > 0
       ? (await postcss(plugins).process(body, { from: url.pathname })).css
       : body;
-    
+
     // TODO avoid having to rebuild response each time?
     return new Response(css, {
       headers: response.headers

--- a/packages/plugin-postcss/src/index.js
+++ b/packages/plugin-postcss/src/index.js
@@ -3,8 +3,7 @@
  * Enable using PostCSS process for CSS files.
  *
  */
-import fs from 'fs/promises';
-import { normalizePathnameForWindows } from '@greenwood/cli/src/lib/resource-utils.js';
+import { checkResourceExists, normalizePathnameForWindows } from '@greenwood/cli/src/lib/resource-utils.js';
 import postcss from 'postcss';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
@@ -12,16 +11,11 @@ async function getConfig (compilation, extendConfig = false) {
   const { projectDirectory } = compilation.context;
   const configFile = 'postcss.config';
   const defaultConfig = (await import(new URL(`./${configFile}.js`, import.meta.url))).default;
-  let userConfig = {};
-
-  try {
-    await fs.access(new URL(`./${configFile}.mjs`, projectDirectory));
-    userConfig = (await import(new URL(`./${configFile}.mjs`, projectDirectory))).default
-  } catch(e) {
-    console.debug('postcss getConfig', { e })
-  }
-
-  let finalConfig = Object.assign({}, userConfig);
+  const userConfigUrl = new URL(`./${configFile}.mjs`, projectDirectory);
+  const userConfig = await checkResourceExists(userConfigUrl)
+    ? (await import(userConfigUrl)).default
+    : {};
+  const finalConfig = Object.assign({}, userConfig);
 
   if (userConfig && extendConfig) {
     finalConfig.plugins = Array.isArray(userConfig.plugins)

--- a/packages/plugin-postcss/src/index.js
+++ b/packages/plugin-postcss/src/index.js
@@ -4,6 +4,7 @@
  *
  */
 import fs from 'fs/promises';
+import { normalizePathnameForWindows } from '@greenwood/cli/src/lib/resource-utils.js';
 import postcss from 'postcss';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
@@ -47,7 +48,7 @@ class PostCssResource extends ResourceInterface {
     const plugins = config.plugins || [];
     const body = await response.text();
     const css = plugins.length > 0
-      ? (await postcss(plugins).process(body, { from: url.pathname })).css
+      ? (await postcss(plugins).process(body, { from: normalizePathnameForWindows(url) })).css
       : body;
 
     return new Response(css);

--- a/packages/plugin-postcss/src/index.js
+++ b/packages/plugin-postcss/src/index.js
@@ -44,10 +44,7 @@ class PostCssResource extends ResourceInterface {
       ? (await postcss(plugins).process(body, { from: url.pathname })).css
       : body;
 
-    // TODO avoid having to rebuild response each time?
-    return new Response(css, {
-      headers: response.headers
-    });
+    return new Response(css);
   }
 }
 

--- a/packages/plugin-renderer-lit/src/ssr-route-worker-lit.js
+++ b/packages/plugin-renderer-lit/src/ssr-route-worker-lit.js
@@ -30,6 +30,7 @@ async function executeRouteModule({ moduleUrl, compilation, route, label, id, pr
     html: null
   };
 
+  console.debug({ moduleUrl });
   // prerender static content
   if (prerender) {
     for (const script of parsedScripts) {

--- a/packages/plugin-renderer-lit/src/ssr-route-worker-lit.js
+++ b/packages/plugin-renderer-lit/src/ssr-route-worker-lit.js
@@ -3,7 +3,6 @@ import { render } from '@lit-labs/ssr/lib/render-with-global-dom-shim.js';
 import { Buffer } from 'buffer';
 import { html } from 'lit';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
-import { pathToFileURL } from 'url';
 import { Readable } from 'stream';
 import { parentPort } from 'worker_threads';
 
@@ -21,7 +20,7 @@ async function getTemplateResultString(template) {
   return await streamToString(Readable.from(render(template)));
 }
 
-async function executeRouteModule({ modulePath, compilation, route, label, id, prerender, htmlContents, scripts }) {
+async function executeRouteModule({ moduleUrl, compilation, route, label, id, prerender, htmlContents, scripts }) {
   const parsedCompilation = JSON.parse(compilation);
   const parsedScripts = scripts ? JSON.parse(scripts) : [];
   const data = {
@@ -41,7 +40,7 @@ async function executeRouteModule({ modulePath, compilation, route, label, id, p
 
     data.html = await getTemplateResultString(templateResult);
   } else {
-    const module = await import(pathToFileURL(modulePath)).then(module => module);
+    const module = await import(moduleUrl).then(module => module);
     const { getTemplate = null, getBody = null, getFrontmatter = null } = module;
 
     if (module.default && module.tagName) {

--- a/packages/plugin-renderer-lit/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-renderer-lit/test/cases/build.default/build.default.spec.js
@@ -182,7 +182,7 @@ describe('Build Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['Content-Type']).to.contain('text/html');
+        expect(response.headers['content-type']).to.contain('text/html');
         done();
       });
 

--- a/packages/plugin-renderer-lit/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-renderer-lit/test/cases/build.default/build.default.spec.js
@@ -182,7 +182,7 @@ describe('Build Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.contain('text/html');
+        expect(response.headers['Content-Type']).to.contain('text/html');
         done();
       });
 

--- a/packages/plugin-renderer-lit/test/cases/build.default/src/pages/artists.js
+++ b/packages/plugin-renderer-lit/test/cases/build.default/src/pages/artists.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { html } from 'lit';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import '../components/greeting.js';
@@ -30,7 +30,7 @@ async function getTemplate(compilation, route) {
 }
 
 async function getBody() {
-  const artists = JSON.parse(await fs.promises.readFile(new URL('../../artists.json', import.meta.url), 'utf-8'));
+  const artists = JSON.parse(await fs.readFile(new URL('../../artists.json', import.meta.url), 'utf-8'));
 
   return html`
     <h1>Lit SSR response</h1>

--- a/packages/plugin-renderer-lit/test/cases/build.default/src/pages/users.js
+++ b/packages/plugin-renderer-lit/test/cases/build.default/src/pages/users.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'fs';
 import { html, LitElement } from 'lit';
 import '../components/footer.js';
 
@@ -6,7 +6,7 @@ class UsersComponent extends LitElement {
 
   constructor() {
     super();
-    this.users = JSON.parse(await fs.promises.readFile(new URL('../../artists.json', import.meta.url), 'utf-8'));
+    this.users = JSON.parse(fs.readFileSync(new URL('../../artists.json', import.meta.url), 'utf-8'));
   }
 
   render() {

--- a/packages/plugin-renderer-lit/test/cases/build.default/src/pages/users.js
+++ b/packages/plugin-renderer-lit/test/cases/build.default/src/pages/users.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { html, LitElement } from 'lit';
 import '../components/footer.js';
 
@@ -6,7 +6,7 @@ class UsersComponent extends LitElement {
 
   constructor() {
     super();
-    this.users = JSON.parse(fs.readFileSync(new URL('../../artists.json', import.meta.url), 'utf-8'));
+    this.users = JSON.parse(await fs.promises.readFile(new URL('../../artists.json', import.meta.url), 'utf-8'));
   }
 
   render() {

--- a/packages/plugin-renderer-puppeteer/src/plugins/resource.js
+++ b/packages/plugin-renderer-puppeteer/src/plugins/resource.js
@@ -8,11 +8,12 @@ class PuppeteerResource extends ResourceInterface {
     this.contentType = 'text/html';
   }
 
-  async shouldIntercept(url) {
-    const { protocol, pathname } = url;
-    const hasMatchingPageRoute = this.compilation.graph.find(node => node.route === pathname);
-    
-    return process.env.__GWD_COMMAND__ === 'build' && protocol.startsWith('http') && hasMatchingPageRoute; // eslint-disable-line no-underscore-dangle
+  async shouldIntercept(url, request, response) {
+    const { protocol } = url;
+
+    return process.env.__GWD_COMMAND__ === 'build' // eslint-disable-line no-underscore-dangle
+      && protocol.startsWith('http')
+      && response.headers.get('content-type').indexOf(this.contentType) >= 0;
   }
 
   async intercept(url, request, response) {

--- a/packages/plugin-renderer-puppeteer/src/plugins/resource.js
+++ b/packages/plugin-renderer-puppeteer/src/plugins/resource.js
@@ -13,7 +13,7 @@ class PuppeteerResource extends ResourceInterface {
 
     return process.env.__GWD_COMMAND__ === 'build' // eslint-disable-line no-underscore-dangle
       && protocol.startsWith('http')
-      && response.headers.get('content-type').indexOf(this.contentType) >= 0;
+      && response.headers.get('Content-Type').indexOf(this.contentType) >= 0;
   }
 
   async intercept(url, request, response) {

--- a/packages/plugin-renderer-puppeteer/src/plugins/resource.js
+++ b/packages/plugin-renderer-puppeteer/src/plugins/resource.js
@@ -24,9 +24,7 @@ class PuppeteerResource extends ResourceInterface {
         <script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
     `);
 
-    return new Response(body, {
-      headers: response.headers
-    });
+    return new Response(body);
   }
 }
 

--- a/packages/plugin-typescript/src/index.js
+++ b/packages/plugin-typescript/src/index.js
@@ -4,7 +4,6 @@
  *
  */
 import fs from 'fs';
-import path from 'path';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import tsc from 'typescript';
 
@@ -17,7 +16,7 @@ const defaultCompilerOptions = {
 
 function getCompilerOptions (projectDirectory, extendConfig) {
   const customOptions = extendConfig
-    ? JSON.parse(fs.readFileSync(path.join(projectDirectory, 'tsconfig.json'), 'utf-8'))
+    ? JSON.parse(fs.readFileSync(new URL('./tsconfig.json', projectDirectory).pathname, 'utf-8'))
     : { compilerOptions: {} };
 
   return {
@@ -29,27 +28,28 @@ function getCompilerOptions (projectDirectory, extendConfig) {
 class TypeScriptResource extends ResourceInterface {
   constructor(compilation, options) {
     super(compilation, options);
-    this.extensions = ['.ts'];
+    this.extensions = ['ts'];
     this.contentType = 'text/javascript';
   }
 
+  async shouldServe(url) {
+    const { pathname, protocol } = url;
+    const isTsFile = protocol === 'file:' && pathname.split('.').pop() === this.extensions[0];
+
+    return isTsFile || isTsFile && url.searchParams.has('type') && url.searchParams.get('type') === this.extensions[0];
+  }
+
   async serve(url) {
-    return new Promise(async (resolve, reject) => {
-      try {
-        const { projectDirectory } = this.compilation.context;
-        const source = await fs.promises.readFile(url, 'utf-8');
-        const compilerOptions = getCompilerOptions(projectDirectory, this.options.extendConfig);
+    const { projectDirectory } = this.compilation.context;
+    const source = await fs.promises.readFile(url, 'utf-8');
+    const compilerOptions = getCompilerOptions(projectDirectory, this.options.extendConfig);
+    // https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API
+    const body = tsc.transpileModule(source, { compilerOptions }).outputText;
 
-        // https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API
-        const result = tsc.transpileModule(source, { compilerOptions });
-
-        resolve({
-          body: result.outputText,
-          contentType: this.contentType
-        });
-      } catch (e) {
-        reject(e);
-      }
+    return new Response(body, {
+      headers: new Headers({
+        'Content-Type': this.contentType
+      })
     });
   }
 }

--- a/packages/plugin-typescript/src/index.js
+++ b/packages/plugin-typescript/src/index.js
@@ -14,7 +14,7 @@ const defaultCompilerOptions = {
   sourceMap: true
 };
 
-function getCompilerOptions (projectDirectory, extendConfig) {
+async function getCompilerOptions (projectDirectory, extendConfig) {
   const customOptions = extendConfig
     ? JSON.parse(await fs.readFile(new URL('./tsconfig.json', projectDirectory), 'utf-8'))
     : { compilerOptions: {} };
@@ -42,7 +42,7 @@ class TypeScriptResource extends ResourceInterface {
   async serve(url) {
     const { projectDirectory } = this.compilation.context;
     const source = await fs.readFile(url, 'utf-8');
-    const compilerOptions = getCompilerOptions(projectDirectory, this.options.extendConfig);
+    const compilerOptions = await getCompilerOptions(projectDirectory, this.options.extendConfig);
     // https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API
     const body = tsc.transpileModule(source, { compilerOptions }).outputText;
 

--- a/packages/plugin-typescript/src/index.js
+++ b/packages/plugin-typescript/src/index.js
@@ -3,7 +3,7 @@
  * Enables using JavaScript to import TypeScript files, using ESM syntax.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import tsc from 'typescript';
 
@@ -16,7 +16,7 @@ const defaultCompilerOptions = {
 
 function getCompilerOptions (projectDirectory, extendConfig) {
   const customOptions = extendConfig
-    ? JSON.parse(fs.readFileSync(new URL('./tsconfig.json', projectDirectory).pathname, 'utf-8'))
+    ? JSON.parse(await fs.readFile(new URL('./tsconfig.json', projectDirectory), 'utf-8'))
     : { compilerOptions: {} };
 
   return {
@@ -41,7 +41,7 @@ class TypeScriptResource extends ResourceInterface {
 
   async serve(url) {
     const { projectDirectory } = this.compilation.context;
-    const source = await fs.promises.readFile(url, 'utf-8');
+    const source = await fs.readFile(url, 'utf-8');
     const compilerOptions = getCompilerOptions(projectDirectory, this.options.extendConfig);
     // https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API
     const body = tsc.transpileModule(source, { compilerOptions }).outputText;

--- a/packages/plugin-typescript/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-typescript/test/cases/develop.default/develop.default.spec.js
@@ -82,7 +82,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['Content-Type']).to.equal('text/javascript');
+        expect(response.headers['content-type']).to.contain('text/javascript');
         done();
       });
 

--- a/packages/plugin-typescript/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-typescript/test/cases/develop.default/develop.default.spec.js
@@ -82,7 +82,7 @@ describe('Develop Greenwood With: ', function() {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/javascript');
+        expect(response.headers['Content-Type']).to.equal('text/javascript');
         done();
       });
 

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -231,7 +231,7 @@ function serve(label) {
       });
 
       it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/html');
+        expect(response.headers['content-type']).to.contain('text/html');
         done();
       });
 

--- a/www/pages/docs/api-routes.md
+++ b/www/pages/docs/api-routes.md
@@ -30,9 +30,9 @@ export async function handler(request) {
   const body = { message: `Hello ${name}!!!` };
 
   return new Response(JSON.stringify(body), {
-    headers: {
+    headers: new Headers({
       'Content-Type': 'application/json'
-    }
+    })
   });
 }
 ```

--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -220,9 +220,7 @@ Path to where all your project files will be located.  Using an absolute path is
 Setting the workspace path to be the _www/_ folder in the current directory from where Greenwood is being run.
 
 ```js
-import { fileURLToPath, URL } from 'url';
-
 export default {
-  workspace: fileURLToPath(new URL('./www', import.meta.url))
+  workspace: new URL('./www', import.meta.url)
 };
 ```

--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -36,7 +36,7 @@ export default {
 
 ### Dev Server
 Configuration for Greenwood's development server is available using the `devServer` option.
-- `extensions`: Provide an array of to watch for changes and reload the live server with.  By default, Greenwood will already watch all "standard" web assets (HTML, CSS, JS, etc) it supports by default, as well as any extensions set by [resource plugins](/plugins/resource) you are using in your _greenwood.config.json_.
+- `extensions`: Provide an array of extensions to watch for changes and reload the live server with.  By default, Greenwood will already watch all "standard" web assets (HTML, CSS, JS, etc) it supports by default, as well as any extensions set by [resource plugins](/plugins/resource) you are using in your _greenwood.config.json_.
 - `hud`: The HUD option ([_head-up display_](https://en.wikipedia.org/wiki/Head-up_display)) is some additional HTML added to your site's page when Greenwood wants to help provide information to you in the browser.  For example, if your HTML is detected as malformed, which could break the parser.  Set this to `false` if you would like to turn it off.
 - `port`: Pick a different port when starting the dev server
 - `proxy`: A set of paths to match and re-route to other hosts.  Highest specificity should go at the end.
@@ -45,7 +45,7 @@ Configuration for Greenwood's development server is available using the `devServ
 ```js
 export default {
   devServer: {
-    extensions: ['.txt', '.rtf'],
+    extensions: ['txt', 'rtf'],
     port: 3000,
     proxy: {
       '/api': 'https://stage.myapp.com',

--- a/www/pages/plugins/context.md
+++ b/www/pages/plugins/context.md
@@ -45,9 +45,7 @@ Your plugin might look like this:
  *     acme-theme-pack.js
  *     package.json
  */
-import { fileURLToPath } from 'url';
-
-export function myCopyPlugin() {
+export function myContextPlugin() {
   return {
     type: 'context',
     name: 'acme-theme-pack:context',
@@ -55,7 +53,7 @@ export function myCopyPlugin() {
       return {
         templates: [
           // when the plugin is installed import.meta.url will be /path/to/node_modules/<your-package>/
-          fileURLToPath(new URL('./dist/layouts', import.meta.url))
+          new URL('./dist/layouts/', import.meta.url)
         ]
       };
     }

--- a/www/pages/plugins/copy.md
+++ b/www/pages/plugins/copy.md
@@ -10,11 +10,8 @@ index: 2
 The copy plugin allows users to copy files around as part of the [build](/docs/#cli) command.  For example, Greenwood uses this feature to copy all files in the user's _/assets/_ directory to final output directory automatically.  You can use this plugin to copy single files, or entire directories.
 
 ## API
-This plugin supports providing an array of "location" objects that can either be files or directories.
-
+This plugin supports providing an array of "paired" URL objects that can either be files or directories, by providing a `from` and `to` location.
 ```js
-import path from 'path';
-
 export function myCopyPlugin() {
   return {
     type: 'copy',
@@ -23,13 +20,13 @@ export function myCopyPlugin() {
       const { context } = compilation;
 
       return [{
-        // can only copy a file to a file
-        from: path.join(context.userWorkspace, 'robots.txt'),
-        to: path.join(context.outputDir, 'robots.txt')
+        // copy a file
+        from: new URL('./robots.txt', context.userWorkspace),
+        to: new URL('./robots.txt', context.outputDir)
       }, {
-        // can only copy a directory to a directory
-        from: path.join(context.userWorkspace, 'pdfs'),
-        to: path.join(context.outputDir, 'pdfs')
+        // copy a directory (notice the trailing /)
+        from: new URL('./pdfs/', context.userWorkspace),
+        to: new URL('./pdfs/', context.outputDir)
       }];
     }
   };

--- a/www/pages/plugins/index.md
+++ b/www/pages/plugins/index.md
@@ -43,7 +43,7 @@ export default {
         }
       }
     }
-  }]
+  ]
 
 }
 ```
@@ -72,7 +72,7 @@ export default {
 #### Context
 This provides access to all the input / output directories and file paths Greenwood uses to build the site and output all the generated files.  Context is especially useful for copying files or writing to the build directory.
 
-Here are paths you can get from `context`, all of which are absolute URLs:
+Here are paths you can get from `context`, all of which are instances of [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) and use the `file://` protocol:
 
 - `outputDir`: Where Greenwood outputs the final static site
 - `pagesDir`: Path to the _pages/_ directory in the user's workspace
@@ -81,26 +81,7 @@ Here are paths you can get from `context`, all of which are absolute URLs:
 - `userTemplatesDir`: Path to the _templates/_ directory in the user's workspace
 - `userWorkspace`: Path to the workspace directory (_src/_ by default)
 
-
-Example using `context` to write to `publicDir` from _greenwood.config.js_
-```javascript
-import fs from 'fs';
-import path from 'path';
-
-export default {
-
-  plugins: [{
-    name: 'my-plugin'
-    type: 'resource',
-    provider: (compilation) => {
-      const { outputDir } = compilation.context;
-
-      fs.writeFileSync(path.join(outputDir, 'robots.txt'), 'Hello World!');
-    }
-  }]
-
-}
-```
+> You can see a good example of this in use in our [context plugin docs](/plugins/copy/)
 
 ### Plugin Types
 While each API has its own documentation section on the left sidebar of this page, here is a quick overview of the current set of Plugin APIs Greenwood supports.

--- a/www/pages/plugins/rollup.md
+++ b/www/pages/plugins/rollup.md
@@ -13,7 +13,7 @@ Though rare, there may be cases and opportunities for tapping into the bundling 
 Install your favorite rollup plugin(s), then create a simple object to provide those plugins to Greenwood.
 
 ```javascript
-import bannerRollup = from 'rollup-plugin-banner';
+import bannerRollup from 'rollup-plugin-banner';
 import fs from 'fs';
 
 const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #948 

## Summary of Changes
1. Adopt (most of) core to work with Web APIs `URL` / `Request` / `Response`
1. Refactor all plugins to adopt above convention
1. Updated all impacted documentation

## TODOs
1. [x] Fix Windows compat - #1047 
1. [x] Refactor `Request.clone` / `Response.clone`, as it seems to cause this issue
    ```sh
    (node:81167) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
    ```
    - somewhat related, maybe we can "undo" this now - #1046 
1. [x] Restore ETag middleware for `develop` command
1. [x] Documentation / Breaking Changes
    - _greenwood.config.js_
    - `ResourceInterface` (extensions, lifecycle signatures, util methods) 
1. [x] Clean up / address TODOs and / or make tracking issues
    - ~~convert node modules lib to use `URL`~~
    - ~~convert the graph lifecycle to use `URL`~~ (maybe as part of https://github.com/ProjectEvergreen/greenwood/issues/946 ?)
     - ~~how to handle `Response` already setting a default `Content-Type` of `text/plain;charset=UTF-8`~~ - https://github.com/ProjectEvergreen/greenwood/issues/1049
     - ~~convert all `fs` usage to `fs.promises` + `URL`~~
     - ~~Figure out consistent usage `fs` and sync / async version for things like `.map`, `.filter`~~ - added to https://github.com/ProjectEvergreen/greenwood/issues/823
     - ~~flesh out all remaining `Response` properties in `mergeResponse`~~ - https://github.com/ProjectEvergreen/greenwood/issues/1048
     - ~~`Content-Type` vs `content-type` consistency ?~~  - tracking in the backlog
     - ~~refactor out `resolveForRelativeUrl` from ResourceInterface~~
     - ~~refactor out find _package.json_~~
     - ~~remove unused `this.extensions`~~
     - ~~refactor rollup.config.js `resolveId` to use `this.resolveRelativeUrl` from ResourceInterface~~
     - ~~convert to Fastify, or something that can handle a native `Response` object?~~ - added to Backlog
 1. [x] Convert / refactor init package (GFI) - https://github.com/ProjectEvergreen/greenwood/issues/1050
 1. [x] static router spec undefined script and preload (_build.config.static-router.spec.js_) (GFI) - https://github.com/ProjectEvergreen/greenwood/issues/1051
      ```html
      <script type="module" src="/undefined"></script>
      ```
 1. [x] `<script>` tag not closing for inline + none optimizations, like for Google Analytics? (GFI) - https://github.com/ProjectEvergreen/greenwood/issues/1052
     ```html
      <script >
        var getOutboundLink = function(url) {
          gtag('event', 'click', {
            'event_category': 'outbound',
            'event_label': url,
            'transport_type': 'beacon'
          });
        }
        window.dataLayer = window.dataLayer || [];
        function gtag(){dataLayer.push(arguments);}
        gtag('js', new Date());
        gtag('config', 'UA-117350131-1', { 'anonymize_ip': true });
      </script>
      ```