### PR TITLE
remove extra runner.runCommand in spec

### DIFF
--- a/packages/cli/test/cases/serve.default.ssr-static-export/serve.default.ssr-static-export.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr-static-export/serve.default.ssr-static-export.spec.js
@@ -126,7 +126,6 @@ describe('Serve Greenwood With: ', function() {
         ...litReactiveElementDecorators,
         ...litReactiveElementPackageJson
       ]);
-      await runner.runCommand(cliPath, 'build');
     });
 
     before(async function() {
@@ -239,8 +238,8 @@ describe('Serve Greenwood With: ', function() {
   });
 
   after(function() {
-    runner.teardown(getOutputTeardownFiles(outputPath));
     runner.stopCommand();
+    runner.teardown(getOutputTeardownFiles(outputPath));
   });
 
 });

--- a/packages/cli/test/cases/serve.default.ssr-static-export/serve.default.ssr-static-export.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr-static-export/serve.default.ssr-static-export.spec.js
@@ -126,10 +126,6 @@ describe('Serve Greenwood With: ', function() {
         ...litReactiveElementDecorators,
         ...litReactiveElementPackageJson
       ]);
-    });
-
-    before(async function() {
-      await runner.setup(outputPath, getSetupFiles(outputPath));
 
       return new Promise(async (resolve) => {
         setTimeout(() => {

--- a/packages/cli/test/cases/serve.default.ssr-static-export/serve.default.ssr-static-export.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr-static-export/serve.default.ssr-static-export.spec.js
@@ -238,8 +238,8 @@ describe('Serve Greenwood With: ', function() {
   });
 
   after(function() {
-    runner.stopCommand();
     runner.teardown(getOutputTeardownFiles(outputPath));
+    runner.stopCommand();
   });
 
 });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1070 

## Summary of Changes
1. Remove duplicate `runCommand` in spec