### PR TITLE
bug/issue 1108 update ETag caching to work with ReadableStreams

### DIFF
--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -136,9 +136,8 @@ async function getDevServer(compilation) {
     console.log(url.pathname);
     // console.log('ctx.body', ctx.body);
 
-    // don't interfere with external requests or API calls, binary files, or JSON
+    // don't interfere with external requests or API calls, only files
     // and only run in development
-    // TODO better buffer / binary data detection
     if (process.env.__GWD_COMMAND__ === 'develop' && url.protocol === 'file:') { // eslint-disable-line no-underscore-dangle
       // const response = new Response(ctx.body._readableState);
       // const teedOff = new ReadableStream(ctx.body).tee();

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -133,72 +133,28 @@ async function getDevServer(compilation) {
   // https://stackoverflow.com/questions/43659756/chrome-ignores-the-etag-header-and-just-uses-the-in-memory-cache-disk-cache
   app.use(async (ctx) => {
     const url = new URL(ctx.url);
-    console.log(url.pathname);
-    // console.log('ctx.body', ctx.body);
 
     // don't interfere with external requests or API calls, only files
     // and only run in development
     if (process.env.__GWD_COMMAND__ === 'develop' && url.protocol === 'file:') { // eslint-disable-line no-underscore-dangle
-      // const response = new Response(ctx.body._readableState);
-      // const teedOff = new ReadableStream(ctx.body).tee();
-      // console.log({ teedOff });
-      // const readStream1 = ctx.body.clone();
-      // const response = new Response(teedOff[0]);
-      // const contents = await response.text();
-      // const contents = await ctx.body.read();
-      console.log('headers', ctx.response.header);
       // TODO there's probably a better way to do this with tee-ing streams but this works for now
       const response = new Response(ctx.body, {
         status: ctx.response.status,
         headers: new Headers(ctx.response.header)
       }).clone();
-      const r2 = response.clone();
-      const contents = await r2.text();
-
-      // const chunks = [];
-      // for await (const chunk of teedOff[0]) {
-      //     chunks.push(Buffer.from(chunk));
-      // }
-
-      // const contents = Buffer.concat(chunks).toString("utf-8");
-      // console.log(ctx.body.read());
-      // console.log(ctx.body._readableState)
-      // console.log({ contents });
-      // console.log({ teedOff });
-      // console.log('is Buffer contents', Buffer.isBuffer(contents))
-      // console.log('is Buffer cdx.body', Buffer.isBuffer(ctx.body))
-
-      // TODO does this still work?
-      // if (url.pathname.endsWith('.webp') || !contents || Buffer.isBuffer(contents)) {
-      //   console.warn(`no body for => ${ctx.url}`);
-      //   // ctx.body = Readable.from(ctx.body);
-      //   ctx.status = 200;
-      //   // ctx.response.body = Readable.from(contents);
-      //   ctx.body = contents;
-      // } else {
+      const splitResponse = response.clone();
+      const contents = await splitResponse.text();
       const inm = ctx.headers['if-none-match'];
-      // const stream1 = contents.pipe(new stream.PassThrough())
-      // const contents = await streamToString(body);
-      // const contents = await (new Response(body)).text();
       const etagHash = url.pathname.split('.').pop() === 'json'
         ? hashString(JSON.stringify(contents))
         : hashString(contents);
 
-      // console.log({ contents });
-      console.log({ inm, etagHash });
-
       if (inm && inm === etagHash) {
-        console.log('cache hit!');
         ctx.status = 304;
         ctx.body = null;
         ctx.set('Etag', etagHash);
         ctx.set('Cache-Control', 'no-cache');
-        // teedOff[0];
       } else if (!inm || inm !== etagHash) {
-        // await next();
-        console.log('cache miss!');
-        console.log('content type', ctx.response.header['content-type']);
-
         ctx.body = Readable.from(response.body);
         ctx.status = ctx.status;
         ctx.set('Content-Type', ctx.response.header['content-type']);
@@ -209,21 +165,7 @@ async function getDevServer(compilation) {
         if (response.headers.has('Content-Length')) {
           ctx.set('Content-Length', response.headers.get('Content-Length'));
         }
-        // console.log({ contents });
-        // ctx.status = 200;
-        // ctx.body = Readable.from(response.body); // Readable.from(contents);
-        // ctx.body.resume();
-      } else {
-        console.log('??????????');
-        // ctx.body = teedOff[1];
-        // ctx.body.resume();
-        // ctx.body = Readable.from(ctx.body);
       }
-
-      // ctx.body.resume();
-      // }
-
-      console.log('======================');
     }
   });
 

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -197,10 +197,11 @@ async function getDevServer(compilation) {
       } else if (!inm || inm !== etagHash) {
         // await next();
         console.log('cache miss!');
+        console.log('content type', ctx.response.header['content-type']);
 
         ctx.body = Readable.from(response.body);
-        ctx.type = response.headers.get('Content-Type');
-        ctx.status = response.status;
+        ctx.status = ctx.status;
+        ctx.set('Content-Type', ctx.response.header['content-type']);
         ctx.set('Etag', etagHash);
   
         // TODO automatically loop and apply all custom headers to Koa response, include Content-Type below

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -923,6 +923,45 @@ describe('Develop Greenwood With: ', function() {
       });
     });
 
+    describe('Develop command with generic video container format (.mp4) behavior that should return an etag hit', function() {
+      let response = {};
+
+      before(async function() {
+        return new Promise((resolve, reject) => {
+          request.get({
+            url: `${hostname}:${port}/assets/splash-clip.mp4`,
+            headers: {
+              'if-none-match': '2130309740'
+            }
+          }, (err, res, body) => {
+            if (err) {
+              reject();
+            }
+
+            response = res;
+            response.body = body;
+
+            resolve();
+          });
+        });
+      });
+
+      it('should return a 304 status', function(done) {
+        expect(response.statusCode).to.equal(304);
+        done();
+      });
+
+      it('should return an empty body', function(done) {
+        expect(response.body).to.contain('');
+        done();
+      });
+
+      it('should return the correct cache-control header', function(done) {
+        expect(response.headers['cache-control']).to.equal('no-cache');
+        done();
+      });
+    });
+
     describe('Develop command with audio format (.mp3) behavior', function() {
       let response = {};
 

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -902,13 +902,18 @@ describe('Develop Greenwood With: ', function() {
         done();
       });
 
-      it('should return the correct content type', function(done) {
+      it('should return the correct content type header', function(done) {
         expect(response.headers['content-type']).to.contain(ext);
         done();
       });
 
-      it('should return the correct content length', function(done) {
+      it('should return the correct content length header', function(done) {
         expect(response.headers['content-length']).to.equal('2498461');
+        done();
+      });
+
+      it('should return the correct etag header', function(done) {
+        expect(response.headers.etag).to.equal('2130309740');
         done();
       });
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1108 

https://github.com/ProjectEvergreen/greenwood/assets/895923/24c2361e-4c53-4d24-a195-416036699f5d

## Summary of Changes
1. Update ETag implementation to work with `ReadableStream`
1. Removed "filter" around binary files, will now work with any `file:` types
1. Add test cases to cover etag hits and misses

## TODO
1. [x] Fix spec failing for missing content length
    <details>
      <pre>
        1) Develop Greenwood With:
         Default Greenwood Configuration and Workspace
           Develop command with generic video container format (.mp4) behavior
             should return the correct content length:
       AssertionError: expected undefined to equal '2498461'
        at Context.<anonymous> (file:///Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/test/cases/develop.default/develop.default.spec.js:911:55)
        at process.processImmediate (node:internal/timers:471:21)
  
        2) Develop Greenwood With:
             Default Greenwood Configuration and Workspace
               Develop command with audio format (.mp3) behavior
                 should return the correct content length:
           AssertionError: expected undefined to equal '5425061'
            at Context.<anonymous> (file:///Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/test/cases/develop.default/develop.default.spec.js:950:55)
            at process.processImmediate (node:internal/timers:471:21)
      </pre>
    </details>
1. [x] Add test case for etag header 
1. [x] Finalize testing / clean up consoles and comments
1. [x] Probably a good idea to make sure this and the disable cache work around are documented somewhere - already covered! - http://localhost:1984/about/how-it-works/#cli