### PR TITLE
leverage `event.composedPath` for static router cross browser event delegation support

### DIFF
--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -2,24 +2,17 @@
 
 document.addEventListener('click', async function(e) {
   const currentUrl = window.location;
-  console.log(e);
-  console.log('PATH', e.path);
-  console.log('COMPOSED PATH', e.composedPath());
-  console.log('originalTarget', e.originalTarget);
-  // https://stackoverflow.com/questions/51493918/vanilla-javascript-event-delegation-when-dealing-with-web-components
   // https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath
   const href = e.composedPath && e.composedPath()[0].tagName === 'A'
     ? e.composedPath()[0].href
     : '';
 
-  console.log('href', { href });
   // best case "guess" is that if the link originates on the current site when resolved by the browser
   // treat it as a client side route, ex:  /about/, /docs/ and trigger the client side router
   // https://github.com/ProjectEvergreen/greenwood/issues/562
   const isOnCurrentDomain = href.indexOf(currentUrl.hostname) >= 0 || href.indexOf('localhost') >= 0;
   const canClientSideRoute = href !== '' && isOnCurrentDomain;
 
-  console.log('canClientSideRoute', { canClientSideRoute, isOnCurrentDomain });
   if (canClientSideRoute) {
     e.preventDefault();
 
@@ -27,12 +20,10 @@ document.addEventListener('click', async function(e) {
     const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
       return outlet.getAttribute('data-route') === targetUrl.pathname;
     })[0];
-    console.log('targetUrl', { targetUrl });
 
     // maintain the app shell if we are navigating between pages that are built from the same page template
     // also, some routes may be SSR, so we may not always match on a static route
     if (routerOutlet && routerOutlet.getAttribute('data-template') === window.__greenwood.currentTemplate) {
-      console.log('DO THE THING!!!');
       const { hash, pathname } = targetUrl;
 
       if (currentUrl.pathname !== pathname) {
@@ -47,7 +38,6 @@ document.addEventListener('click', async function(e) {
     } else {
       // this page uses is a completely different page template from the current page
       // so just load the new page
-      console.log('no thing ...');
       window.location.href = href;
     }
   }

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -7,6 +7,7 @@ document.addEventListener('click', async function(e) {
   console.log('COMPOSED PATH', e.composedPath());
   console.log('originalTarget', e.originalTarget);
   // https://stackoverflow.com/questions/51493918/vanilla-javascript-event-delegation-when-dealing-with-web-components
+  // https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath
   const href = e.composedPath && e.composedPath()[0].tagName === 'A'
     ? e.composedPath()[0].href
     : '';

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -1,21 +1,24 @@
 /* eslint-disable no-underscore-dangle */
 
-// ** THIS DOES NOT WORK ON SAFARI **
-// It will just load pages as if staticRouter was not enabled
-// https://github.com/ProjectEvergreen/greenwood/issues/559
-document.addEventListener('click', async function(e) {
+document.addEventListener('click', function(e) {
   const currentUrl = window.location;
-  const href = (e.path && e.path[0]
-    ? e.path[0].href // chrome + edge
-    : e.originalTarget && e.originalTarget.href
-      ? e.originalTarget.href // firefox
-      : '') || '';
+  console.log(e);
+  console.log('PATH', e.path);
+  console.log('COMPOSED PATH', e.composedPath());
+  console.log('originalTarget', e.originalTarget);
+  // https://stackoverflow.com/questions/51493918/vanilla-javascript-event-delegation-when-dealing-with-web-components
+  const href = e.composedPath && e.composedPath()[0].tagName === 'A'
+    ? e.composedPath()[0].href
+    : '';
+
+  console.log('href', { href });
   // best case "guess" is that if the link originates on the current site when resolved by the browser
   // treat it as a client side route, ex:  /about/, /docs/ and trigger the client side router
   // https://github.com/ProjectEvergreen/greenwood/issues/562
   const isOnCurrentDomain = href.indexOf(currentUrl.hostname) >= 0 || href.indexOf('localhost') >= 0;
   const canClientSideRoute = href !== '' && isOnCurrentDomain;
 
+  console.log('canClientSideRoute', { canClientSideRoute, isOnCurrentDomain });
   if (canClientSideRoute) {
     e.preventDefault();
 
@@ -23,14 +26,16 @@ document.addEventListener('click', async function(e) {
     const routerOutlet = Array.from(document.getElementsByTagName('greenwood-route')).filter(outlet => {
       return outlet.getAttribute('data-route') === targetUrl.pathname;
     })[0];
+    console.log('targetUrl', { targetUrl });
 
     // maintain the app shell if we are navigating between pages that are built from the same page template
     // also, some routes may be SSR, so we may not always match on a static route
     if (routerOutlet && routerOutlet.getAttribute('data-template') === window.__greenwood.currentTemplate) {
+      console.log('DO THE THING!!!');
       const { hash, pathname } = targetUrl;
 
       if (currentUrl.pathname !== pathname) {
-        await routerOutlet.loadRoute();
+        routerOutlet.loadRoute();
 
         history.pushState({}, '', pathname);
       }
@@ -41,6 +46,7 @@ document.addEventListener('click', async function(e) {
     } else {
       // this page uses is a completely different page template from the current page
       // so just load the new page
+      console.log('no thing ...');
       window.location.href = href;
     }
   }

--- a/packages/cli/src/lib/router.js
+++ b/packages/cli/src/lib/router.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 
-document.addEventListener('click', function(e) {
+document.addEventListener('click', async function(e) {
   const currentUrl = window.location;
   console.log(e);
   console.log('PATH', e.path);
@@ -35,7 +35,7 @@ document.addEventListener('click', function(e) {
       const { hash, pathname } = targetUrl;
 
       if (currentUrl.pathname !== pathname) {
-        routerOutlet.loadRoute();
+        await routerOutlet.loadRoute();
 
         history.pushState({}, '', pathname);
       }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1068 / #559 

## Summary of Changes
1. Found a [cross browser compatible API](https://stackoverflow.com/questions/51493918/vanilla-javascript-event-delegation-when-dealing-with-web-components) for static router ([`composedPath`](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) 💯 🙌 

## TODO
1. [x] Seems to work on all browsers (even Safari) but will want to do some more testing first
1. [x] Clean up console logging
1. [ ] Can we unmark this as experimental in the docs?