### PR TITLE
fix matching for bundling inline script tags

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -117,7 +117,7 @@ function greenwoodSyncPageResourceBundlesPlugin(compilation) {
               ...compilation.resources.get(resource.sourcePathURL.pathname),
               optimizedFileName: fileName,
               optimizedFileContents: await fs.readFile(outputPath, 'utf-8'),
-              contents: contents.replace(/\.\//g, '/')
+              contents
             });
 
             if (noop) {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Fix a regression with some inline `<script>` tags not getting bundled correctly - https://github.com/ProjectEvergreen/projectevergreen.github.io/pull/97