### PR TITLE
add support for optimizing CSS `:has` / `:is` pseudo-selectors

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -46,6 +46,7 @@ function bundleCss(body, url, projectDirectory) {
 
         switch (name) {
 
+          case 'is':
           case 'has':
           case 'lang':
           case 'not':
@@ -154,6 +155,7 @@ function bundleCss(body, url, projectDirectory) {
         case 'PseudoClassSelector':
           switch (node.name) {
 
+            case 'is':
             case 'has':
             case 'lang':
             case 'not':

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -46,6 +46,7 @@ function bundleCss(body, url, projectDirectory) {
 
         switch (name) {
 
+          case 'has':
           case 'lang':
           case 'not':
           case 'nth-child':
@@ -153,6 +154,7 @@ function bundleCss(body, url, projectDirectory) {
         case 'PseudoClassSelector':
           switch (node.name) {
 
+            case 'has':
             case 'lang':
             case 'not':
             case 'nth-child':

--- a/packages/cli/test/cases/build.config.optimization-default/fixtures/expected.css
+++ b/packages/cli/test/cases/build.config.optimization-default/fixtures/expected.css
@@ -57,3 +57,5 @@ a[href*='greenwood'],a[href$='.pdf']{color:orange}
 @font-feature-values Font One{@styleset {nice-style:12}}
 
 h1:has(+h2){margin:0 0 0.25rem 0}
+
+:is(ol,ul,menu:unsupported) :is(ol,ul){color:green}

--- a/packages/cli/test/cases/build.config.optimization-default/fixtures/expected.css
+++ b/packages/cli/test/cases/build.config.optimization-default/fixtures/expected.css
@@ -55,3 +55,5 @@ a[href*='greenwood'],a[href$='.pdf']{color:orange}
 @page {size:8.5in 9in;margin-top:4in;}
 
 @font-feature-values Font One{@styleset {nice-style:12}}
+
+h1:has(+h2){margin:0 0 0.25rem 0}

--- a/packages/cli/test/cases/build.config.optimization-default/src/styles/main.css
+++ b/packages/cli/test/cases/build.config.optimization-default/src/styles/main.css
@@ -126,3 +126,7 @@ a[href*="greenwood"], a[href$=".pdf"] {
 h1:has(+ h2) {
   margin: 0 0 0.25rem 0;
 }
+
+:is(ol, ul, menu:unsupported) :is(ol, ul) {
+  color: green;
+}

--- a/packages/cli/test/cases/build.config.optimization-default/src/styles/main.css
+++ b/packages/cli/test/cases/build.config.optimization-default/src/styles/main.css
@@ -122,3 +122,7 @@ a[href*="greenwood"], a[href$=".pdf"] {
     nice-style: 12;
   }
 }
+
+h1:has(+ h2) {
+  margin: 0 0 0.25rem 0;
+}


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1106 

So for example, with this HTML
```html
<h1>Heading for :has (should be red)</h1>
<p>Testing :has!</p>

<h1>Heading for :is (should not be red)</h1>
<ol>
  <li>Saturn</li>
  <li>
    <ul>
      <li>Mimas</li>
      <li>Enceladus</li>
      <li>
        <ol>
          <li>Voyager</li>
          <li>Cassini</li>
        </ol>
      </li>
      <li>Tethys</li>
    </ul>
  </li>
  <li>Uranus</li>
  <li>
    <ol>
      <li>Titania</li>
      <li>Oberon</li>
    </ol>
  </li>
</ol>
```

And this CSS (from the MDN page)
```css
h1:has(+ p) {
  color: red;
}

ol {
  list-style-type: upper-alpha;
  color: darkblue;
}

:is(ol, ul, menu:unsupported) :is(ol, ul) {
  color: green;
}

:is(ol, ul) :is(ol, ul) ol {
  list-style-type: lower-greek;
  color: chocolate;
}
```

The styles work as expected in dev and production builds
![Screenshot 2023-11-03 at 7 37 48 PM](https://github.com/ProjectEvergreen/greenwood/assets/895923/471c2bd4-567c-43ae-a26d-5de511399870)
![Screenshot 2023-11-03 at 7 51 25 PM](https://github.com/ProjectEvergreen/greenwood/assets/895923/a612eefb-6ed0-47a9-8948-6fd313598aec)

## Summary of Changes
1. Add support for optimizing [`:has`](https://developer.mozilla.org/en-US/docs/Web/CSS/:has)
1. Add support for optimizing [`:is`](https://developer.mozilla.org/en-US/docs/Web/CSS/:is)
1. Add test case

## TODO
1. [x] Demo / test
1. [x] also need `:is` support?