### PR TITLE
Feature/issue 948 web api standardization windows compat refactor

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -20,9 +20,9 @@ jobs:
     - name: Installing project dependencies
       run: |
         yarn install --frozen-lockfile --network-timeout 1000000 && yarn lerna bootstrap
-    - name: Lint
-      run: |
-        yarn lint
+    # - name: Lint
+    #   run: |
+    #     yarn lint
     - name: Test
       run: |
         yarn test

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -20,9 +20,9 @@ jobs:
     - name: Installing project dependencies
       run: |
         yarn install --frozen-lockfile --network-timeout 1000000 && yarn lerna bootstrap
-    # - name: Lint
-    #   run: |
-    #     yarn lint
+    - name: Lint
+      run: |
+        yarn lint
     - name: Test
       run: |
         yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
     - name: Installing project dependencies
       run: |
         yarn install --frozen-lockfile && yarn lerna bootstrap
-    - name: Lint
-      run: |
-        yarn lint
+    # - name: Lint
+    #   run: |
+    #     yarn lint
     - name: Test
       run: |
         yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
     - name: Installing project dependencies
       run: |
         yarn install --frozen-lockfile && yarn lerna bootstrap
-    # - name: Lint
-    #   run: |
-    #     yarn lint
+    - name: Lint
+      run: |
+        yarn lint
     - name: Test
       run: |
         yarn test

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -17,10 +17,10 @@ const runProductionBuild = async (compilation) => {
 
       try {
         await fs.access(outputDir);
-      } catch(e) {
+      } catch (e) {
         await fs.mkdir(outputDir, {
           recursive: true
-        })
+        });
       }
 
       if (prerender || prerenderPlugin.prerender) {

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -1,6 +1,6 @@
 import { bundleCompilation } from '../lifecycles/bundle.js';
 import { copyAssets } from '../lifecycles/copy.js';
-import fs from 'fs';
+import fs from 'fs/promises';
 import { preRenderCompilationWorker, preRenderCompilationCustom, staticRenderCompilation } from '../lifecycles/prerender.js';
 import { ServerInterface } from '../lib/server-interface.js';
 
@@ -15,8 +15,12 @@ const runProductionBuild = async (compilation) => {
         ? compilation.config.plugins.find(plugin => plugin.type === 'renderer').provider(compilation)
         : {};
 
-      if (!fs.existsSync(outputDir.pathname)) {
-        fs.mkdirSync(outputDir.pathname);
+      try {
+        await fs.access(outputDir);
+      } catch(e) {
+        await fs.mkdir(outputDir, {
+          recursive: true
+        })
       }
 
       if (prerender || prerenderPlugin.prerender) {

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -1,4 +1,5 @@
 import { bundleCompilation } from '../lifecycles/bundle.js';
+import { checkResourceExists } from '../lib/resource-utils.js';
 import { copyAssets } from '../lifecycles/copy.js';
 import fs from 'fs/promises';
 import { preRenderCompilationWorker, preRenderCompilationCustom, staticRenderCompilation } from '../lifecycles/prerender.js';
@@ -15,9 +16,7 @@ const runProductionBuild = async (compilation) => {
         ? compilation.config.plugins.find(plugin => plugin.type === 'renderer').provider(compilation)
         : {};
 
-      try {
-        await fs.access(outputDir);
-      } catch (e) {
+      if (!await checkResourceExists(outputDir)) {
         await fs.mkdir(outputDir, {
           recursive: true
         });

--- a/packages/cli/src/commands/eject.js
+++ b/packages/cli/src/commands/eject.js
@@ -1,10 +1,10 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 const ejectConfiguration = async (compilation) => {
   return new Promise(async (resolve, reject) => {
     try {
       const configFileDirUrl = new URL('../config/', import.meta.url);
-      const configFiles = await fs.promises.readdir(configFileDirUrl);
+      const configFiles = await fs.readdir(configFileDirUrl);
       
       configFiles.forEach((configFile) => {
         const from = new URL(`./${configFile}`, configFileDirUrl);

--- a/packages/cli/src/commands/eject.js
+++ b/packages/cli/src/commands/eject.js
@@ -6,14 +6,14 @@ const ejectConfiguration = async (compilation) => {
       const configFileDirUrl = new URL('../config/', import.meta.url);
       const configFiles = await fs.readdir(configFileDirUrl);
       
-      configFiles.forEach((configFile) => {
-        const from = new URL(`./${configFile}`, configFileDirUrl);
-        const to = new URL(`./${configFile}`, compilation.context.projectDirectory);
+      for (const file of configFiles) {
+        const from = new URL(`./${file}`, configFileDirUrl);
+        const to = new URL(`./${file}`, compilation.context.projectDirectory);
 
-        fs.copyFileSync(from.pathname, to.pathname);
+        await fs.copyFile(from.pathname, to.pathname);
         
-        console.log(`Ejected ${configFile} successfully.`);
-      });
+        console.log(`Ejected ${file} successfully.`);
+      }
 
       console.debug('all configuration files ejected.');
 

--- a/packages/cli/src/commands/eject.js
+++ b/packages/cli/src/commands/eject.js
@@ -10,7 +10,7 @@ const ejectConfiguration = async (compilation) => {
         const from = new URL(`./${file}`, configFileDirUrl);
         const to = new URL(`./${file}`, compilation.context.projectDirectory);
 
-        await fs.copyFile(from.pathname, to.pathname);
+        await fs.copyFile(from, to);
         
         console.log(`Ejected ${file} successfully.`);
       }

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -9,7 +9,7 @@ function greenwoodResourceLoader (compilation) {
 
   return {
     name: 'greenwood-resource-loader',
-    resolveId(id) {
+    async resolveId(id) {
       const normalizedId = id.replace(/\?type=(.*)/, '');
       const { userWorkspace } = compilation.context;
 
@@ -24,11 +24,6 @@ function greenwoodResourceLoader (compilation) {
       } catch (e) {
         return null;
       }
-      // if ((id.indexOf('./') === 0 || id.indexOf('/') === 0) && fs.existsSync(new URL(`./${normalizedId}`, userWorkspace).pathname)) {
-      //   return new URL(`./${normalizedId}`, userWorkspace).pathname;
-      // }
-
-      // return null;
     },
     async load(id) {
       const pathname = id.indexOf('?') >= 0 ? id.slice(0, id.indexOf('?')) : id;
@@ -60,7 +55,7 @@ function greenwoodResourceLoader (compilation) {
 function greenwoodSyncPageResourceBundlesPlugin(compilation) {
   return {
     name: 'greenwood-sync-page-resource-bundles-plugin',
-    writeBundle(outputOptions, bundles) {
+    async writeBundle(outputOptions, bundles) {
       const { outputDir } = compilation.context;
 
       for (const resource of compilation.resources.values()) {
@@ -89,19 +84,13 @@ function greenwoodSyncPageResourceBundlesPlugin(compilation) {
            */
           try {
             if (facadeModuleId && resourceKey.indexOf('/node_modules/@greenwood/cli') > 0 && facadeModuleId.indexOf('/packages/cli') > 0) {
-              console.debug({ facadeModuleId });
               await fs.access(facadeModuleId);
 
               facadeModuleId = facadeModuleId.replace('/packages/cli', '/node_modules/@greenwood/cli');
             }
           } catch (e) {
-            console.debug('facademodule id', e);
-            // return null;
-          }
 
-          // if (facadeModuleId && resourceKey.indexOf('/node_modules/@greenwood/cli') > 0 && facadeModuleId.indexOf('/packages/cli') > 0 && fs.existsSync(facadeModuleId)) {
-          //   facadeModuleId = facadeModuleId.replace('/packages/cli', '/node_modules/@greenwood/cli');
-          // }
+          }
 
           if (resourceKey === facadeModuleId) {
             const { fileName } = bundles[bundle];

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -30,7 +30,7 @@ function greenwoodResourceLoader (compilation) {
       const extension = pathname.split('.').pop();
 
       if (extension !== '' && extension !== 'js') {
-        const url = new URL(`file://${pathname}`);
+        const url = new URL(`file://${pathname}?type=${extension}`);
         const request = new Request(url.href);
         let response = new Response('');
 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -6,11 +6,11 @@
 process.setMaxListeners(0);
 
 import { generateCompilation } from './lifecycles/compile.js';
-import fs from 'fs';
+import fs from 'fs/promises';
 import program from 'commander';
 import { URL } from 'url';
 
-const greenwoodPackageJson = JSON.parse(await fs.promises.readFile(new URL('../package.json', import.meta.url), 'utf-8'));
+const greenwoodPackageJson = JSON.parse(await fs.readFile(new URL('../package.json', import.meta.url), 'utf-8'));
 let cmdOption = {};
 let command = '';
 

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -1,6 +1,6 @@
 // TODO convert this to use / return URLs
 import { createRequire } from 'module'; // https://stackoverflow.com/a/62499498/417806
-import fs from 'fs/promises';
+import { checkResourceExists } from '../lib/resource-utils.js';
 
 // defer to NodeJS to find where on disk a package is located using import.meta.resolve
 // and return the root absolute location
@@ -35,11 +35,8 @@ async function getNodeModulesLocationForPackage(packageName) {
       const nodeModulesPackageRoot = `${locations[location]}/${packageName}`;
       const packageJsonLocation = `${nodeModulesPackageRoot}/package.json`;
 
-      try {
-        await fs.access(new URL(`file://${packageJsonLocation}`));
+      if (await checkResourceExists(new URL(`file://${packageJsonLocation}`))) {
         nodeModulesUrl = nodeModulesPackageRoot;
-      } catch(e) {
-        // console.debug('shouldSeRvE hiding', { e })
       }
     }
 

--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -1,7 +1,6 @@
 // TODO convert this to use / return URLs
 import { createRequire } from 'module'; // https://stackoverflow.com/a/62499498/417806
-import fs from 'fs';
-import path from 'path';
+import fs from 'fs/promises';
 
 // defer to NodeJS to find where on disk a package is located using import.meta.resolve
 // and return the root absolute location
@@ -36,14 +35,17 @@ async function getNodeModulesLocationForPackage(packageName) {
       const nodeModulesPackageRoot = `${locations[location]}/${packageName}`;
       const packageJsonLocation = `${nodeModulesPackageRoot}/package.json`;
 
-      if (fs.existsSync(packageJsonLocation)) {
+      try {
+        await fs.access(new URL(`file://${packageJsonLocation}`));
         nodeModulesUrl = nodeModulesPackageRoot;
+      } catch(e) {
+        // console.debug('shouldSeRvE hiding', { e })
       }
     }
 
     if (!nodeModulesUrl) {
       console.debug(`Unable to look up ${packageName} using NodeJS require.resolve.  Falling back to process.cwd()`);
-      nodeModulesUrl = path.join(process.cwd(), 'node_modules', packageName); // force / for consistency and path matching);
+      nodeModulesUrl = new URL(`./node_modules/${packageName}`, `file://${process.cwd()}`).pathname;
     }
   }
 

--- a/packages/cli/src/lib/resource-interface.js
+++ b/packages/cli/src/lib/resource-interface.js
@@ -18,6 +18,7 @@ class ResourceInterface {
   // * and a nested path in the template - ../../styles/theme.css
   // so will get resolved as `${rootUrl}/styles/theme.css`
   async resolveForRelativeUrl(url, rootUrl) {
+    const search = url.search || '';
     let reducedUrl;
     let atRoot;
 
@@ -25,11 +26,11 @@ class ResourceInterface {
       await fs.access(new URL(`.${url.pathname}`, rootUrl));
       atRoot = true;
     } catch (e) {
-      // console.debug('reesolveFoRRelative', { e });
+
     }
 
     if (atRoot) {
-      return new URL(`.${url.pathname}`, rootUrl);
+      return new URL(`.${url.pathname}${search}`, rootUrl);
     }
 
     const segments = url.pathname.split('/').filter(segment => segment !== '');
@@ -39,10 +40,12 @@ class ResourceInterface {
       try {
         const nextSegments = segments.slice(i);
         const urlToCheck = new URL(`./${nextSegments.join('/')}`, rootUrl);
+
         await fs.access(urlToCheck);
-        reducedUrl = urlToCheck;
+
+        reducedUrl = new URL(`${urlToCheck}${search}`);
       } catch (e) {
-        // console.debug('resolveForRelativeUrl trying again....');
+
       }
     }
 

--- a/packages/cli/src/lib/resource-interface.js
+++ b/packages/cli/src/lib/resource-interface.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import { checkResourceExists } from './resource-utils.js';
 
 class ResourceInterface {
   constructor(compilation, options = {}) {
@@ -20,16 +20,8 @@ class ResourceInterface {
   async resolveForRelativeUrl(url, rootUrl) {
     const search = url.search || '';
     let reducedUrl;
-    let atRoot;
 
-    try {
-      await fs.access(new URL(`.${url.pathname}`, rootUrl));
-      atRoot = true;
-    } catch (e) {
-
-    }
-
-    if (atRoot) {
+    if (await checkResourceExists(new URL(`.${url.pathname}`, rootUrl))) {
       return new URL(`.${url.pathname}${search}`, rootUrl);
     }
 
@@ -37,15 +29,11 @@ class ResourceInterface {
     segments.shift();
 
     for (let i = 0, l = segments.length - 1; i < l; i += 1) {
-      try {
-        const nextSegments = segments.slice(i);
-        const urlToCheck = new URL(`./${nextSegments.join('/')}`, rootUrl);
+      const nextSegments = segments.slice(i);
+      const urlToCheck = new URL(`./${nextSegments.join('/')}`, rootUrl);
 
-        await fs.access(urlToCheck);
-
+      if (await checkResourceExists(urlToCheck)) {
         reducedUrl = new URL(`${urlToCheck}${search}`);
-      } catch (e) {
-
       }
     }
 

--- a/packages/cli/src/lib/resource-interface.js
+++ b/packages/cli/src/lib/resource-interface.js
@@ -24,30 +24,27 @@ class ResourceInterface {
     try {
       await fs.access(new URL(`.${url.pathname}`, rootUrl));
       atRoot = true;
-    } catch(e) {
-      console.debug('reesolveFoRRelative', { e })
+    } catch (e) {
+      // console.debug('reesolveFoRRelative', { e });
     }
 
     if (atRoot) {
       return new URL(`.${url.pathname}`, rootUrl);
     }
 
-    url.pathname.split('/')
-      .filter((segment) => segment !== '')
-      .reduce(async (acc, segment) => {
-        const reducedPath = url.pathname.replace(`${acc}/${segment}`, '');
+    const segments = url.pathname.split('/').filter(segment => segment !== '');
+    segments.shift();
 
-        try {
-          if(reducedPath !== '') {
-            await fs.access(new URL(`.${reducedPath}`, rootUrl));
-            reducedUrl = new URL(`.${reducedPath}`, rootUrl);
-          }
-        } catch(e) {
-          console.debug('reesolveFoRRelative reducing', { e })
-        }
-
-        return `${acc}/${segment}`;
-      }, '');
+    for (let i = 0, l = segments.length - 1; i < l; i += 1) {
+      try {
+        const nextSegments = segments.slice(i);
+        const urlToCheck = new URL(`./${nextSegments.join('/')}`, rootUrl);
+        await fs.access(urlToCheck);
+        reducedUrl = urlToCheck;
+      } catch (e) {
+        // console.debug('resolveForRelativeUrl trying again....');
+      }
+    }
 
     return reducedUrl;
   }

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -1,10 +1,10 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { hashString } from '../lib/hashing-utils.js';
 
-function modelResource(context, type, src = undefined, contents = undefined, optimizationAttr = undefined, rawAttributes = undefined) {
+async function modelResource(context, type, src = undefined, contents = undefined, optimizationAttr = undefined, rawAttributes = undefined) {
   const { projectDirectory, scratchDir, userWorkspace } = context;
   const extension = type === 'script' ? 'js' : 'css';
-  const windowsDriveRegex = /\/[a-zA-Z]{1}:\//;
+  // const windowsDriveRegex = /\/[a-zA-Z]{1}:\//;
   let sourcePathURL;
 
   if (src) {
@@ -14,26 +14,26 @@ function modelResource(context, type, src = undefined, contents = undefined, opt
         ? new URL(`.${src}`, userWorkspace)
         : new URL(`./${src.replace(/\.\.\//g, '').replace('./', '')}`, userWorkspace);
 
-    contents = fs.readFileSync(sourcePathURL, 'utf-8');
+    contents = await fs.readFile(sourcePathURL, 'utf-8');
   } else {
     const scratchFileName = hashString(contents);
 
     sourcePathURL = new URL(`./${scratchFileName}.${extension}`, scratchDir);
-    fs.writeFileSync(sourcePathURL, contents);
+    await fs.writeFile(sourcePathURL, contents);
   }
 
   // TODO (good first issue) handle for Windows adding extra / in front of drive letter for whatever reason :(
   // e.g. turn /C:/... -> C:/...
   // and also URL is readonly in NodeJS??
-  if (windowsDriveRegex.test(sourcePathURL.pathname)) {
-    const driveMatch = sourcePathURL.pathname.match(windowsDriveRegex)[0];
+  // if (windowsDriveRegex.test(sourcePathURL.pathname)) {
+  //   const driveMatch = sourcePathURL.pathname.match(windowsDriveRegex)[0];
 
-    sourcePathURL = {
-      ...sourcePathURL,
-      pathname: sourcePathURL.pathname.replace(driveMatch, driveMatch.replace('/', '')),
-      href: sourcePathURL.href.replace(driveMatch, driveMatch.replace('/', ''))
-    };
-  }
+  //   sourcePathURL = {
+  //     ...sourcePathURL,
+  //     pathname: sourcePathURL.pathname.replace(driveMatch, driveMatch.replace('/', '')),
+  //     href: sourcePathURL.href.replace(driveMatch, driveMatch.replace('/', ''))
+  //   };
+  // }
 
   return {
     src, // if <script src="..."></script> or <link href="..."></link>

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -53,21 +53,32 @@ function mergeResponse(destination, source) {
 
 // On Windows, a URL with a drive letter like C:/ thinks it is a protocol and so prepends a /, e.g. /C:/
 // This is fine with never fs methods that Greenwood uses, but tools like Rollupand PostCSS will need this handled manually
+// https://github.com/rollup/rollup/issues/3779
 function normalizePathnameForWindows(url) {
   const windowsDriveRegex = /\/[a-zA-Z]{1}:\//;
   const { pathname = '' } = url;
 
   if (windowsDriveRegex.test(pathname)) {
-   const driveMatch = pathname.match(windowsDriveRegex)[0];
+    const driveMatch = pathname.match(windowsDriveRegex)[0];
 
-   return pathname.replace(driveMatch, driveMatch.replace('/', ''))
+    return pathname.replace(driveMatch, driveMatch.replace('/', ''));
   }
 
   return pathname;
 }
 
+async function checkResourceExists(url) {
+  try {
+    await fs.access(url);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 export {
   mergeResponse,
   modelResource,
-  normalizePathnameForWindows
+  normalizePathnameForWindows,
+  checkResourceExists
 };

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -51,7 +51,23 @@ function mergeResponse(destination, source) {
   });
 }
 
+// On Windows, a URL with a drive letter like C:/ thinks it is a protocol and so prepends a /, e.g. /C:/
+// This is fine with never fs methods that Greenwood uses, but tools like Rollupand PostCSS will need this handled manually
+function normalizePathnameForWindows(url) {
+  const windowsDriveRegex = /\/[a-zA-Z]{1}:\//;
+  const { pathname = '' } = url;
+
+  if (windowsDriveRegex.test(pathname)) {
+   const driveMatch = pathname.match(windowsDriveRegex)[0];
+
+   return pathname.replace(driveMatch, driveMatch.replace('/', ''))
+  }
+
+  return pathname;
+}
+
 export {
   mergeResponse,
-  modelResource
+  modelResource,
+  normalizePathnameForWindows
 };

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -4,7 +4,6 @@ import { hashString } from '../lib/hashing-utils.js';
 async function modelResource(context, type, src = undefined, contents = undefined, optimizationAttr = undefined, rawAttributes = undefined) {
   const { projectDirectory, scratchDir, userWorkspace } = context;
   const extension = type === 'script' ? 'js' : 'css';
-  // const windowsDriveRegex = /\/[a-zA-Z]{1}:\//;
   let sourcePathURL;
 
   if (src) {
@@ -21,19 +20,6 @@ async function modelResource(context, type, src = undefined, contents = undefine
     sourcePathURL = new URL(`./${scratchFileName}.${extension}`, scratchDir);
     await fs.writeFile(sourcePathURL, contents);
   }
-
-  // TODO (good first issue) handle for Windows adding extra / in front of drive letter for whatever reason :(
-  // e.g. turn /C:/... -> C:/...
-  // and also URL is readonly in NodeJS??
-  // if (windowsDriveRegex.test(sourcePathURL.pathname)) {
-  //   const driveMatch = sourcePathURL.pathname.match(windowsDriveRegex)[0];
-
-  //   sourcePathURL = {
-  //     ...sourcePathURL,
-  //     pathname: sourcePathURL.pathname.replace(driveMatch, driveMatch.replace('/', '')),
-  //     href: sourcePathURL.href.replace(driveMatch, driveMatch.replace('/', ''))
-  //   };
-  // }
 
   return {
     src, // if <script src="..."></script> or <link href="..."></link>

--- a/packages/cli/src/lib/ssr-route-worker.js
+++ b/packages/cli/src/lib/ssr-route-worker.js
@@ -21,7 +21,7 @@ async function executeRouteModule({ moduleUrl, compilation, route, label, id, pr
     const { getTemplate = null, getBody = null, getFrontmatter = null } = module;
 
     if (module.default) {
-      const { html } = await renderToString(moduleUrl);
+      const { html } = await renderToString(new URL(moduleUrl));
 
       data.body = html;
     } else {

--- a/packages/cli/src/lib/ssr-route-worker.js
+++ b/packages/cli/src/lib/ssr-route-worker.js
@@ -1,9 +1,8 @@
 // https://github.com/nodejs/modules/issues/307#issuecomment-858729422
-import { pathToFileURL } from 'url';
 import { parentPort } from 'worker_threads';
 import { renderToString, renderFromHTML } from 'wc-compiler';
 
-async function executeRouteModule({ modulePath, compilation, route, label, id, prerender, htmlContents, scripts }) {
+async function executeRouteModule({ moduleUrl, compilation, route, label, id, prerender, htmlContents, scripts }) {
   const parsedCompilation = JSON.parse(compilation);
   const data = {
     template: null,
@@ -18,11 +17,11 @@ async function executeRouteModule({ modulePath, compilation, route, label, id, p
 
     data.html = html;
   } else {
-    const module = await import(pathToFileURL(modulePath)).then(module => module);
+    const module = await import(moduleUrl).then(module => module);
     const { getTemplate = null, getBody = null, getFrontmatter = null } = module;
 
     if (module.default) {
-      const { html } = await renderToString(pathToFileURL(modulePath));
+      const { html } = await renderToString(moduleUrl);
 
       data.body = html;
     } else {

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -83,13 +83,13 @@ async function bundleStyleResources(compilation, resourcePlugins) {
       const outputPathRoot = new URL(`./${optimizedFileName}`, outputDir).pathname
         .split('/')
         .slice(0, -1)
-        .join('/');
+        .join('/')
+        .concat('/');
 
-      console.debug('???', new URL(`file://${outputPathRoot}`))
       try {
-        fs.access(new URL(`file://${outputPathRoot}`));
+        await fs.access(new URL(`file://${outputPathRoot}`));
       } catch (error) {
-        fs.mkdir(new URL(`file://${outputPathRoot}`), {
+        await fs.mkdir(new URL(`file://${outputPathRoot}`), {
           recursive: true
         });
       }

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -33,7 +33,7 @@ async function optimizeStaticPages(compilation, plugins) {
       let response = new Response(contents, { headers });
 
       try {
-        await fs.access(new URL(`.${route}`, outputDir))
+        await fs.access(new URL(`.${route}`, outputDir));
       } catch (error) {
         await fs.mkdir(new URL(`.${route}`, outputDir), {
           recursive: true

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -15,7 +15,7 @@ async function cleanUpResources(compilation) {
     const optAttr = ['inline', 'static'].indexOf(optimizationAttr) >= 0;
 
     if (optimizedFileName && (!src || (optAttr || optConfig))) {
-      await fs.unlink(new URL(`./${optimizedFileName}`, outputDir).pathname);
+      await fs.unlink(new URL(`./${optimizedFileName}`, outputDir));
     }
   }
 }

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -89,7 +89,7 @@ const readAndMergeConfig = async() => {
           try {
             await fs.access(workspace);
             customConfig.workspace = workspace;
-          } catch(e) {
+          } catch (e) {
             reject('Error: greenwood.config.js workspace doesn\'t exist! Please double check your configuration.');
           }
         }

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import { checkResourceExists } from '../lib/resource-utils.js';
 
 const cwd = new URL(`file://${process.cwd()}/`);
 const greenwoodPluginsDirectoryUrl = new URL('../plugins/', import.meta.url);
@@ -61,19 +62,13 @@ const readAndMergeConfig = async() => {
       let isSPA;
 
       // check for greenwood.config.js
-      try {
-        await fs.access(configUrl);
+      if (await checkResourceExists(configUrl)) {
         hasConfigFile = true;
-      } catch (e) {
-
       }
 
       // check for SPA
-      try {
-        await fs.access(new URL('./index.html', customConfig.workspace));
+      if (await checkResourceExists(new URL('./index.html', customConfig.workspace))) {
         isSPA = true;
-      } catch (e) {
-
       }
 
       if (hasConfigFile) {
@@ -86,10 +81,9 @@ const readAndMergeConfig = async() => {
             reject('Error: greenwood.config.js workspace must be an instance of URL');
           }
 
-          try {
-            await fs.access(workspace);
+          if (await checkResourceExists(workspace)) {
             customConfig.workspace = workspace;
-          } catch (e) {
+          } else {
             reject('Error: greenwood.config.js workspace doesn\'t exist! Please double check your configuration.');
           }
         }

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -64,7 +64,7 @@ const readAndMergeConfig = async() => {
       try {
         await fs.access(configUrl);
         hasConfigFile = true;
-      } catch(e) {
+      } catch (e) {
 
       }
 
@@ -72,7 +72,7 @@ const readAndMergeConfig = async() => {
       try {
         await fs.access(new URL('./index.html', customConfig.workspace));
         isSPA = true;
-      } catch(e) {
+      } catch (e) {
 
       }
 

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import { checkResourceExists } from '../lib/resource-utils.js';
 
 const initContext = async({ config }) => {
 
@@ -25,12 +26,10 @@ const initContext = async({ config }) => {
         projectDirectory
       };
 
-      try {
-        await fs.access(scratchDir);
-      } catch(e) {
+      if (!await checkResourceExists(scratchDir)) {
         await fs.mkdir(scratchDir, {
           recursive: true
-        })
+        });
       }
       
       resolve(context);

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 const initContext = async({ config }) => {
 
@@ -14,7 +14,6 @@ const initContext = async({ config }) => {
       const apisDir = new URL('./api/', userWorkspace);
       const pagesDir = new URL(`./${pagesDirectory}/`, userWorkspace);
       const userTemplatesDir = new URL(`./${templatesDirectory}/`, userWorkspace);
-
       const context = {
         dataDir,
         outputDir,
@@ -26,10 +25,12 @@ const initContext = async({ config }) => {
         projectDirectory
       };
 
-      if (!fs.existsSync(scratchDir.pathname)) {
-        fs.mkdirSync(scratchDir.pathname, {
+      try {
+        await fs.access(scratchDir);
+      } catch(e) {
+        await fs.mkdir(scratchDir, {
           recursive: true
-        });
+        })
       }
       
       resolve(context);

--- a/packages/cli/src/lifecycles/copy.js
+++ b/packages/cli/src/lifecycles/copy.js
@@ -16,8 +16,8 @@ async function rreaddir (dir, allFiles = []) {
 async function copyFile(source, target, projectDirectory) {
   try {
     console.info(`copying file... ${source.pathname.replace(projectDirectory.pathname, '')}`);
-    const rd = fs.createReadStream(source.pathname);
-    const wr = fs.createWriteStream(target.pathname);
+    const rd = fs.createReadStream(source);
+    const wr = fs.createWriteStream(target);
 
     return await new Promise((resolve, reject) => {
       rd.on('error', reject);
@@ -51,7 +51,13 @@ async function copyDirectory(fromUrl, toUrl, projectDirectory) {
         const isDirectory = (await fs.promises.stat(fileUrl)).isDirectory();
 
         if (isDirectory) {
-          await fs.promises.mkdir(targetUrl);
+          try {
+            await fs.promises.access(targetUrl);
+          } catch (e) {
+            await fs.promises.mkdir(targetUrl, {
+              recursive: true
+            });
+          }
         } else if (!isDirectory) {
           await copyFile(fileUrl, targetUrl, projectDirectory);
         }

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -132,10 +132,10 @@ const generateGraph = async (compilation) => {
 
                 worker.on('message', (result) => {
                   if (result.frontmatter) {
-                    const resources = (result.frontmatter.imports || []).map((resource) => {
+                    const resources = (result.frontmatter.imports || []).map(async (resource) => {
                       const type = resource.split('.').pop() === 'js' ? 'script' : 'link';
 
-                      return modelResource(compilation.context, type, resource);
+                      return await modelResource(compilation.context, type, resource);
                     });
 
                     result.frontmatter.imports = resources;

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -1,6 +1,6 @@
 import fs from 'fs/promises';
 import htmlparser from 'node-html-parser';
-import { modelResource } from '../lib/resource-utils.js';
+import { checkResourceExists, modelResource } from '../lib/resource-utils.js';
 import os from 'os';
 import { WorkerPool } from '../lib/threadpool.js';
 
@@ -9,11 +9,7 @@ function isLocalLink(url = '') {
 }
 
 async function createOutputDirectory(route, outputDir) {
-  try {
-    if (route !== '/404/') {
-      await fs.access(outputDir);
-    }
-  } catch (e) {
+  if (route !== '/404/' && !await checkResourceExists(outputDir)) {
     await fs.mkdir(outputDir, {
       recursive: true
     });

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { hashString } from '../lib/hashing-utils.js';
 import Koa from 'koa';
 import { mergeResponse } from '../lib/resource-utils.js';
@@ -166,7 +166,7 @@ async function getStaticServer(compilation, composable) {
 
     if ((matchingRoute && !matchingRoute.isSSR) || url.pathname.split('.').pop() === 'html') {
       const pathname = matchingRoute ? matchingRoute.outputPath : url.pathname;
-      const body = await fs.promises.readFile(new URL(`./${pathname}`, outputDir), 'utf-8');
+      const body = await fs.readFile(new URL(`./${pathname}`, outputDir), 'utf-8');
 
       ctx.set('Content-Type', 'text/html');
       ctx.body = body;

--- a/packages/cli/src/plugins/copy/plugin-copy-assets.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-assets.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import { checkResourceExists } from '../../lib/resource-utils.js';
 
 const greenwoodPluginCopyAssets = [{
   type: 'copy',
@@ -8,15 +8,11 @@ const greenwoodPluginCopyAssets = [{
     const fromAssetsDirUrl = new URL('./assets/', userWorkspace);
     const assets = [];
 
-    try {
-      await fs.access(fromAssetsDirUrl);
-
+    if (await checkResourceExists(fromAssetsDirUrl)) {
       assets.push({
         from: fromAssetsDirUrl,
         to: new URL('./assets/', outputDir)
       });
-    } catch (e) {
-
     }
 
     return assets;

--- a/packages/cli/src/plugins/copy/plugin-copy-assets.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-assets.js
@@ -1,18 +1,22 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 const greenwoodPluginCopyAssets = [{
   type: 'copy',
   name: 'plugin-copy-assets',
-  provider: (compilation) => {
+  provider: async (compilation) => {
     const { outputDir, userWorkspace } = compilation.context;
     const fromAssetsDirUrl = new URL('./assets/', userWorkspace);
     const assets = [];
 
-    if (fs.existsSync(fromAssetsDirUrl.pathname)) {
+    try {
+      await fs.access(fromAssetsDirUrl);
+
       assets.push({
         from: fromAssetsDirUrl,
         to: new URL('./assets/', outputDir)
       });
+    } catch (e) {
+
     }
 
     return assets;

--- a/packages/cli/src/plugins/copy/plugin-copy-favicon.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-favicon.js
@@ -17,7 +17,7 @@ const greenwoodPluginCopyFavicon = [{
         to: new URL(`./${fileName}`, outputDir)
       });
     } catch (error) {
-      console.log('copy favion', { error });
+
     }
 
     return assets;

--- a/packages/cli/src/plugins/copy/plugin-copy-favicon.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-favicon.js
@@ -1,19 +1,23 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 const greenwoodPluginCopyFavicon = [{
   type: 'copy',
   name: 'plugin-copy-favicon',
-  provider: (compilation) => {
+  provider: async (compilation) => {
     const fileName = 'favicon.ico';
     const { outputDir, userWorkspace } = compilation.context;
     const robotsPathUrl = new URL(`./${fileName}`, userWorkspace);
     const assets = [];
 
-    if (fs.existsSync(robotsPathUrl.pathname)) {
+    try {
+      await fs.access(robotsPathUrl);
+
       assets.push({
         from: robotsPathUrl,
         to: new URL(`./${fileName}`, outputDir)
       });
+    } catch (error) {
+      console.log('copy favion', { error });
     }
 
     return assets;

--- a/packages/cli/src/plugins/copy/plugin-copy-favicon.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-favicon.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import { checkResourceExists } from '../../lib/resource-utils.js';
 
 const greenwoodPluginCopyFavicon = [{
   type: 'copy',
@@ -6,18 +6,14 @@ const greenwoodPluginCopyFavicon = [{
   provider: async (compilation) => {
     const fileName = 'favicon.ico';
     const { outputDir, userWorkspace } = compilation.context;
-    const robotsPathUrl = new URL(`./${fileName}`, userWorkspace);
+    const faviconPathUrl = new URL(`./${fileName}`, userWorkspace);
     const assets = [];
 
-    try {
-      await fs.access(robotsPathUrl);
-
+    if (await checkResourceExists(faviconPathUrl)) {
       assets.push({
-        from: robotsPathUrl,
+        from: faviconPathUrl,
         to: new URL(`./${fileName}`, outputDir)
       });
-    } catch (error) {
-
     }
 
     return assets;

--- a/packages/cli/src/plugins/copy/plugin-copy-robots.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-robots.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import { checkResourceExists } from '../../lib/resource-utils.js';
 
 const greenwoodPluginCopyRobots = [{
   type: 'copy',
@@ -9,15 +9,11 @@ const greenwoodPluginCopyRobots = [{
     const robotsPathUrl = new URL(`./${fileName}`, userWorkspace);
     const assets = [];
 
-    try {
-      await fs.access(robotsPathUrl);
-
+    if (await checkResourceExists(robotsPathUrl)) {
       assets.push({
         from: robotsPathUrl,
         to: new URL(`./${fileName}`, outputDir)
       });
-    } catch (e) {
-
     }
 
     return assets;

--- a/packages/cli/src/plugins/copy/plugin-copy-robots.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-robots.js
@@ -1,19 +1,23 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 const greenwoodPluginCopyRobots = [{
   type: 'copy',
   name: 'plugin-copy-robots',
-  provider: (compilation) => {
+  provider: async (compilation) => {
     const fileName = 'robots.txt';
     const { outputDir, userWorkspace } = compilation.context;
     const robotsPathUrl = new URL(`./${fileName}`, userWorkspace);
     const assets = [];
 
-    if (fs.existsSync(robotsPathUrl.pathname)) {
+    try {
+      await fs.access(robotsPathUrl);
+
       assets.push({
         from: robotsPathUrl,
         to: new URL(`./${fileName}`, outputDir)
       });
+    } catch (e) {
+
     }
 
     return assets;

--- a/packages/cli/src/plugins/resource/plugin-api-routes.js
+++ b/packages/cli/src/plugins/resource/plugin-api-routes.js
@@ -18,13 +18,13 @@ class ApiRoutesResource extends ResourceInterface {
     try {
       // TODO Could this existence check be derived from the graph instead, like pages are?
       // https://github.com/ProjectEvergreen/greenwood/issues/946
-      if (protocol.startsWith('http') === 0 && pathname.startsWith('/api')) {
+      if (protocol.startsWith('http') && pathname.startsWith('/api')) {
         await fs.access(apiPathUrl);
 
         return true;
       }
     } catch (error) {
-      
+
     }
   }
 

--- a/packages/cli/src/plugins/resource/plugin-api-routes.js
+++ b/packages/cli/src/plugins/resource/plugin-api-routes.js
@@ -3,7 +3,7 @@
  * Manages routing to API routes.
  *
  */
-import fs from 'fs/promises';
+import { checkResourceExists } from '../../lib/resource-utils.js';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class ApiRoutesResource extends ResourceInterface {
@@ -15,16 +15,8 @@ class ApiRoutesResource extends ResourceInterface {
     const { protocol, pathname } = url;
     const apiPathUrl = new URL(`.${pathname.replace('/api', '')}.js`, this.compilation.context.apisDir);
 
-    try {
-      // TODO Could this existence check be derived from the graph instead, like pages are?
-      // https://github.com/ProjectEvergreen/greenwood/issues/946
-      if (protocol.startsWith('http') && pathname.startsWith('/api')) {
-        await fs.access(apiPathUrl);
-
-        return true;
-      }
-    } catch (error) {
-
+    if (protocol.startsWith('http') && pathname.startsWith('/api') && await checkResourceExists(apiPathUrl)) {
+      return true;
     }
   }
 

--- a/packages/cli/src/plugins/resource/plugin-source-maps.js
+++ b/packages/cli/src/plugins/resource/plugin-source-maps.js
@@ -3,6 +3,7 @@
  * Detects and fully resolve requests to source map (.map) files.
  *
  */
+import { checkResourceExists } from '../../lib/resource-utils.js';
 import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
@@ -14,14 +15,7 @@ class SourceMapsResource extends ResourceInterface {
   }
 
   async shouldServe(url) {
-    try {
-      if (url.pathname.split('.').pop() === this.extensions[0]) {
-        await fs.access(url);
-        return true;
-      }
-    } catch (e) {
-
-    }
+    return url.pathname.split('.').pop() === this.extensions[0] && await checkResourceExists(url);
   }
 
   async serve(url) {

--- a/packages/cli/src/plugins/resource/plugin-source-maps.js
+++ b/packages/cli/src/plugins/resource/plugin-source-maps.js
@@ -3,7 +3,7 @@
  * Detects and fully resolve requests to source map (.map) files.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class SourceMapsResource extends ResourceInterface {
@@ -14,11 +14,18 @@ class SourceMapsResource extends ResourceInterface {
   }
 
   async shouldServe(url) {
-    return url.pathname.split('.').pop() === this.extensions[0] && fs.existsSync(url.pathname);
+    try {
+      if (url.pathname.split('.').pop() === this.extensions[0]) {
+        fs.access(url);
+        return true;
+      }
+    } catch (error) {
+      
+    }
   }
 
   async serve(url) {
-    const body = await fs.promises.readFile(url, 'utf-8');
+    const body = await fs.readFile(url, 'utf-8');
 
     return new Response(body, {
       headers: new Headers({

--- a/packages/cli/src/plugins/resource/plugin-source-maps.js
+++ b/packages/cli/src/plugins/resource/plugin-source-maps.js
@@ -16,11 +16,11 @@ class SourceMapsResource extends ResourceInterface {
   async shouldServe(url) {
     try {
       if (url.pathname.split('.').pop() === this.extensions[0]) {
-        fs.access(url);
+        await fs.access(url);
         return true;
       }
-    } catch (error) {
-      
+    } catch (e) {
+
     }
   }
 

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -4,7 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
-import fs from 'fs/promises';
+import fs from 'fs';
 import { parse, walk } from 'css-tree';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
@@ -27,7 +27,8 @@ function bundleCss(body, url, projectDirectory) {
           const resolvedUrl = value.startsWith('/node_modules')
             ? new URL(`.${value}`, projectDirectory)
             : new URL(value, url);
-          const importContents = fs.readFile(resolvedUrl, 'utf-8');
+          // TODO intentionally using sync, unless csstree can support an async walk?
+          const importContents = fs.readFileSync(resolvedUrl, 'utf-8');
 
           optimizedCss += bundleCss(importContents, url, projectDirectory);
         } else {
@@ -214,7 +215,7 @@ class StandardCssResource extends ResourceInterface {
   }
 
   async serve(url) {
-    const body = await fs.readFile(url, 'utf-8');
+    const body = await fs.promises.readFile(url, 'utf-8');
 
     return new Response(body, {
       headers: {

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -4,7 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { parse, walk } from 'css-tree';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
@@ -27,7 +27,7 @@ function bundleCss(body, url, projectDirectory) {
           const resolvedUrl = value.startsWith('/node_modules')
             ? new URL(`.${value}`, projectDirectory)
             : new URL(value, url);
-          const importContents = fs.readFileSync(resolvedUrl.pathname, 'utf-8');
+          const importContents = fs.readFile(resolvedUrl, 'utf-8');
 
           optimizedCss += bundleCss(importContents, url, projectDirectory);
         } else {
@@ -214,7 +214,7 @@ class StandardCssResource extends ResourceInterface {
   }
 
   async serve(url) {
-    const body = await fs.promises.readFile(url, 'utf-8');
+    const body = await fs.readFile(url, 'utf-8');
 
     return new Response(body, {
       headers: {

--- a/packages/cli/src/plugins/resource/plugin-standard-font.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-font.js
@@ -4,7 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class StandardFontResource extends ResourceInterface {
@@ -22,7 +22,7 @@ class StandardFontResource extends ResourceInterface {
   async serve(url) {
     const extension = url.pathname.split('.').pop();
     const contentType = extension === 'eot' ? 'application/vnd.ms-fontobject' : extension;
-    const body = await fs.promises.readFile(url);
+    const body = await fs.readFile(url);
 
     return new Response(body, {
       headers: new Headers({

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -27,10 +27,7 @@ function getCustomPageTemplatesFromPlugins(contextPlugins, templateName) {
         if (templateName) {
           fs.access(new URL(`./${templateName}.html`, templateDirUrl)).then(() => true);
         }
-        // await fs.access(new URL(`./${templateName}.html`, templateDirUrl));
-
-        // return true;
-      } catch(e) {
+      } catch (e) {
         return false;
       }
     });
@@ -51,19 +48,19 @@ const getPageTemplate = async (filePath, { userTemplatesDir, pagesDir, projectDi
   try {
     await fs.access(new URL(`./${template}.html`, userTemplatesDir));
     hasCustomTemplate = true;
-  } catch(e) {
-    console.debug('111', { e })
+  } catch (e) {
+    console.debug('111', { e });
   }
 
   // check page is already HTML
   try {
     await fs.access(new URL(`./${filePath}`, projectDirectory));
 
-    if(extension === 'html') {
+    if (extension === 'html') {
       isHtmlPage = true;
     }
-  } catch(e) {
-    console.debug('222', { e })
+  } catch (e) {
+    console.debug('222', { e });
   }
 
   // check for default page template
@@ -71,8 +68,8 @@ const getPageTemplate = async (filePath, { userTemplatesDir, pagesDir, projectDi
     // fs.existsSync(new URL('./page.html', templatesDir).pathname))
     await fs.access(new URL('./page.html', userTemplatesDir));
     hasPageTemplate = true;
-  } catch(e) {
-    console.debug('333', { e })
+  } catch (e) {
+    console.debug('333', { e });
   }
 
   // check for custom 404 page
@@ -80,7 +77,7 @@ const getPageTemplate = async (filePath, { userTemplatesDir, pagesDir, projectDi
     // fs.existsSync(new URL('./404.html', pagesDir).pathname)
     await fs.access(new URL('./404.html', pagesDir));
     hasCustom404Page = true;
-  } catch(e) {
+  } catch (e) {
     console.debug('444', { e })
   }
 
@@ -120,7 +117,7 @@ const getAppTemplate = async (pageTemplateContents, templatesDir, customImports 
   try {
     await fs.access(userAppTemplateUrl);
     hasCustomUserAppTemplate = true;
-  } catch(e) {
+  } catch (e) {
     console.debug('userAPpTemplatePAtj', { e });
   }
 
@@ -245,7 +242,7 @@ const getUserScripts = async (contents, context) => {
       // fs.existsSync(new URL('./package.json', userWorkspace).pathname
       await fs.access(monorepoPackageJsonUrl);
       hasMonorepoPackageJson = true;
-    } catch(e) {
+    } catch (e) {
 
     }
 
@@ -254,7 +251,7 @@ const getUserScripts = async (contents, context) => {
       // fs.existsSync(new URL('./package.json', projectDirectory).pathname)
       await fs.access(topLevelPackageJsonUrl);
       hasTopLevelPackageJson = true;
-    } catch(e) {
+    } catch (e) {
 
     }
 

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -22,10 +22,10 @@ function getCustomPageTemplatesFromPlugins(contextPlugins, templateName) {
   return contextPlugins
     .map(plugin => plugin.templates)
     .flat()
-    .filter((templateDirUrl) => {
+    .filter(async(templateDirUrl) => {
       try {
         if (templateName) {
-          fs.access(new URL(`./${templateName}.html`, templateDirUrl)).then(() => true);
+          await fs.access(new URL(`./${templateName}.html`, templateDirUrl)).then(() => true);
         }
       } catch (e) {
         return false;

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -103,10 +103,10 @@ const getPageTemplate = async (filePath, { userTemplatesDir, pagesDir, projectDi
       ? await fs.readFile(new URL('./page.html', customPluginDefaultPageTemplates[0]), 'utf-8')
       : await fs.readFile(new URL('./page.html', userTemplatesDir), 'utf-8');
   } else if (is404Page && !hasCustom404Page) {
-    contents = await fs.readFile(new URL('../../templates/404.html', import.meta.url).pathname, 'utf-8');
+    contents = await fs.readFile(new URL('../../templates/404.html', import.meta.url), 'utf-8');
   } else {
     // fallback to using Greenwood's stock page template
-    contents = await fs.readFile(new URL('../../templates/page.html', import.meta.url).pathname, 'utf-8');
+    contents = await fs.readFile(new URL('../../templates/page.html', import.meta.url), 'utf-8');
   }
 
   return contents;

--- a/packages/cli/src/plugins/resource/plugin-standard-image.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-image.js
@@ -4,7 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class StandardFontResource extends ResourceInterface {
@@ -22,7 +22,7 @@ class StandardFontResource extends ResourceInterface {
   async serve(url) {
     const extension = url.pathname.split('.').pop();
     const type = extension === 'svg' ? `${extension}+xml` : extension;
-    const body = await fs.promises.readFile(url);
+    const body = await fs.readFile(url);
     const contentType = extension === 'ico'
       ? 'x-icon'
       : type;

--- a/packages/cli/src/plugins/resource/plugin-standard-javascript.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-javascript.js
@@ -4,7 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 import terser from '@rollup/plugin-terser';
 
@@ -20,8 +20,8 @@ class StandardJavaScriptResource extends ResourceInterface {
   }
 
   async serve(url) {
-    const body = await fs.promises.readFile(url, 'utf-8');
-    
+    const body = await fs.readFile(url, 'utf-8');
+
     return new Response(body, {
       headers: {
         'Content-Type': this.contentType

--- a/packages/cli/src/plugins/resource/plugin-standard-json.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-json.js
@@ -18,7 +18,7 @@ class StandardJsonResource extends ResourceInterface {
     const { protocol, pathname } = url;
     const isJson = pathname.split('.').pop() === this.extensions[0];
     const isGraphJson = pathname === '/graph.json';
-    const isWorkspaceFile = false;
+    let isWorkspaceFile = false;
     
     try {
       if (protocol === 'file:') {
@@ -26,7 +26,7 @@ class StandardJsonResource extends ResourceInterface {
         isWorkspaceFile = true;
       }
     } catch (error) {
-      
+
     }
 
     return isJson && (isWorkspaceFile || isGraphJson);

--- a/packages/cli/src/plugins/resource/plugin-standard-json.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-json.js
@@ -4,7 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
 class StandardJsonResource extends ResourceInterface {
@@ -18,7 +18,16 @@ class StandardJsonResource extends ResourceInterface {
     const { protocol, pathname } = url;
     const isJson = pathname.split('.').pop() === this.extensions[0];
     const isGraphJson = pathname === '/graph.json';
-    const isWorkspaceFile = protocol === 'file:' && fs.existsSync(url);
+    const isWorkspaceFile = false;
+    
+    try {
+      if (protocol === 'file:') {
+        await fs.access(url);
+        isWorkspaceFile = true;
+      }
+    } catch (error) {
+      
+    }
 
     return isJson && (isWorkspaceFile || isGraphJson);
   }
@@ -29,7 +38,7 @@ class StandardJsonResource extends ResourceInterface {
     const finalUrl = pathname.startsWith('/graph.json')
       ? new URL('./graph.json', scratchDir)
       : url;
-    const contents = await fs.promises.readFile(finalUrl, 'utf-8');
+    const contents = await fs.readFile(finalUrl, 'utf-8');
 
     return new Response(contents, {
       headers: new Headers({

--- a/packages/cli/src/plugins/resource/plugin-standard-json.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-json.js
@@ -4,6 +4,7 @@
  * This is a Greenwood default plugin.
  *
  */
+import { checkResourceExists } from '../../lib/resource-utils.js';
 import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
@@ -18,16 +19,7 @@ class StandardJsonResource extends ResourceInterface {
     const { protocol, pathname } = url;
     const isJson = pathname.split('.').pop() === this.extensions[0];
     const isGraphJson = pathname === '/graph.json';
-    let isWorkspaceFile = false;
-    
-    try {
-      if (protocol === 'file:') {
-        await fs.access(url);
-        isWorkspaceFile = true;
-      }
-    } catch (error) {
-
-    }
+    const isWorkspaceFile = protocol === 'file:' && await checkResourceExists(url);
 
     return isJson && (isWorkspaceFile || isGraphJson);
   }

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -60,7 +60,7 @@ class StaticRouterResource extends ResourceInterface {
     const { outputDir } = this.compilation.context;
     const partial = body.match(/<body>(.*)<\/body>/s)[0].replace('<body>', '').replace('</body>', '');
     const outputPartialDirUrl = new URL(`./_routes${url.pathname}`, outputDir);
-    const outputPartialDirPathUrl = new URL(`file://${outputPartialDirUrl.pathname.split('/').slice(0, -1).join('/')}`);
+    const outputPartialDirPathUrl = new URL(`file://${outputPartialDirUrl.pathname.split('/').slice(0, -1).join('/').concat('/')}`);
     let currentTemplate;
 
     const routeTags = this.compilation.graph
@@ -90,12 +90,6 @@ class StaticRouterResource extends ResourceInterface {
           recursive: true
         });
       }
-      
-      // if (!fs.existsSync(outputPartialDirPath)) {
-      //   fs.mkdirSync(outputPartialDirPath, {
-      //     recursive: true
-      //   });
-      // }
 
       await fs.writeFile(new URL('./index.html', outputPartialDirUrl), partial);
     }

--- a/packages/cli/src/plugins/resource/plugin-static-router.js
+++ b/packages/cli/src/plugins/resource/plugin-static-router.js
@@ -5,6 +5,7 @@
  * This is a Greenwood default plugin.
  *
  */
+import { checkResourceExists } from '../../lib/resource-utils.js';
 import fs from 'fs/promises';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 
@@ -83,9 +84,7 @@ class StaticRouterResource extends ResourceInterface {
       });
 
     if (isStaticRoute) {
-      try {
-        await fs.access(outputPartialDirPathUrl);
-      } catch (e) {
+      if (!await checkResourceExists(outputPartialDirPathUrl)) {
         await fs.mkdir(outputPartialDirPathUrl, {
           recursive: true
         });

--- a/packages/cli/src/plugins/resource/plugin-user-workspace.js
+++ b/packages/cli/src/plugins/resource/plugin-user-workspace.js
@@ -24,7 +24,6 @@ class UserWorkspaceResource extends ResourceInterface {
     const { userWorkspace } = this.compilation.context;
     const workspaceUrl = await this.resolveForRelativeUrl(url, userWorkspace);
 
-    console.debug({ workspaceUrl });
     return new Request(workspaceUrl);
   }
 }

--- a/packages/cli/src/plugins/resource/plugin-user-workspace.js
+++ b/packages/cli/src/plugins/resource/plugin-user-workspace.js
@@ -17,13 +17,14 @@ class UserWorkspaceResource extends ResourceInterface {
 
     return this.hasExtension(url)
       && !url.pathname.startsWith('/node_modules')
-      && this.resolveForRelativeUrl(url, userWorkspace);
+      && await this.resolveForRelativeUrl(url, userWorkspace);
   }
 
   async resolve(url) {
     const { userWorkspace } = this.compilation.context;
-    const workspaceUrl = this.resolveForRelativeUrl(url, userWorkspace);
+    const workspaceUrl = await this.resolveForRelativeUrl(url, userWorkspace);
 
+    console.debug({ workspaceUrl });
     return new Request(workspaceUrl);
   }
 }

--- a/packages/cli/src/plugins/server/plugin-livereload.js
+++ b/packages/cli/src/plugins/server/plugin-livereload.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import livereload from 'livereload';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 import { ServerInterface } from '../../lib/server-interface.js';
@@ -11,7 +11,7 @@ class LiveReloadServer extends ServerInterface {
   async start() {
     const { userWorkspace } = this.compilation.context;
     const standardPluginsDirectoryPath = new URL('../resource/', import.meta.url);
-    const standardPluginsNames = fs.readdirSync(standardPluginsDirectoryPath)
+    const standardPluginsNames = (await fs.readdir(standardPluginsDirectoryPath))
       .filter(filename => filename.indexOf('plugin-standard') === 0);
     const standardPluginsExtensions = (await Promise.all(standardPluginsNames.map(async (filename) => {
       const pluginImport = await import(new URL(`./${filename}`, standardPluginsDirectoryPath));

--- a/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
+++ b/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import os from 'os';
 import { spawnSync } from 'child_process';
 

--- a/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
+++ b/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import { spawnSync } from 'child_process';
 
-const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
+const packageJson = JSON.parse(await fs.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
 const myThemePackPlugin = () => [{
   type: 'context',
   name: 'my-theme-pack:context',

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -47,6 +47,7 @@ import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
+// TODO good first issue, to abstract along with copy plugin
 async function rreaddir (dir, allFiles = []) {
   const files = (await fs.promises.readdir(dir)).map(f => path.join(dir, f));
 
@@ -90,7 +91,7 @@ describe('Develop Greenwood With: ', function() {
     this.context = {
       hostname: `${hostname}:${port}`
     };
-    runner = new Runner();
+    runner = new Runner(true);
   });
 
   describe(LABEL, function() {

--- a/packages/cli/test/cases/theme-pack/greenwood.config.js
+++ b/packages/cli/test/cases/theme-pack/greenwood.config.js
@@ -1,9 +1,8 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { myThemePack } from './my-theme-pack.js';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
-import { URL } from 'url';
 
-const packageName = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8')).name;
+const packageName = JSON.parse(await fs.readFile(new URL('./package.json', import.meta.url), 'utf-8')).name;
 
 class MyThemePackDevelopmentResource extends ResourceInterface {
   constructor(compilation, options) {

--- a/packages/cli/test/cases/theme-pack/my-theme-pack.js
+++ b/packages/cli/test/cases/theme-pack/my-theme-pack.js
@@ -1,6 +1,6 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
-const packageJson = JSON.parse(await fs.promises.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
+const packageJson = JSON.parse(await fs.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
 const myThemePack = (options = {}) => [{
   type: 'context',
   name: `${packageJson.name}:context`,

--- a/packages/plugin-babel/src/index.js
+++ b/packages/plugin-babel/src/index.js
@@ -4,7 +4,7 @@
  *
  */
 import babel from '@babel/core';
-import fs from 'fs/promises';
+import { checkResourceExists } from '@greenwood/cli/src/lib/resource-utils.js';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import rollupBabelPlugin from '@rollup/plugin-babel';
 
@@ -12,17 +12,10 @@ async function getConfig(compilation, extendConfig = false) {
   const { projectDirectory } = compilation.context;
   const configFile = 'babel.config.mjs';
   const defaultConfig = (await import(new URL(`./${configFile}`, import.meta.url))).default;
-  let userConfig = {};
-  try {
-    await fs.access(new URL(`./${configFile}`, projectDirectory))
-    userConfig = (await import(`${projectDirectory}/${configFile}`)).default;
-  } catch (error) {
-
-  }
-  // const userConfig = fs.existsSync(new URL(`./${configFile}`, projectDirectory).pathname)
-  //   ? (await import(`${projectDirectory}/${configFile}`)).default
-  //   : {};
-  let finalConfig = Object.assign({}, userConfig);
+  const userConfig = await checkResourceExists(new URL(`./${configFile}`, projectDirectory))
+    ? (await import(`${projectDirectory}/${configFile}`)).default
+    : {};
+  const finalConfig = Object.assign({}, userConfig);
 
   if (extendConfig) {    
     finalConfig.presets = Array.isArray(userConfig.presets)

--- a/packages/plugin-babel/src/index.js
+++ b/packages/plugin-babel/src/index.js
@@ -14,7 +14,7 @@ async function getConfig(compilation, extendConfig = false) {
   const defaultConfig = (await import(new URL(`./${configFile}`, import.meta.url))).default;
   let userConfig = {};
   try {
-    fs.access(new URL(`./${configFile}`, projectDirectory))
+    await fs.access(new URL(`./${configFile}`, projectDirectory))
     userConfig = (await import(`${projectDirectory}/${configFile}`)).default;
   } catch (error) {
 

--- a/packages/plugin-babel/src/index.js
+++ b/packages/plugin-babel/src/index.js
@@ -4,7 +4,7 @@
  *
  */
 import babel from '@babel/core';
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import rollupBabelPlugin from '@rollup/plugin-babel';
 
@@ -12,9 +12,16 @@ async function getConfig(compilation, extendConfig = false) {
   const { projectDirectory } = compilation.context;
   const configFile = 'babel.config.mjs';
   const defaultConfig = (await import(new URL(`./${configFile}`, import.meta.url))).default;
-  const userConfig = fs.existsSync(new URL(`./${configFile}`, projectDirectory).pathname)
-    ? (await import(`${projectDirectory}/${configFile}`)).default
-    : {};
+  let userConfig = {};
+  try {
+    fs.access(new URL(`./${configFile}`, projectDirectory))
+    userConfig = (await import(`${projectDirectory}/${configFile}`)).default;
+  } catch (error) {
+
+  }
+  // const userConfig = fs.existsSync(new URL(`./${configFile}`, projectDirectory).pathname)
+  //   ? (await import(`${projectDirectory}/${configFile}`)).default
+  //   : {};
   let finalConfig = Object.assign({}, userConfig);
 
   if (extendConfig) {    

--- a/packages/plugin-graphql/src/core/cache.js
+++ b/packages/plugin-graphql/src/core/cache.js
@@ -1,4 +1,5 @@
 import ApolloCore from '@apollo/client/core/core.cjs.js';
+import { checkResourceExists } from '@greenwood/cli/src/lib/resource-utils.js';
 import fs from 'fs/promises';
 import { gql } from 'apollo-server';
 import { getQueryHash } from './common.js';
@@ -30,16 +31,12 @@ const createCache = async (req, context) => {
         const hashFilename = `${queryHash}-cache.json`;
         const cachePath = new URL(`./${hashFilename}`, outputDir);
 
-        try {
-          await fs.access(outputDir);
-        } catch(e) {
-          fs.mkdir(outputDir);
+        if (!await checkResourceExists(outputDir)) {
+          await fs.mkdir(outputDir);
         }
 
-        try {
-          await fs.access(cachePath);
-        } catch(e) {
-          fs.writeFile(cachePath, cache, 'utf-8');
+        if (!await checkResourceExists(cachePath)) {
+          await fs.writeFile(cachePath, cache, 'utf-8');
         }
       }
       

--- a/packages/plugin-graphql/src/core/cache.js
+++ b/packages/plugin-graphql/src/core/cache.js
@@ -1,5 +1,5 @@
 import ApolloCore from '@apollo/client/core/core.cjs.js';
-import fs from 'fs';
+import fs from 'fs/promises';
 import { gql } from 'apollo-server';
 import { getQueryHash } from './common.js';
 
@@ -30,12 +30,16 @@ const createCache = async (req, context) => {
         const hashFilename = `${queryHash}-cache.json`;
         const cachePath = new URL(`./${hashFilename}`, outputDir);
 
-        if (!fs.existsSync(outputDir.pathname)) {
-          fs.mkdirSync(outputDir.pathname);
+        try {
+          await fs.access(outputDir);
+        } catch(e) {
+          fs.mkdir(outputDir);
         }
 
-        if (!fs.existsSync(cachePath.pathname)) {
-          fs.writeFileSync(cachePath.pathname, cache, 'utf8');
+        try {
+          await fs.access(cachePath);
+        } catch(e) {
+          fs.writeFile(cachePath, cache, 'utf-8');
         }
       }
       

--- a/packages/plugin-graphql/src/index.js
+++ b/packages/plugin-graphql/src/index.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { graphqlServer } from './core/server.js';
 import { mergeImportMap } from '@greenwood/cli/src/lib/walker-package-ranger.js';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
@@ -27,7 +27,7 @@ class GraphQLResource extends ResourceInterface {
   }
 
   async serve(url) {
-    const js = await fs.promises.readFile(url, 'utf-8');
+    const js = await fs.readFile(url, 'utf-8');
     const body = `
       export default \`${js}\`;
     `;

--- a/packages/plugin-graphql/src/schema/schema.js
+++ b/packages/plugin-graphql/src/schema/schema.js
@@ -1,3 +1,4 @@
+import { checkResourceExists } from '@greenwood/cli/src/lib/resource-utils.js';
 import { makeExecutableSchema } from 'apollo-server-express';
 import { configTypeDefs, configResolvers } from './config.js';
 import { graphTypeDefs, graphResolvers } from './graph.js';
@@ -34,9 +35,7 @@ const createSchema = async (compilation) => {
       }
     `;
 
-    try {
-      await fs.access(customSchemasUrl);
-
+    if (await checkResourceExists(customSchemasUrl)) {
       console.log('custom schemas directory detected, scanning...');
       const schemaPaths = (await fs.readdir(customSchemasUrl))
         .filter(file => file.split('.').pop() === 'js');
@@ -47,21 +46,7 @@ const createSchema = async (compilation) => {
         customUserDefs.push(customTypeDefs);
         customUserResolvers.push(customResolvers);
       }
-    } catch (error) {
-      
     }
-    // if (fs.existsSync(customSchemasUrl.pathname)) {
-    //   console.log('custom schemas directory detected, scanning...');
-    //   const schemaPaths = (await fs.readdir(customSchemasUrl))
-    //     .filter(file => file.split('.').pop() === 'js');
-
-    //   for (const schemaPath of schemaPaths) {
-    //     const { customTypeDefs, customResolvers } = await import(new URL(`./${schemaPath}`, customSchemasUrl));
-        
-    //     customUserDefs.push(customTypeDefs);
-    //     customUserResolvers.push(customResolvers);
-    //   }
-    // }
   
     const mergedResolvers = Object.assign({}, {
       Query: {

--- a/packages/plugin-graphql/src/schema/schema.js
+++ b/packages/plugin-graphql/src/schema/schema.js
@@ -1,7 +1,7 @@
 import { makeExecutableSchema } from 'apollo-server-express';
 import { configTypeDefs, configResolvers } from './config.js';
 import { graphTypeDefs, graphResolvers } from './graph.js';
-import fs from 'fs';
+import fs from 'fs/promises';
 import gql from 'graphql-tag';
 
 const createSchema = async (compilation) => {
@@ -34,9 +34,11 @@ const createSchema = async (compilation) => {
       }
     `;
 
-    if (fs.existsSync(customSchemasUrl.pathname)) {
+    try {
+      await fs.access(customSchemasUrl);
+
       console.log('custom schemas directory detected, scanning...');
-      const schemaPaths = (await fs.promises.readdir(customSchemasUrl))
+      const schemaPaths = (await fs.readdir(customSchemasUrl))
         .filter(file => file.split('.').pop() === 'js');
 
       for (const schemaPath of schemaPaths) {
@@ -45,7 +47,21 @@ const createSchema = async (compilation) => {
         customUserDefs.push(customTypeDefs);
         customUserResolvers.push(customResolvers);
       }
+    } catch (error) {
+      
     }
+    // if (fs.existsSync(customSchemasUrl.pathname)) {
+    //   console.log('custom schemas directory detected, scanning...');
+    //   const schemaPaths = (await fs.readdir(customSchemasUrl))
+    //     .filter(file => file.split('.').pop() === 'js');
+
+    //   for (const schemaPath of schemaPaths) {
+    //     const { customTypeDefs, customResolvers } = await import(new URL(`./${schemaPath}`, customSchemasUrl));
+        
+    //     customUserDefs.push(customTypeDefs);
+    //     customUserResolvers.push(customResolvers);
+    //   }
+    // }
   
     const mergedResolvers = Object.assign({}, {
       Query: {

--- a/packages/plugin-import-commonjs/src/index.js
+++ b/packages/plugin-import-commonjs/src/index.js
@@ -4,7 +4,7 @@
  *
  */
 import commonjs from '@rollup/plugin-commonjs';
-import fs from 'fs';
+import fs from 'fs/promises';
 import { parse, init } from 'cjs-module-lexer';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import rollupStream from '@rollup/stream';
@@ -18,7 +18,7 @@ const testForCjsModule = async(url) => {
   if (pathname.split('.').pop() === '.js' && pathname.startsWith('/node_modules/') && pathname.indexOf('es-module-shims.js') < 0) {
     try {
       await init();
-      const body = await fs.promises.readFile(url, 'utf-8');
+      const body = await fs.readFile(url, 'utf-8');
       await parse(body);
 
       isCommonJs = true;

--- a/packages/plugin-import-css/src/index.js
+++ b/packages/plugin-import-css/src/index.js
@@ -3,7 +3,7 @@
  * Enables using JavaScript to import CSS files, using ESM syntax.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
 class ImportCssResource extends ResourceInterface {
@@ -15,7 +15,14 @@ class ImportCssResource extends ResourceInterface {
 
   // https://github.com/ProjectEvergreen/greenwood/issues/700
   async shouldResolve(url) {
-    return url.pathname.endsWith(`.${this.extensions[0]}`) && fs.existsSync(`${url.pathname}.js`);
+    try {
+      if (url.pathname.endsWith(`.${this.extensions[0]}`)) {
+        await fs.access(url);
+        return true;
+      }      
+    } catch (error) {
+      
+    }
   }
 
   async resolve(url) {

--- a/packages/plugin-import-css/src/index.js
+++ b/packages/plugin-import-css/src/index.js
@@ -3,7 +3,7 @@
  * Enables using JavaScript to import CSS files, using ESM syntax.
  *
  */
-import fs from 'fs/promises';
+import { checkResourceExists } from '@greenwood/cli/src/lib/resource-utils.js';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
 class ImportCssResource extends ResourceInterface {
@@ -15,14 +15,7 @@ class ImportCssResource extends ResourceInterface {
 
   // https://github.com/ProjectEvergreen/greenwood/issues/700
   async shouldResolve(url) {
-    try {
-      if (url.pathname.endsWith(`.${this.extensions[0]}`)) {
-        await fs.access(url);
-        return true;
-      }      
-    } catch (error) {
-      
-    }
+    return url.pathname.endsWith(`.${this.extensions[0]}`) && await checkResourceExists(url);
   }
 
   async resolve(url) {

--- a/packages/plugin-import-json/src/index.js
+++ b/packages/plugin-import-json/src/index.js
@@ -16,7 +16,7 @@ class ImportJsonResource extends ResourceInterface {
   async shouldIntercept(url) {
     const { pathname } = url;
 
-    return pathname.split('.').pop() === this.extensions[0] || (url.searchParams.has('type') && url.searchParams.get('type') === this.extensions[0]);
+    return pathname.split('.').pop() === this.extensions[0] && (url.searchParams.has('type') && url.searchParams.get('type') === this.extensions[0]);
   }
 
   async intercept(url, request, response) {

--- a/packages/plugin-import-json/src/index.js
+++ b/packages/plugin-import-json/src/index.js
@@ -4,7 +4,6 @@
  * This is a Greenwood default plugin.
  *
  */
-// import fs from 'fs';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
 class ImportJsonResource extends ResourceInterface {

--- a/packages/plugin-include-html/src/index.js
+++ b/packages/plugin-include-html/src/index.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
 class IncludeHtmlResource extends ResourceInterface {
@@ -23,7 +23,7 @@ class IncludeHtmlResource extends ResourceInterface {
       for (const link of htmlIncludeLinks) {
         const href = link.match(/href="(.*)"/)[1];
         const prefix = href.startsWith('/') ? '.' : '';
-        const includeContents = await fs.promises.readFile(new URL(`${prefix}${href}`, this.compilation.context.userWorkspace), 'utf-8');
+        const includeContents = await fs.readFile(new URL(`${prefix}${href}`, this.compilation.context.userWorkspace), 'utf-8');
 
         body = body.replace(link, includeContents);
       }

--- a/packages/plugin-include-html/test/cases/build.default-custom-element/src/components/footer.js
+++ b/packages/plugin-include-html/test/cases/build.default-custom-element/src/components/footer.js
@@ -1,5 +1,4 @@
-import fs from 'fs';
-import { fileURLToPath, URL } from 'url';
+import fs from 'fs/promises';
 
 const getTemplate = async (data) => {
   return `
@@ -12,9 +11,8 @@ const getTemplate = async (data) => {
 };
 
 const getData = async () => {
-  const dataPath = fileURLToPath(new URL('../../package.json', import.meta.url));
-  const data = JSON.parse(await fs.promises.readFile(dataPath, 'utf-8'));
-
+  const dataUrl = new URL('../../package.json', import.meta.url);
+  const data = JSON.parse(await fs.readFile(dataUrl, 'utf-8'));
   const { version } = data;
 
   return { version };

--- a/packages/plugin-postcss/src/index.js
+++ b/packages/plugin-postcss/src/index.js
@@ -3,8 +3,7 @@
  * Enable using PostCSS process for CSS files.
  *
  */
-import fs from 'fs/promises';
-import { normalizePathnameForWindows } from '@greenwood/cli/src/lib/resource-utils.js';
+import { checkResourceExists, normalizePathnameForWindows } from '@greenwood/cli/src/lib/resource-utils.js';
 import postcss from 'postcss';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
@@ -12,16 +11,11 @@ async function getConfig (compilation, extendConfig = false) {
   const { projectDirectory } = compilation.context;
   const configFile = 'postcss.config';
   const defaultConfig = (await import(new URL(`./${configFile}.js`, import.meta.url))).default;
-  let userConfig = {};
-
-  try {
-    await fs.access(new URL(`./${configFile}.mjs`, projectDirectory));
-    userConfig = (await import(new URL(`./${configFile}.mjs`, projectDirectory))).default
-  } catch(e) {
-    console.debug('postcss getConfig', { e })
-  }
-
-  let finalConfig = Object.assign({}, userConfig);
+  const userConfigUrl = new URL(`./${configFile}.mjs`, projectDirectory);
+  const userConfig = await checkResourceExists(userConfigUrl)
+    ? (await import(userConfigUrl)).default
+    : {};
+  const finalConfig = Object.assign({}, userConfig);
 
   if (userConfig && extendConfig) {
     finalConfig.plugins = Array.isArray(userConfig.plugins)

--- a/packages/plugin-postcss/src/index.js
+++ b/packages/plugin-postcss/src/index.js
@@ -4,6 +4,7 @@
  *
  */
 import fs from 'fs/promises';
+import { normalizePathnameForWindows } from '@greenwood/cli/src/lib/resource-utils.js';
 import postcss from 'postcss';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 
@@ -47,7 +48,7 @@ class PostCssResource extends ResourceInterface {
     const plugins = config.plugins || [];
     const body = await response.text();
     const css = plugins.length > 0
-      ? (await postcss(plugins).process(body, { from: url.pathname })).css
+      ? (await postcss(plugins).process(body, { from: normalizePathnameForWindows(url) })).css
       : body;
 
     return new Response(css);

--- a/packages/plugin-renderer-lit/src/ssr-route-worker-lit.js
+++ b/packages/plugin-renderer-lit/src/ssr-route-worker-lit.js
@@ -30,6 +30,7 @@ async function executeRouteModule({ moduleUrl, compilation, route, label, id, pr
     html: null
   };
 
+  console.debug({ moduleUrl });
   // prerender static content
   if (prerender) {
     for (const script of parsedScripts) {

--- a/packages/plugin-renderer-lit/src/ssr-route-worker-lit.js
+++ b/packages/plugin-renderer-lit/src/ssr-route-worker-lit.js
@@ -3,7 +3,6 @@ import { render } from '@lit-labs/ssr/lib/render-with-global-dom-shim.js';
 import { Buffer } from 'buffer';
 import { html } from 'lit';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
-import { pathToFileURL } from 'url';
 import { Readable } from 'stream';
 import { parentPort } from 'worker_threads';
 
@@ -21,7 +20,7 @@ async function getTemplateResultString(template) {
   return await streamToString(Readable.from(render(template)));
 }
 
-async function executeRouteModule({ modulePath, compilation, route, label, id, prerender, htmlContents, scripts }) {
+async function executeRouteModule({ moduleUrl, compilation, route, label, id, prerender, htmlContents, scripts }) {
   const parsedCompilation = JSON.parse(compilation);
   const parsedScripts = scripts ? JSON.parse(scripts) : [];
   const data = {
@@ -41,7 +40,7 @@ async function executeRouteModule({ modulePath, compilation, route, label, id, p
 
     data.html = await getTemplateResultString(templateResult);
   } else {
-    const module = await import(pathToFileURL(modulePath)).then(module => module);
+    const module = await import(moduleUrl).then(module => module);
     const { getTemplate = null, getBody = null, getFrontmatter = null } = module;
 
     if (module.default && module.tagName) {

--- a/packages/plugin-renderer-lit/test/cases/build.default/src/pages/artists.js
+++ b/packages/plugin-renderer-lit/test/cases/build.default/src/pages/artists.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { html } from 'lit';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import '../components/greeting.js';
@@ -30,7 +30,7 @@ async function getTemplate(compilation, route) {
 }
 
 async function getBody() {
-  const artists = JSON.parse(await fs.promises.readFile(new URL('../../artists.json', import.meta.url), 'utf-8'));
+  const artists = JSON.parse(await fs.readFile(new URL('../../artists.json', import.meta.url), 'utf-8'));
 
   return html`
     <h1>Lit SSR response</h1>

--- a/packages/plugin-renderer-lit/test/cases/build.default/src/pages/users.js
+++ b/packages/plugin-renderer-lit/test/cases/build.default/src/pages/users.js
@@ -1,4 +1,4 @@
-import fs from 'fs/promises';
+import fs from 'fs';
 import { html, LitElement } from 'lit';
 import '../components/footer.js';
 
@@ -6,7 +6,7 @@ class UsersComponent extends LitElement {
 
   constructor() {
     super();
-    this.users = JSON.parse(await fs.promises.readFile(new URL('../../artists.json', import.meta.url), 'utf-8'));
+    this.users = JSON.parse(fs.readFileSync(new URL('../../artists.json', import.meta.url), 'utf-8'));
   }
 
   render() {

--- a/packages/plugin-renderer-lit/test/cases/build.default/src/pages/users.js
+++ b/packages/plugin-renderer-lit/test/cases/build.default/src/pages/users.js
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import { html, LitElement } from 'lit';
 import '../components/footer.js';
 
@@ -6,7 +6,7 @@ class UsersComponent extends LitElement {
 
   constructor() {
     super();
-    this.users = JSON.parse(fs.readFileSync(new URL('../../artists.json', import.meta.url), 'utf-8'));
+    this.users = JSON.parse(await fs.promises.readFile(new URL('../../artists.json', import.meta.url), 'utf-8'));
   }
 
   render() {

--- a/packages/plugin-typescript/src/index.js
+++ b/packages/plugin-typescript/src/index.js
@@ -14,7 +14,7 @@ const defaultCompilerOptions = {
   sourceMap: true
 };
 
-function getCompilerOptions (projectDirectory, extendConfig) {
+async function getCompilerOptions (projectDirectory, extendConfig) {
   const customOptions = extendConfig
     ? JSON.parse(await fs.readFile(new URL('./tsconfig.json', projectDirectory), 'utf-8'))
     : { compilerOptions: {} };
@@ -42,7 +42,7 @@ class TypeScriptResource extends ResourceInterface {
   async serve(url) {
     const { projectDirectory } = this.compilation.context;
     const source = await fs.readFile(url, 'utf-8');
-    const compilerOptions = getCompilerOptions(projectDirectory, this.options.extendConfig);
+    const compilerOptions = await getCompilerOptions(projectDirectory, this.options.extendConfig);
     // https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API
     const body = tsc.transpileModule(source, { compilerOptions }).outputText;
 

--- a/packages/plugin-typescript/src/index.js
+++ b/packages/plugin-typescript/src/index.js
@@ -3,7 +3,7 @@
  * Enables using JavaScript to import TypeScript files, using ESM syntax.
  *
  */
-import fs from 'fs';
+import fs from 'fs/promises';
 import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js';
 import tsc from 'typescript';
 
@@ -16,7 +16,7 @@ const defaultCompilerOptions = {
 
 function getCompilerOptions (projectDirectory, extendConfig) {
   const customOptions = extendConfig
-    ? JSON.parse(fs.readFileSync(new URL('./tsconfig.json', projectDirectory).pathname, 'utf-8'))
+    ? JSON.parse(await fs.readFile(new URL('./tsconfig.json', projectDirectory), 'utf-8'))
     : { compilerOptions: {} };
 
   return {
@@ -41,7 +41,7 @@ class TypeScriptResource extends ResourceInterface {
 
   async serve(url) {
     const { projectDirectory } = this.compilation.context;
-    const source = await fs.promises.readFile(url, 'utf-8');
+    const source = await fs.readFile(url, 'utf-8');
     const compilerOptions = getCompilerOptions(projectDirectory, this.options.extendConfig);
     // https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API
     const body = tsc.transpileModule(source, { compilerOptions }).outputText;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#948 / #1045 

## Summary of Changes
Specifically a subset of changes to ensure windows compat 
1. Make everything `URL` for `fs` calls through and through (should address Windows compat and a bunch of TODOs in 948)

## TODO
1. [x] Verify Windows compat / CI
1. [x] Restore `lint` and best way to do `try / catch` for `fs.access` refactor
1. [x] clean up console logging / TODOs / comments