### PR TITLE
port was hardcoded with `serve` command and SSR

### DIFF
--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -1,5 +1,5 @@
 import { getStaticServer, getHybridServer } from '../lifecycles/serve.js';
-import { checkResourceExists } from '@greenwood/cli/src/lib/resource-utils.js';
+import { checkResourceExists } from '../lib/resource-utils.js';
 
 const runProdServer = async (compilation) => {
 

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -270,13 +270,13 @@ async function getStaticServer(compilation, composable) {
 }
 
 async function getHybridServer(compilation) {
-  const { graph, manifest, context } = compilation;
+  const { graph, manifest, context, config } = compilation;
   const { outputDir } = context;
   const app = await getStaticServer(compilation, true);
 
   app.use(async (ctx) => {
     try {
-      const url = new URL(`http://localhost:8080${ctx.url}`);
+      const url = new URL(`http://localhost:${config.port}${ctx.url}`);
       const matchingRoute = graph.find((node) => node.route === url.pathname) || { data: {} };
       const isApiRoute = manifest.apis.has(url.pathname);
       const request = new Request(url.href, {

--- a/packages/cli/test/cases/serve.default.ssr/greenwood.config.js
+++ b/packages/cli/test/cases/serve.default.ssr/greenwood.config.js
@@ -1,3 +1,3 @@
 export default {
-  interpolateFrontmatter: true
+  port: 8181
 };

--- a/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
@@ -9,7 +9,9 @@
  * greenwood build
  *
  * User Config
- * None
+ * {
+ *   port: 8181
+ * }
  *
  * User Workspace
  *  src/
@@ -40,7 +42,7 @@ describe('Serve Greenwood With: ', function() {
   const LABEL = 'A Server Rendered Application (SSR)';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
-  const hostname = 'http://127.0.0.1:8080';
+  const hostname = 'http://127.0.0.1:8181';
   let runner;
 
   before(async function() {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#1079

## Summary of Changes
1. Use port from configuration when using `serve` command with SSR pages / API
1. Fixed an errant reference to **@greenwood/cli** inside a lib file