### PR TITLE
show correct label for test cases using serve smoke tests

### DIFF
--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -236,7 +236,7 @@ function serve(label) {
       });
 
       it('should do all the common checks for an HTML page', function(done) {
-        commonIndexSpecs(dom, response.body);
+        commonIndexSpecs(dom, response.body, label);
         done();
       });
     });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

Running test cases that use the `serve` smoke test would output undefined in the terminal
```sh
  Running Common Index Smoke Tests for undefined
    document <html>
```

## Summary of Changes
1. Show correct label for test cases using serve smoke tests