### PR TITLE
bug/use Worker threads for full API routes cache busting in development mode

### DIFF
--- a/packages/cli/src/lib/api-route-worker.js
+++ b/packages/cli/src/lib/api-route-worker.js
@@ -21,6 +21,8 @@ async function responseAsObject (response) {
     return filtered;
   }
 
+  // TODO handle full response
+  // https://github.com/ProjectEvergreen/greenwood/issues/1048
   return {
     ...stringifiableObject(response),
     headers: Object.fromEntries(response.headers),
@@ -30,11 +32,9 @@ async function responseAsObject (response) {
 }
 
 async function executeRouteModule({ href, request }) {
-  // console.log('WORKER', { href, message, request })
   const { handler } = await import(href);
   const response = await handler(request);
 
-  // console.log('WORKER', { response })
   parentPort.postMessage(await responseAsObject(response));
 }
 

--- a/packages/cli/src/lib/api-route-worker.js
+++ b/packages/cli/src/lib/api-route-worker.js
@@ -1,0 +1,43 @@
+// https://github.com/nodejs/modules/issues/307#issuecomment-858729422
+import { parentPort } from 'worker_threads';
+
+// based on https://stackoverflow.com/questions/57447685/how-can-i-convert-a-request-object-into-a-stringifiable-object-in-javascript
+async function responseAsObject (response) {
+  if (!response instanceof Response) {
+    throw Object.assign(
+      new Error(),
+      { name: 'TypeError', message: 'Argument must be a Response object' }
+    );
+  }
+  response = response.clone();
+
+  function stringifiableObject (obj) {
+    const filtered = {};
+    for (const key in obj) {
+      if (['boolean', 'number', 'string'].includes(typeof obj[key]) || obj[key] === null) {
+        filtered[key] = obj[key];
+      }
+    }
+    return filtered;
+  }
+
+  return {
+    ...stringifiableObject(response),
+    headers: Object.fromEntries(response.headers),
+    // signal: stringifiableObject(request.signal),
+    body: await response.text()
+  };
+}
+
+async function executeRouteModule({ href, request }) {
+  // console.log('WORKER', { href, message, request })
+  const { handler } = await import(href);
+  const response = await handler(request);
+
+  // console.log('WORKER', { response })
+  parentPort.postMessage(await responseAsObject(response));
+}
+
+parentPort.on('message', async (task) => {
+  await executeRouteModule(task);
+});

--- a/packages/cli/src/plugins/resource/plugin-api-routes.js
+++ b/packages/cli/src/plugins/resource/plugin-api-routes.js
@@ -26,6 +26,8 @@ function requestAsObject (request) {
     return filtered;
   }
 
+  // TODO handle full response
+  // https://github.com/ProjectEvergreen/greenwood/issues/1048
   return {
     ...stringifiableObject(request),
     headers: Object.fromEntries(request.headers),
@@ -53,8 +55,6 @@ class ApiRoutesResource extends ResourceInterface {
       ...request
     });
 
-    // console.log({ req });
-
     // TODO does this ever run in anything but development mode?
     if (process.env.__GWD_COMMAND__ === 'develop') { // eslint-disable-line no-underscore-dangle
       const workerUrl = new URL('../../lib/api-route-worker.js', import.meta.url);
@@ -64,7 +64,6 @@ class ApiRoutesResource extends ResourceInterface {
         const req = requestAsObject(request);
 
         worker.on('message', (result) => {
-          // console.log('RESULT =====>', { result });
           resolve(result);
         });
         worker.on('error', reject);
@@ -74,12 +73,9 @@ class ApiRoutesResource extends ResourceInterface {
           }
         });
 
-        // console.log('OUT', { reqUnrevied });
-
         worker.postMessage({ href, request: req });
       });
 
-      // console.log('SUCCESS', {response})
       return new Response(response.body, {
         ...response
       });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1104 

https://user-images.githubusercontent.com/895923/235521979-16c01cf7-f966-44db-b0b2-6f326ed3a84e.mov

## Summary of Changes
1. Implement Workers based work around for full API routes cache busting in development mode

> _Seems to work well enough in a demo repo, not sure if we're missing any other properties, per https://github.com/ProjectEvergreen/greenwood/issues/1048? _

## TODO
1. [x] Clean up console logs / debug code
1. [ ] Creating tracking ticket (GFI) to put all these JSON stringify / parse functions into a util file (including `reviver`, etc)