### PR TITLE
Chore/issue 1070 remove async before that are not async

### DIFF
--- a/packages/cli/test/cases/serve.default.ssr-prerender/serve.default.ssr-prerender.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr-prerender/serve.default.ssr-prerender.spec.js
@@ -40,7 +40,7 @@ describe('Serve Greenwood With: ', function() {
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
-  before(async function() {
+  before(function() {
     this.context = {
       publicDir: path.join(outputPath, 'public'),
       hostname

--- a/packages/cli/test/cases/serve.default.ssr-static-export/serve.default.ssr-static-export.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr-static-export/serve.default.ssr-static-export.spec.js
@@ -39,7 +39,7 @@ describe('Serve Greenwood With: ', function() {
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
 
-  before(async function() {
+  before(function() {
     this.context = { 
       publicDir: path.join(outputPath, 'public'),
       hostname

--- a/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
@@ -43,7 +43,7 @@ describe('Serve Greenwood With: ', function() {
   const hostname = 'http://127.0.0.1:8080';
   let runner;
 
-  before(async function() {
+  before(function() {
     this.context = {
       publicDir: path.join(outputPath, 'public'),
       hostname


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1070 

Based on the error message, wondering if the issue is using `async` in `before` calls that don't return a promise?
```sh
       "before all" hook in "A Server Rendered Application (SSR) that is statically exported":
     Error: Timeout of 90000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```

## Summary of Changes
1. Clean up usages of `before(async function() {`