### PR TITLE
upgrade to gallinago with handling for process on exit

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -1,3 +1,3 @@
 module.exports = {
-  timeout: 90000
+  timeout: 120000
 };

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -23,7 +23,7 @@ async function cleanUpResources(compilation) {
 async function optimizeStaticPages(compilation, plugins) {
   const { scratchDir, outputDir } = compilation.context;
 
-  return Promise.all(compilation.graph
+  return await Promise.all(compilation.graph
     .filter(page => !page.isSSR || (page.isSSR && page.data.static) || (page.isSSR && compilation.config.prerender))
     .map(async (page) => {
       const { route, outputPath } = page;

--- a/packages/cli/test/cases/build.config.default/build.config.default.spec.js
+++ b/packages/cli/test/cases/build.config.default/build.config.default.spec.js
@@ -17,7 +17,7 @@
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 describe('Build Greenwood With: ', function() {

--- a/packages/cli/test/cases/build.config.error-dev-server-extensions/build.config.error-dev-server-extensions.spec.js
+++ b/packages/cli/test/cases/build.config.error-dev-server-extensions/build.config.error-dev-server-extensions.spec.js
@@ -20,7 +20,7 @@
  */
 import chai from 'chai';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.error-dev-server-hud/build.config.error-dev-server-hud.spec.js
+++ b/packages/cli/test/cases/build.config.error-dev-server-hud/build.config.error-dev-server-hud.spec.js
@@ -20,7 +20,7 @@
  */
 import chai from 'chai';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.error-optimization/build.config.error-optimization.spec.js
+++ b/packages/cli/test/cases/build.config.error-optimization/build.config.error-optimization.spec.js
@@ -18,7 +18,7 @@
  */
 import chai from 'chai';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.error-pages-directory/build.config.error-pages-directory.spec.js
+++ b/packages/cli/test/cases/build.config.error-pages-directory/build.config.error-pages-directory.spec.js
@@ -18,7 +18,7 @@
  */
 import chai from 'chai';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.error-prerender/build.config.error-prerender.spec.js
+++ b/packages/cli/test/cases/build.config.error-prerender/build.config.error-prerender.spec.js
@@ -18,7 +18,7 @@
  */
 import chai from 'chai';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.error-templates-directory/build.config.error-templates-directory.spec.js
+++ b/packages/cli/test/cases/build.config.error-templates-directory/build.config.error-templates-directory.spec.js
@@ -18,7 +18,7 @@
  */
 import chai from 'chai';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.error-workspace-absolute/build.config.error-workspace-absolute.spec.js
+++ b/packages/cli/test/cases/build.config.error-workspace-absolute/build.config.error-workspace-absolute.spec.js
@@ -18,7 +18,7 @@
  */
 import chai from 'chai';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.error-workspace/build.config.error-workspace.spec.js
+++ b/packages/cli/test/cases/build.config.error-workspace/build.config.error-workspace.spec.js
@@ -18,7 +18,7 @@
  */
 import chai from 'chai';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.interpolate-frontmatter/build.config.interpolate-frontmatter.spec.js
+++ b/packages/cli/test/cases/build.config.interpolate-frontmatter/build.config.interpolate-frontmatter.spec.js
@@ -26,7 +26,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import chai from 'chai';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.markdown-custom.plugins/build.config.markdown-custom.spec.js
+++ b/packages/cli/test/cases/build.config.markdown-custom.plugins/build.config.markdown-custom.spec.js
@@ -25,7 +25,7 @@ import path from 'path';
 import chai from 'chai';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.markdown-custom.settings/build.config.markdown-custom.settings.spec.js
+++ b/packages/cli/test/cases/build.config.markdown-custom.settings/build.config.markdown-custom.settings.spec.js
@@ -22,7 +22,7 @@ import { JSDOM } from 'jsdom';
 import chai from 'chai';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
@@ -25,7 +25,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getDependencyFiles, getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
@@ -29,7 +29,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
@@ -28,7 +28,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.optimization-overrides/build.config-optimization-overrides.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-overrides/build.config-optimization-overrides.spec.js
@@ -26,7 +26,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.optimization-static/build.config-optimization-static.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-static/build.config-optimization-static.spec.js
@@ -25,7 +25,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.pages-directory/build.config.pages-directory.spec.js
+++ b/packages/cli/test/cases/build.config.pages-directory/build.config.pages-directory.spec.js
@@ -25,7 +25,7 @@ import path from 'path';
 import chai from 'chai';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.prerender/build.config.prerender.spec.js
+++ b/packages/cli/test/cases/build.config.prerender/build.config.prerender.spec.js
@@ -25,7 +25,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
+++ b/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
@@ -26,7 +26,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { fileURLToPath, URL } from 'url';
 

--- a/packages/cli/test/cases/build.config.templates-directory/build.config.templates-directory.spec.js
+++ b/packages/cli/test/cases/build.config.templates-directory/build.config.templates-directory.spec.js
@@ -27,7 +27,7 @@ import path from 'path';
 import chai from 'chai';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.config.workspace-custom/build.config.workspace-custom.spec.js
+++ b/packages/cli/test/cases/build.config.workspace-custom/build.config.workspace-custom.spec.js
@@ -25,7 +25,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -24,7 +24,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.markdown/build.default.markdown.spec.js
+++ b/packages/cli/test/cases/build.default.markdown/build.default.markdown.spec.js
@@ -19,7 +19,7 @@ import path from 'path';
 import chai from 'chai';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.meta-files/build.default.meta-files.spec.js
+++ b/packages/cli/test/cases/build.default.meta-files/build.default.meta-files.spec.js
@@ -21,7 +21,7 @@ import glob from 'glob-promise';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.meta/build.default.meta.spec.js
+++ b/packages/cli/test/cases/build.default.meta/build.default.meta.spec.js
@@ -29,7 +29,7 @@ import path from 'path';
 import chai from 'chai';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.quick-start-npx/build.default.quick-start-npx.spec.js
+++ b/packages/cli/test/cases/build.default.quick-start-npx/build.default.quick-start-npx.spec.js
@@ -21,7 +21,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.spa/build.default.spa.spec.js
+++ b/packages/cli/test/cases/build.default.spa/build.default.spa.spec.js
@@ -28,7 +28,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.ssr-prerender/build.default.ssr-prerender.spec.js
+++ b/packages/cli/test/cases/build.default.ssr-prerender/build.default.ssr-prerender.spec.js
@@ -27,7 +27,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.ssr-static-export/build.default.ssr-static-export.spec.js
+++ b/packages/cli/test/cases/build.default.ssr-static-export/build.default.ssr-static-export.spec.js
@@ -32,7 +32,7 @@ import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
-describe.only('Build Greenwood With: ', function() {
+describe('Build Greenwood With: ', function() {
   const LABEL = 'A Server Rendered Application (SSR) that is statically exported';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));

--- a/packages/cli/test/cases/build.default.ssr-static-export/build.default.ssr-static-export.spec.js
+++ b/packages/cli/test/cases/build.default.ssr-static-export/build.default.ssr-static-export.spec.js
@@ -27,12 +27,12 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
 
-describe('Build Greenwood With: ', function() {
+describe.only('Build Greenwood With: ', function() {
   const LABEL = 'A Server Rendered Application (SSR) that is statically exported';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));

--- a/packages/cli/test/cases/build.default.title/build.default.title.spec.js
+++ b/packages/cli/test/cases/build.default.title/build.default.title.spec.js
@@ -26,7 +26,7 @@ import path from 'path';
 import chai from 'chai';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-404-markdown/build.default.workspace-404-markdown.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-404-markdown/build.default.workspace-404-markdown.spec.js
@@ -31,7 +31,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-404/build.default.workspace-404.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-404/build.default.workspace-404.spec.js
@@ -31,7 +31,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-assets/build.default.workspace-assets.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-assets/build.default.workspace-assets.spec.js
@@ -17,7 +17,7 @@ import fs from 'fs';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-frontmatter-imports/build.default.workspace-frontmatter-imports.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-frontmatter-imports/build.default.workspace-frontmatter-imports.spec.js
@@ -32,7 +32,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-getting-started/build.default.workspace-getting-started.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-getting-started/build.default.workspace-getting-started.spec.js
@@ -36,7 +36,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles, tagsMatch } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-javascript-css-remote/build.default.workspace-javascript-css-remote.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css-remote/build.default.workspace-javascript-css-remote.spec.js
@@ -22,7 +22,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -26,7 +26,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-nested/build.default.workspace-nested.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-nested/build.default.workspace-nested.spec.js
@@ -46,7 +46,7 @@ import fs from 'fs';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-template-app/build.default.workspace-template-app.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-template-app/build.default.workspace-template-app.spec.js
@@ -22,7 +22,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-template-page-and-app/build.default.workspace-template-page-and-app.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-template-page-and-app/build.default.workspace-template-page-and-app.spec.js
@@ -32,7 +32,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-template-page-bare-merging/build.default.workspace-template-page-bare-merging.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-template-page-bare-merging/build.default.workspace-template-page-bare-merging.spec.js
@@ -23,7 +23,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-template-page/build.default.workspace-template-page.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-template-page/build.default.workspace-template-page.spec.js
@@ -25,7 +25,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-templates-empty/build.default.workspace-templates-empty.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-templates-empty/build.default.workspace-templates-empty.spec.js
@@ -30,7 +30,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-templates-relative-paths/build.default.workspace-templates-relative-paths.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-templates-relative-paths/build.default.workspace-templates-relative-paths.spec.js
@@ -37,7 +37,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-top-level-pages/build.default.workspace-top-level-pages.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-top-level-pages/build.default.workspace-top-level-pages.spec.js
@@ -24,7 +24,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default.workspace-user-directory-mapping/build.default.workspace-user-directory-mapping.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-user-directory-mapping/build.default.workspace-user-directory-mapping.spec.js
@@ -37,7 +37,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.default/build.default.spec.js
+++ b/packages/cli/test/cases/build.default/build.default.spec.js
@@ -19,7 +19,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
+++ b/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
@@ -24,7 +24,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.plugins.copy/build.plugins.copy.spec.js
+++ b/packages/cli/test/cases/build.plugins.copy/build.plugins.copy.spec.js
@@ -18,7 +18,7 @@ import glob from 'glob-promise';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles, getDependencyFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.plugins.error-name/build.plugins.error-name.spec.js
+++ b/packages/cli/test/cases/build.plugins.error-name/build.plugins.error-name.spec.js
@@ -23,7 +23,7 @@
 
 import chai from 'chai';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.plugins.error-provider/build.plugins.error-provider.spec.js
+++ b/packages/cli/test/cases/build.plugins.error-provider/build.plugins.error-provider.spec.js
@@ -24,7 +24,7 @@
 
 import chai from 'chai';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.plugins.error-type/build.plugins.error-type.spec.js
+++ b/packages/cli/test/cases/build.plugins.error-type/build.plugins.error-type.spec.js
@@ -24,7 +24,7 @@
 
 import chai from 'chai';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.plugins.resource/build.config.plugins-resource.spec.js
+++ b/packages/cli/test/cases/build.plugins.resource/build.config.plugins-resource.spec.js
@@ -34,7 +34,7 @@ import fs from 'fs';
 import glob from 'glob-promise';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
+++ b/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
@@ -38,7 +38,7 @@ import glob from 'glob-promise';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/develop.default.hud-disabled/develop.default.hud-disabled.spec.js
+++ b/packages/cli/test/cases/develop.default.hud-disabled/develop.default.hud-disabled.spec.js
@@ -21,7 +21,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles } from '../../../../../test/utils.js';
 import request from 'request';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { fileURLToPath, URL } from 'url';
 

--- a/packages/cli/test/cases/develop.default.hud/develop.default.hud.spec.js
+++ b/packages/cli/test/cases/develop.default.hud/develop.default.hud.spec.js
@@ -21,7 +21,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles } from '../../../../../test/utils.js';
 import request from 'request';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { fileURLToPath, URL } from 'url';
 

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -44,7 +44,7 @@ import path from 'path';
 import { getDependencyFiles, getSetupFiles } from '../../../../../test/utils.js';
 import request from 'request';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
+++ b/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
@@ -24,7 +24,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import request from 'request';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/develop.spa/develop.spa.spec.js
+++ b/packages/cli/test/cases/develop.spa/develop.spa.spec.js
@@ -23,7 +23,7 @@ import path from 'path';
 import { getDependencyFiles } from '../../../../../test/utils.js';
 import request from 'request';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/develop.ssr/develop.ssr.spec.js
+++ b/packages/cli/test/cases/develop.ssr/develop.ssr.spec.js
@@ -26,7 +26,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import request from 'request';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/eject.default/eject.default.spec.js
+++ b/packages/cli/test/cases/eject.default/eject.default.spec.js
@@ -13,7 +13,7 @@ import path from 'path';
 import chai from 'chai';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/serve.config.static-router/serve.config.static-router.spec.js
+++ b/packages/cli/test/cases/serve.config.static-router/serve.config.static-router.spec.js
@@ -26,7 +26,7 @@ import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import request from 'request';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/serve.default.api/serve.default.api.spec.js
+++ b/packages/cli/test/cases/serve.default.api/serve.default.api.spec.js
@@ -21,7 +21,7 @@ import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import request from 'request';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
@@ -31,7 +31,7 @@ import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import request from 'request';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/serve.default/serve.default.spec.js
+++ b/packages/cli/test/cases/serve.default/serve.default.spec.js
@@ -37,7 +37,7 @@ import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import request from 'request';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/serve.spa/serve.spa.spec.js
+++ b/packages/cli/test/cases/serve.spa/serve.spa.spec.js
@@ -23,7 +23,7 @@ import { getOutputTeardownFiles } from '../../../../../test/utils.js';
 import path from 'path';
 import request from 'request';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/theme-pack/theme-pack.build.spec.js
+++ b/packages/cli/test/cases/theme-pack/theme-pack.build.spec.js
@@ -31,7 +31,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/cli/test/cases/theme-pack/theme-pack.develop.spec.js
+++ b/packages/cli/test/cases/theme-pack/theme-pack.develop.spec.js
@@ -30,7 +30,7 @@ import fs from 'fs';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import request from 'request';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { fileURLToPath, URL } from 'url';
 

--- a/packages/init/test/cases/build.default/build.default.spec.js
+++ b/packages/init/test/cases/build.default/build.default.spec.js
@@ -14,7 +14,7 @@
 import chai from 'chai';
 import fs from 'fs';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { fileURLToPath, URL } from 'url';
 

--- a/packages/init/test/cases/develop.default/develop.default.spec.js
+++ b/packages/init/test/cases/develop.default/develop.default.spec.js
@@ -17,7 +17,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles } from '../../../../../test/utils.js';
 import request from 'request';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { fileURLToPath, URL } from 'url';
 

--- a/packages/init/test/cases/init.default/init.default.spec.js
+++ b/packages/init/test/cases/init.default/init.default.spec.js
@@ -14,7 +14,7 @@
 import chai from 'chai';
 import fs from 'fs';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/init/test/cases/init.template/init.template.spec.js
+++ b/packages/init/test/cases/init.template/init.template.spec.js
@@ -14,7 +14,7 @@
 import chai from 'chai';
 import fs from 'fs';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/init/test/cases/init.yarn/init.yarn.spec.js
+++ b/packages/init/test/cases/init.yarn/init.yarn.spec.js
@@ -14,7 +14,7 @@
 import chai from 'chai';
 import fs from 'fs';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { fileURLToPath, URL } from 'url';
 

--- a/packages/plugin-babel/test/cases/default/default.spec.js
+++ b/packages/plugin-babel/test/cases/default/default.spec.js
@@ -31,7 +31,7 @@ import glob from 'glob-promise';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-babel/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-babel/test/cases/options.extend-config/options.extend-config.spec.js
@@ -41,7 +41,7 @@ import glob from 'glob-promise';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-google-analytics/test/cases/default/default.spec.js
+++ b/packages/plugin-google-analytics/test/cases/default/default.spec.js
@@ -28,7 +28,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-google-analytics/test/cases/error-analytics-id/error-analytics-id.spec.js
+++ b/packages/plugin-google-analytics/test/cases/error-analytics-id/error-analytics-id.spec.js
@@ -23,7 +23,7 @@
  */
 import chai from 'chai';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
+++ b/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
@@ -29,7 +29,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-graphql/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-graphql/test/cases/develop.default/develop.default.spec.js
@@ -21,7 +21,7 @@ import chai from 'chai';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import request from 'request';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 

--- a/packages/plugin-graphql/test/cases/qraphql-server/graphql-server.spec.js
+++ b/packages/plugin-graphql/test/cases/qraphql-server/graphql-server.spec.js
@@ -17,7 +17,7 @@
 import chai from 'chai';
 import request from 'request';
 import path from 'path';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-graphql/test/cases/query-children/query-children.spec.js
+++ b/packages/plugin-graphql/test/cases/query-children/query-children.spec.js
@@ -31,7 +31,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-graphql/test/cases/query-config/query-config.spec.js
+++ b/packages/plugin-graphql/test/cases/query-config/query-config.spec.js
@@ -27,7 +27,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-graphql/test/cases/query-custom-frontmatter/query-custom-frontmatter.spec.js
+++ b/packages/plugin-graphql/test/cases/query-custom-frontmatter/query-custom-frontmatter.spec.js
@@ -33,7 +33,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-graphql/test/cases/query-custom-schema/query-custom-schema.spec.js
+++ b/packages/plugin-graphql/test/cases/query-custom-schema/query-custom-schema.spec.js
@@ -28,7 +28,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
+++ b/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
@@ -29,7 +29,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-graphql/test/cases/query-menu/query-menu.spec.js
+++ b/packages/plugin-graphql/test/cases/query-menu/query-menu.spec.js
@@ -31,7 +31,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-import-commonjs/test/cases/default/default.spec.js
+++ b/packages/plugin-import-commonjs/test/cases/default/default.spec.js
@@ -32,7 +32,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-import-css/test/cases/default/default.spec.js
+++ b/packages/plugin-import-css/test/cases/default/default.spec.js
@@ -30,7 +30,7 @@ import glob from 'glob-promise';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
@@ -25,7 +25,7 @@
 import chai from 'chai';
 import path from 'path';
 import request from 'request';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 

--- a/packages/plugin-import-css/test/cases/exp-build.prerender/exp-build.prerender.spec.js
+++ b/packages/plugin-import-css/test/cases/exp-build.prerender/exp-build.prerender.spec.js
@@ -33,7 +33,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-import-json/test/cases/default/default.spec.js
+++ b/packages/plugin-import-json/test/cases/default/default.spec.js
@@ -32,7 +32,7 @@ import glob from 'glob-promise';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
@@ -26,7 +26,7 @@
 import chai from 'chai';
 import path from 'path';
 import request from 'request';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 

--- a/packages/plugin-import-json/test/cases/exp-build.prerender/exp-build.prerender.spec.js
+++ b/packages/plugin-import-json/test/cases/exp-build.prerender/exp-build.prerender.spec.js
@@ -33,7 +33,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-include-html/test/cases/build.default-custom-element/build.default.custom-element.spec.js
+++ b/packages/plugin-include-html/test/cases/build.default-custom-element/build.default.custom-element.spec.js
@@ -30,7 +30,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-include-html/test/cases/build.default-link-tag/build.default.link-tag.spec.js
+++ b/packages/plugin-include-html/test/cases/build.default-link-tag/build.default.link-tag.spec.js
@@ -30,7 +30,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-polyfills/test/cases/default/default.spec.js
+++ b/packages/plugin-polyfills/test/cases/default/default.spec.js
@@ -27,7 +27,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-polyfills/test/cases/dsd/dsd.spec.js
+++ b/packages/plugin-polyfills/test/cases/dsd/dsd.spec.js
@@ -25,7 +25,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-polyfills/test/cases/lit/lit.spec.js
+++ b/packages/plugin-polyfills/test/cases/lit/lit.spec.js
@@ -28,7 +28,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-postcss/test/cases/default/default.spec.js
+++ b/packages/plugin-postcss/test/cases/default/default.spec.js
@@ -30,7 +30,7 @@ import glob from 'glob-promise';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-postcss/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-postcss/test/cases/options.extend-config/options.extend-config.spec.js
@@ -37,7 +37,7 @@ import glob from 'glob-promise';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-renderer-lit/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-renderer-lit/test/cases/build.default/build.default.spec.js
@@ -29,7 +29,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { getSetupFiles, getDependencyFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
 import request from 'request';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-renderer-lit/test/cases/build.prerender.getting-started/build.prerender.getting-started.spec.js
+++ b/packages/plugin-renderer-lit/test/cases/build.prerender.getting-started/build.prerender.getting-started.spec.js
@@ -43,7 +43,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getDependencyFiles, getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-renderer-puppeteer/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-renderer-puppeteer/test/cases/build.default/build.default.spec.js
@@ -31,7 +31,7 @@ import { JSDOM } from 'jsdom';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getDependencyFiles, getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-typescript/test/cases/default/default.spec.js
+++ b/packages/plugin-typescript/test/cases/default/default.spec.js
@@ -41,7 +41,7 @@ import glob from 'glob-promise';
 import path from 'path';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/packages/plugin-typescript/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-typescript/test/cases/develop.default/develop.default.spec.js
@@ -19,7 +19,7 @@
 import chai from 'chai';
 import path from 'path';
 import request from 'request';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 

--- a/packages/plugin-typescript/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-typescript/test/cases/options.extend-config/options.extend-config.spec.js
@@ -41,7 +41,7 @@ import glob from 'glob-promise';
 import { runSmokeTest } from '../../../../../test/smoke-test.js';
 import path from 'path';
 import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
-import { Runner } from 'gallinago';
+import { Runner } from '../../../../../runner.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;

--- a/runner.js
+++ b/runner.js
@@ -54,6 +54,14 @@ class Runner {
         detached: true
       });
 
+      this.childProcess.on('close', code => {
+        if (err !== '' && code && code !== 0) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+
       this.childProcess.on('exit', code => {
         if (err !== '' && code && code !== 0) {
           reject(err);

--- a/runner.js
+++ b/runner.js
@@ -54,7 +54,7 @@ class Runner {
         detached: true
       });
 
-      this.childProcess.on('close', code => {
+      this.childProcess.on('exit', code => {
         if (err !== '' && code && code !== 0) {
           reject(err);
           return;

--- a/runner.js
+++ b/runner.js
@@ -1,0 +1,117 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawn } from 'child_process';
+
+class Runner {
+  constructor(enableStdOut = false, forwardParentArgs = false) {
+    this.enableStdOut = enableStdOut; // debugging tests
+    this.forwardParentArgs = forwardParentArgs;
+    this.setupFiles = [];
+    this.childProcess = null;
+  }
+
+  setup(rootDir, setupFiles = []) {
+    this.setupFiles = setupFiles;
+
+    return new Promise((resolve, reject) => {
+      if (path.isAbsolute(rootDir)) {
+
+        if (!fs.existsSync(rootDir)) {
+          fs.mkdirSync(rootDir);
+        }
+
+        this.rootDir = rootDir;
+
+        if (setupFiles.length > 0) {
+          setupFiles.forEach((file) => {
+            fs.mkdirSync(path.dirname(file.destination), { recursive: true });
+            fs.copyFileSync(file.source, file.destination);
+          });
+        }
+
+        resolve();
+      } else {
+        reject('Error: rootDir is not an absolute path');
+      }
+    });
+  }
+
+  runCommand(binPath, args = '') {
+    return new Promise(async (resolve, reject) => {
+      const cliPath = binPath;
+      const finalArgs = this.forwardParentArgs ? process.execArgv : [];
+      let err = '';
+
+      if (!fs.existsSync(binPath)) {
+        reject(`Error: Cannot find path ${binPath}`);
+      }
+
+      const runner = os.platform() === 'win32' ? 'node.cmd' : 'node';
+      this.childProcess = spawn(runner, [...finalArgs, cliPath, args], {
+        cwd: this.rootDir,
+        shell: false,
+        detached: true
+      });
+
+      this.childProcess.on('close', code => {
+        if (err !== '' && code && code !== 0) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+
+      this.childProcess.stderr.on('data', (data) => {
+        err = data.toString('utf8');
+        if (this.enableStdOut) {
+          console.error(err); // eslint-disable-line
+        }
+        reject(err);
+      });
+
+      this.childProcess.stdout.on('data', (data) => {
+        if (this.enableStdOut) {
+          console.log(data.toString('utf8')); // eslint-disable-line
+        }
+      });
+    });
+  }
+
+  stopCommand() {
+    if (this.childProcess) {
+      if (os.platform() === 'win32') {
+        spawn('taskkill', ['/pid', this.childProcess.pid, '/t', '/f']);
+      } else {
+        process.kill(-this.childProcess.pid, 'SIGKILL');
+      }
+    }
+  }
+
+  teardown(additionalFiles = []) {
+    return new Promise(async (resolve, reject) => {
+      try {
+        this.setupFiles.concat(additionalFiles).forEach((file) => {
+          const deletePath = file.destination
+            ? file.destination
+            : file;
+
+          if (fs.lstatSync(deletePath).isDirectory()) {
+            fs.rmSync(deletePath, { recursive: true });
+          } else {
+            fs.unlinkSync(deletePath);
+          }
+        });
+        this.setupFiles = [];
+
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+}
+
+export {
+  Runner
+};


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1070 

## Summary of Changes
1. Testing **gallinago** with `process.on('exit')` based on doing some more reading on the difference between [`close` and exit`](https://stackoverflow.com/a/40898359/417806)
> _So, if you are only interested in the process termination (e.g. because the process holds an exclusive resource), listening for "exit" is sufficient. If you don't care about the program, and only about its input and/or output, use the "close" event._

## TODO
1. [ ] Expecting the first build to fail, then seeing if change **gallinago** 
1. [ ] If it works, will need to upstream this change to **gallinago**