### PR TITLE
resource plugins refactoring for serve lifecycle and extensions

### DIFF
--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -25,8 +25,11 @@ const greenwoodPlugins = (await Promise.all([
       : [plugin];
   }));
 }))).flat(PLUGINS_FLATTENED_DEPTH).map((plugin) => {
+  const isStandardStaticResource = (plugin.name.startsWith('plugin-standard') && plugin.name !== 'plugin-standard-html') || plugin.name === 'plugin-source-maps';
+
   return {
     isGreenwoodDefaultPlugin: true,
+    isStandardStaticResource,
     ...plugin
   };
 });

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -285,7 +285,7 @@ async function getHybridServer(compilation) {
       });
 
       if (matchingRoute.isSSR && !matchingRoute.data.static) {
-        const { handler } = await import(`${outputDir}${matchingRoute.filename}`);
+        const { handler } = await import(new URL(`./${matchingRoute.filename}`, outputDir));
         // TODO passing compilation this way too hacky?
         // https://github.com/ProjectEvergreen/greenwood/issues/1008
         const response = await handler(request, compilation);
@@ -295,7 +295,7 @@ async function getHybridServer(compilation) {
         ctx.status = 200;
       } else if (isApiRoute) {
         const apiRoute = manifest.apis.get(url.pathname);
-        const { handler } = await import(`${outputDir}${apiRoute.path.replace('/', '')}`);
+        const { handler } = await import(new URL(`.${apiRoute.path}`, outputDir));
         const response = await handler(request);
 
         ctx.status = 200;

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -165,9 +165,7 @@ async function getStaticServer(compilation, composable) {
   const app = new Koa();
   const { outputDir } = compilation.context;
   const standardResourcePlugins = compilation.config.plugins.filter((plugin) => {
-    return plugin.type === 'resource'
-      && plugin.isGreenwoodDefaultPlugin
-      && plugin.name !== 'plugin-standard-html';
+    return plugin.type === 'resource' && plugin.isGreenwoodDefaultPlugin;
   });
 
   app.use(async (ctx, next) => {
@@ -228,9 +226,11 @@ async function getStaticServer(compilation, composable) {
   app.use(async (ctx, next) => {
     try {
       const url = new URL(`.${ctx.url}`, outputDir.href);
-      const resourcePlugins = standardResourcePlugins.map((plugin) => {
-        return plugin.provider(compilation);
-      });
+      const resourcePlugins = standardResourcePlugins
+        .filter((plugin) => plugin.isStandardStaticResource)
+        .map((plugin) => {
+          return plugin.provider(compilation);
+        });
 
       const request = new Request(url.href, {
         headers: new Headers(ctx.request.header)

--- a/packages/cli/src/plugins/server/plugin-livereload.js
+++ b/packages/cli/src/plugins/server/plugin-livereload.js
@@ -20,12 +20,12 @@ class LiveReloadServer extends ServerInterface {
       return plugin;
     })))
       .filter(plugin => plugin.type === 'resource')
-      .map((plugin) => plugin.provider(this.compilation).extensions.flat())
+      .map((plugin) => plugin.provider(this.compilation).extensions || [].flat())
       .flat();
     const customPluginsExtensions = this.compilation.config.plugins
       .filter((plugin) => plugin.type === 'resource')
       .map((plugin) => {
-        return plugin.provider(this.compilation).extensions.flat();
+        return plugin.provider(this.compilation).extensions || [].flat();
       }).flat();
 
     // filter out wildcards or otherwise undesired values and remove any . since livereload likes them that way

--- a/packages/cli/test/cases/build.plugins.resource/greenwood.config.js
+++ b/packages/cli/test/cases/build.plugins.resource/greenwood.config.js
@@ -1,9 +1,10 @@
 import fs from 'fs/promises';
-import { ResourceInterface } from '../../../src/lib/resource-interface.js';
 
-class FooResource extends ResourceInterface {
+// intentionally omitting `extends ResourceInterface` since it should still work the same
+class FooResource {
   constructor(compilation, options) {
-    super(compilation, options);
+    this.compilation = compilation;
+    this.options = options;
     
     this.extensions = ['foo'];
     this.contentType = 'text/javascript';


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Refactored serve lifecycle to be more granular with plugins used for serving requests
1. Made resource plugins `extensions` checks more graceful
1. Refactor `import` lines to use `URL` in `getHybridServer`