### PR TITLE
Enhancement/restore rollup local workspace resolution

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -1,5 +1,5 @@
 import fs from 'fs/promises';
-import { checkResourceExists, normalizePathnameForWindows, resolveForRelativeUrl } from '../lib/resource-utils.js';
+import { checkResourceExists, normalizePathnameForWindows } from '../lib/resource-utils.js';
 
 function greenwoodResourceLoader (compilation) {
   const resourcePlugins = compilation.config.plugins.filter((plugin) => {
@@ -14,10 +14,9 @@ function greenwoodResourceLoader (compilation) {
       const normalizedId = id.replace(/\?type=(.*)/, '');
       const { projectDirectory, userWorkspace } = compilation.context;
 
-      if (id.startsWith('.') || id.startsWith('/')) {
+      if ((id.startsWith('.') || id.startsWith('/')) && !id.startsWith(projectDirectory.pathname)) {
         const prefix = id.startsWith('/') ? '.' : '';
-        const contextUrl = id.indexOf('/node_modules/') >= 0 ? projectDirectory : userWorkspace;
-        const userWorkspaceUrl = await resolveForRelativeUrl(new URL(`${prefix}${normalizedId}`, contextUrl), contextUrl);
+        const userWorkspaceUrl = new URL(`${prefix}${normalizedId}`, userWorkspace);
 
         if (await checkResourceExists(userWorkspaceUrl)) {
           return normalizePathnameForWindows(userWorkspaceUrl);

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -14,9 +14,9 @@ function greenwoodResourceLoader (compilation) {
       const normalizedId = id.replace(/\?type=(.*)/, '');
       const { projectDirectory, userWorkspace } = compilation.context;
 
-      if ((id.startsWith('.') || id.startsWith('/')) && !id.startsWith(projectDirectory.pathname)) {
-        const prefix = id.startsWith('/') ? '.' : '';
-        const userWorkspaceUrl = new URL(`${prefix}${normalizedId}`, userWorkspace);
+      if (id.startsWith('.') && !id.startsWith(projectDirectory.pathname)) {
+        const prefix = id.startsWith('..') ? './' : '';
+        const userWorkspaceUrl = new URL(`${prefix}${normalizedId.replace(/\.\.\//g, '')}`, userWorkspace);
 
         if (await checkResourceExists(userWorkspaceUrl)) {
           return normalizePathnameForWindows(userWorkspaceUrl);

--- a/packages/plugin-graphql/README.md
+++ b/packages/plugin-graphql/README.md
@@ -175,7 +175,7 @@ query($name: String!) {
 And then you can use it in your code as such:
 ```js
 import client from '@greenwood/plugin-graphql/core/client';
-import GalleryQuery from '/data/queries/gallery.gql';
+import GalleryQuery from '../relative/path/to/data/queries/gallery.gql';
 
 client.query({
   query: GalleryQuery,

--- a/packages/plugin-graphql/test/cases/query-custom-schema/src/pages/index.html
+++ b/packages/plugin-graphql/test/cases/query-custom-schema/src/pages/index.html
@@ -4,7 +4,7 @@
   <head>
     <script type="module">
       import client from '@greenwood/plugin-graphql/core/client';
-      import GalleryQuery from '/data/queries/gallery.gql';
+      import GalleryQuery from '../data/queries/gallery.gql';
 
       client.query({
         query: GalleryQuery,


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

Noticed some odd paths coming out some projects while upgrading them to **v0.28.0-alpha.1**.  Nothing was broken but I also noticed compared to the [original logic](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/cli/src/config/rollup.config.js#L13), it was also doing bit more than it should be.

## Summary of Changes
1. Restore Rollup local workspace resolution

## TODO
1. [x] Add / update test case for ESM path that doesn't start with a `.` (Per ESM, imports can not start with a `/`)