### PR TITLE
Bug/issue 1059 api routes and api calls overlap

### DIFF
--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -1,4 +1,5 @@
 import { getStaticServer, getHybridServer } from '../lifecycles/serve.js';
+import { checkResourceExists } from '@greenwood/cli/src/lib/resource-utils.js';
 
 const runProdServer = async (compilation) => {
 
@@ -6,7 +7,7 @@ const runProdServer = async (compilation) => {
 
     try {
       const port = compilation.config.port;
-      const hasApisDir = compilation.context.apisDir;
+      const hasApisDir = await checkResourceExists(compilation.context.apisDir);
       const hasDynamicRoutes = compilation.graph.filter(page => page.isSSR && ((page.data.hasOwnProperty('static') && !page.data.static) || !compilation.config.prerender));
       const server = hasDynamicRoutes.length > 0 || hasApisDir ? getHybridServer : getStaticServer;
 

--- a/packages/cli/test/cases/serve.default/serve.default.spec.js
+++ b/packages/cli/test/cases/serve.default/serve.default.spec.js
@@ -42,7 +42,7 @@ describe('Serve Greenwood With: ', function() {
     this.context = {
       hostname
     };
-    runner = new Runner();
+    runner = new Runner(true);
   });
 
   describe(LABEL, function() {
@@ -92,6 +92,41 @@ describe('Serve Greenwood With: ', function() {
 
       it('should return the correct response body', function(done) {
         expect(response.body).to.have.lengthOf(1);
+        done();
+      });
+    });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/1059
+    describe('Serve command with dev proxy with an /api prefix', function() {
+      let response = {};
+
+      before(async function() {
+        return new Promise((resolve, reject) => {
+          request.get(`${hostname}/api/posts?id=7`, (err, res, body) => {
+            if (err) {
+              reject();
+            }
+
+            response = res;
+            response.body = JSON.parse(body);
+
+            resolve();
+          });
+        });
+      });
+
+      it('should return a 200 status', function(done) {
+        expect(response.statusCode).to.equal(200);
+        done();
+      });
+
+      it('should return the correct content type', function(done) {
+        expect(response.headers['content-type']).to.contain('application/json');
+        done();
+      });
+
+      it('should return the correct response body', function(done) {
+        expect(JSON.stringify(response.body)).to.equal('{}');
         done();
       });
     });

--- a/packages/cli/test/cases/serve.default/serve.default.spec.js
+++ b/packages/cli/test/cases/serve.default/serve.default.spec.js
@@ -42,7 +42,7 @@ describe('Serve Greenwood With: ', function() {
     this.context = {
       hostname
     };
-    runner = new Runner(true);
+    runner = new Runner();
   });
 
   describe(LABEL, function() {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1059

## Summary of Changes
1. Properly detect API routes directory for hybrid server detection
1. Within hybrid server, properly detect for API Routes from `/api*` calls

## TODO
1. [x] Should probably be able to find way to test this