### PR TITLE
break after first found resource match for dev server serve lifecyle

### DIFF
--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -69,6 +69,7 @@ async function getDevServer(compilation) {
           const merged = mergeResponse(response.clone(), current.clone());
 
           response = merged;
+          break;
         }
       }
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
seems like a regression from #1054 , where the [`break` was removed](https://github.com/ProjectEvergreen/greenwood/pull/1054/files#diff-d61c0039ae5955506325c361ce49501ca90c732a543cc2a45ac2b7de0ab93329L69).  Reproducible in https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/85

![Screen Shot 2023-03-25 at 11 00 55 AM](https://user-images.githubusercontent.com/895923/227725939-d46a989c-c17c-492b-a9e6-3a130bcf670c.png)

(there's probably a little more than meet's the eye here but probably better to err on the side of caution and preserve existing behavior when it was not intended to be changed)


## Summary of Changes
1. Restore `break` in serve resource lifecycle in dev server