### PR TITLE
add max listeners suppression back

### DIFF
--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
 /* eslint-disable no-underscore-dangle */
+
+// https://github.com/ProjectEvergreen/greenwood/issues/141
+process.setMaxListeners(0);
+
 import { generateCompilation } from './lifecycles/compile.js';
 import fs from 'fs/promises';
 import program from 'commander';


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#1070 

Did a little sleuthing into the [release branch commit history](https://github.com/ProjectEvergreen/greenwood/commits/release/0.28.0) and seems that the first time this error started occurring was after we merged https://github.com/ProjectEvergreen/greenwood/pull/1046?
https://github.com/ProjectEvergreen/greenwood/actions/runs/4208842090/jobs/7305302032
<img width="1399" alt="Screen Shot 2023-04-08 at 1 35 37 PM" src="https://user-images.githubusercontent.com/895923/230735297-f272cff0-c4f2-4a08-b5a7-905823426dc9.png">

But then things are fine for a while, and then it starts happening again after merging https://github.com/ProjectEvergreen/greenwood/pull/1079?
https://github.com/ProjectEvergreen/greenwood/actions/runs/4585376551/jobs/8097482557
<img width="1562" alt="Screen Shot 2023-04-08 at 1 39 05 PM" src="https://user-images.githubusercontent.com/895923/230735378-3333fcec-cc2d-483a-9462-668c996ce94a.png">

## Summary of Changes
1. restore `process.setMaxListeners(0);` to test