### PR TITLE
Enhancement/issue 1088 refactor workers out of SSR builds

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -98,7 +98,7 @@ const runProductionBuild = async (compilation) => {
           return Promise.resolve(server);
         }));
 
-        if (prerenderPlugin.workerUrl) {
+        if (prerenderPlugin.executeModuleUrl) {
           await trackResourcesForRoutes(compilation);
           await preRenderCompilationWorker(compilation, prerenderPlugin);
         } else {

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -224,10 +224,28 @@ const getRollupConfigForSsr = async (compilation, input) => {
     },
     plugins: [
       greenwoodJsonLoader(),
-      nodeResolve(),
+      // TODO should this be used in all configs?
+      nodeResolve({
+        preferBuiltins: true
+      }),
       commonjs(),
       importMetaAssets()
-    ]
+    ],
+    onwarn: (errorObj) => {
+      const { code, message } = errorObj;
+
+      switch (code) {
+
+        case 'CIRCULAR_DEPENDENCY':
+          // let this through for lit to enable nodeResolve({ preferBuiltins: true })
+          // https://github.com/lit/lit/issues/449
+          break;
+        default:
+          // otherwise, log all warnings from rollup
+          console.debug(message);
+
+      }
+    }
   }];
 };
 

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -263,7 +263,9 @@ const getRollupConfigForSsr = async (compilation, input) => {
       switch (code) {
 
         case 'CIRCULAR_DEPENDENCY':
-          // TODO let this through for lit to enable nodeResolve({ preferBuiltins: true })
+          // TODO let this through for lit by suppressing it
+          // Error: the string "Circular dependency: ../../../../../node_modules/@lit-labs/ssr/lib/render-lit-html.js ->
+          // ../../../../../node_modules/@lit-labs/ssr/lib/lit-element-renderer.js -> ../../../../../node_modules/@lit-labs/ssr/lib/render-lit-html.js\n" was thrown, throw an Error :)
           // https://github.com/lit/lit/issues/449
           break;
         default:

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -132,6 +132,7 @@ function greenwoodSyncPageResourceBundlesPlugin(compilation) {
 
 // TODO could we use this instead?
 // https://github.com/rollup/rollup/blob/v2.79.1/docs/05-plugin-development.md#resolveimportmeta
+// https://github.com/ProjectEvergreen/greenwood/issues/1087
 function greenwoodPatchSsrPagesEntryPointRuntimeImport() {
   return {
     name: 'greenwood-patch-ssr-pages-entry-point-runtime-import',
@@ -217,7 +218,7 @@ const getRollupConfigForApis = async (compilation) => {
     .map(api => normalizePathnameForWindows(new URL(`.${api.path}`, userWorkspace)));
 
   // TODO should routes and APIs have chunks?
-  // https://github.com/ProjectEvergreen/greenwood/issues/1008
+  // https://github.com/ProjectEvergreen/greenwood/issues/1118
   return [{
     input,
     output: {
@@ -238,7 +239,7 @@ const getRollupConfigForSsr = async (compilation, input) => {
   const { outputDir } = compilation.context;
 
   // TODO should routes and APIs have chunks?
-  // https://github.com/ProjectEvergreen/greenwood/issues/1008
+  // https://github.com/ProjectEvergreen/greenwood/issues/1118
   return [{
     input,
     output: {
@@ -250,6 +251,7 @@ const getRollupConfigForSsr = async (compilation, input) => {
       greenwoodJsonLoader(),
       // TODO let this through for lit to enable nodeResolve({ preferBuiltins: true })
       // https://github.com/lit/lit/issues/449
+      // https://github.com/ProjectEvergreen/greenwood/issues/1118
       nodeResolve({
         preferBuiltins: true
       }),
@@ -267,6 +269,7 @@ const getRollupConfigForSsr = async (compilation, input) => {
           // Error: the string "Circular dependency: ../../../../../node_modules/@lit-labs/ssr/lib/render-lit-html.js ->
           // ../../../../../node_modules/@lit-labs/ssr/lib/lit-element-renderer.js -> ../../../../../node_modules/@lit-labs/ssr/lib/render-lit-html.js\n" was thrown, throw an Error :)
           // https://github.com/lit/lit/issues/449
+          // https://github.com/ProjectEvergreen/greenwood/issues/1118
           break;
         default:
           // otherwise, log all warnings from rollup

--- a/packages/cli/src/lib/execute-route-module.js
+++ b/packages/cli/src/lib/execute-route-module.js
@@ -3,7 +3,7 @@ import { renderToString, renderFromHTML } from 'wc-compiler';
 // TODO simplify this API signature (lot of things could be combined)
 // - route, label and id could just be the current page
 // - scripts is already part of the compilation
-async function executeRouteModule({ moduleUrl, compilation, route, label, id, prerender, htmlContents, scripts }) {
+async function executeRouteModule({ moduleUrl, compilation, page = {}, prerender = false, htmlContents = null, scripts = [] }) {
   const data = {
     template: null,
     body: null,
@@ -26,16 +26,16 @@ async function executeRouteModule({ moduleUrl, compilation, route, label, id, pr
       data.body = html;
     } else {
       if (getBody) {
-        data.body = await getBody(compilation, route);
+        data.body = await getBody(compilation, page);
       }
     }
 
     if (getTemplate) {
-      data.template = await getTemplate(compilation, route);
+      data.template = await getTemplate(compilation, page);
     }
 
     if (getFrontmatter) {
-      data.frontmatter = await getFrontmatter(compilation, route, label, id);
+      data.frontmatter = await getFrontmatter(compilation, page);
     }
   }
 

--- a/packages/cli/src/lib/execute-route-module.js
+++ b/packages/cli/src/lib/execute-route-module.js
@@ -1,0 +1,45 @@
+import { renderToString, renderFromHTML } from 'wc-compiler';
+
+// TODO simplify this API signature (lot of things could be combined)
+// - route, label and id could just be the current page
+// - scripts is already part of the compilation
+async function executeRouteModule({ moduleUrl, compilation, route, label, id, prerender, htmlContents, scripts }) {
+  const data = {
+    template: null,
+    body: null,
+    frontmatter: null,
+    html: null
+  };
+
+  if (prerender) {
+    const scriptURLs = scripts.map(scriptFile => new URL(scriptFile));
+    const { html } = await renderFromHTML(htmlContents, scriptURLs);
+
+    data.html = html;
+  } else {
+    const module = await import(moduleUrl).then(module => module);
+    const { getTemplate = null, getBody = null, getFrontmatter = null } = module;
+
+    if (module.default) {
+      const { html } = await renderToString(new URL(moduleUrl), false);
+
+      data.body = html;
+    } else {
+      if (getBody) {
+        data.body = await getBody(compilation, route);
+      }
+    }
+
+    if (getTemplate) {
+      data.template = await getTemplate(compilation, route);
+    }
+
+    if (getFrontmatter) {
+      data.frontmatter = await getFrontmatter(compilation, route, label, id);
+    }
+  }
+
+  return data;
+}
+
+export { executeRouteModule };

--- a/packages/cli/src/lib/execute-route-module.js
+++ b/packages/cli/src/lib/execute-route-module.js
@@ -1,8 +1,5 @@
 import { renderToString, renderFromHTML } from 'wc-compiler';
 
-// TODO simplify this API signature (lot of things could be combined)
-// - route, label and id could just be the current page
-// - scripts is already part of the compilation
 async function executeRouteModule({ moduleUrl, compilation, page = {}, prerender = false, htmlContents = null, scripts = [] }) {
   const data = {
     template: null,

--- a/packages/cli/src/lib/ssr-route-worker.js
+++ b/packages/cli/src/lib/ssr-route-worker.js
@@ -1,9 +1,9 @@
 // https://github.com/nodejs/modules/issues/307#issuecomment-858729422
 import { parentPort } from 'worker_threads';
 
-async function executeModule({ executeRouteModuleUrl, moduleUrl, compilation, route, label, id, prerender, htmlContents, scripts = '[]' }) {
-  const { executeRouteModule } = await import(executeRouteModuleUrl);
-  const data = await executeRouteModule({ moduleUrl, compilation: JSON.parse(compilation), route, label, id, prerender, htmlContents, scripts: JSON.parse(scripts) });
+async function executeModule({ executeModuleUrl, moduleUrl, compilation, page, prerender = false, htmlContents = null, scripts = '[]' }) {
+  const { executeRouteModule } = await import(executeModuleUrl);
+  const data = await executeRouteModule({ moduleUrl, compilation: JSON.parse(compilation), page: JSON.parse(page), prerender, htmlContents, scripts: JSON.parse(scripts) });
 
   parentPort.postMessage(data);
 }

--- a/packages/cli/src/lib/ssr-route-worker.js
+++ b/packages/cli/src/lib/ssr-route-worker.js
@@ -1,8 +1,8 @@
 // https://github.com/nodejs/modules/issues/307#issuecomment-858729422
 import { parentPort } from 'worker_threads';
-import { executeRouteModule } from './execute-route-module.js';
 
-async function executeModule({ moduleUrl, compilation, route, label, id, prerender, htmlContents, scripts = '[]' }) {
+async function executeModule({ executeRouteModuleUrl, moduleUrl, compilation, route, label, id, prerender, htmlContents, scripts = '[]' }) {
+  const { executeRouteModule } = await import(executeRouteModuleUrl);
   const data = await executeRouteModule({ moduleUrl, compilation: JSON.parse(compilation), route, label, id, prerender, htmlContents, scripts: JSON.parse(scripts) });
 
   parentPort.postMessage(data);

--- a/packages/cli/src/lib/ssr-route-worker.js
+++ b/packages/cli/src/lib/ssr-route-worker.js
@@ -1,47 +1,13 @@
 // https://github.com/nodejs/modules/issues/307#issuecomment-858729422
 import { parentPort } from 'worker_threads';
-import { renderToString, renderFromHTML } from 'wc-compiler';
+import { executeRouteModule } from './execute-route-module.js';
 
-async function executeRouteModule({ moduleUrl, compilation, route, label, id, prerender, htmlContents, scripts }) {
-  const parsedCompilation = JSON.parse(compilation);
-  const data = {
-    template: null,
-    body: null,
-    frontmatter: null,
-    html: null
-  };
-
-  if (prerender) {
-    const scriptURLs = JSON.parse(scripts).map(scriptFile => new URL(scriptFile));
-    const { html } = await renderFromHTML(htmlContents, scriptURLs);
-
-    data.html = html;
-  } else {
-    const module = await import(moduleUrl).then(module => module);
-    const { getTemplate = null, getBody = null, getFrontmatter = null } = module;
-
-    if (module.default) {
-      const { html } = await renderToString(new URL(moduleUrl), false);
-
-      data.body = html;
-    } else {
-      if (getBody) {
-        data.body = await getBody(parsedCompilation, route);
-      }
-    }
-
-    if (getTemplate) {
-      data.template = await getTemplate(parsedCompilation, route);
-    }
-
-    if (getFrontmatter) {
-      data.frontmatter = await getFrontmatter(parsedCompilation, route, label, id);
-    }
-  }
+async function executeModule({ moduleUrl, compilation, route, label, id, prerender, htmlContents, scripts = '[]' }) {
+  const data = await executeRouteModule({ moduleUrl, compilation: JSON.parse(compilation), route, label, id, prerender, htmlContents, scripts: JSON.parse(scripts) });
 
   parentPort.postMessage(data);
 }
 
 parentPort.on('message', async (task) => {
-  await executeRouteModule(task);
+  await executeModule(task);
 });

--- a/packages/cli/src/lib/templating-utils.js
+++ b/packages/cli/src/lib/templating-utils.js
@@ -177,6 +177,8 @@ async function getAppTemplate(pageTemplateContents, context, customImports = [],
 }
 
 async function getUserScripts (contents, context) {
+  // TODO get rid of lit polyfills in core
+  // https://github.com/ProjectEvergreen/greenwood/issues/728
   // https://lit.dev/docs/tools/requirements/#polyfills
   if (process.env.__GWD_COMMAND__ === 'build') { // eslint-disable-line no-underscore-dangle
     const userPackageJson = await getPackageJson(context);

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -197,26 +197,16 @@ async function bundleSsrPages(compilation) {
         const entryFileUrl = new URL(`./_${filename}`, scratchDir);
         const moduleUrl = new URL(`./${filename}`, pagesDir);
         // TODO getTemplate has to be static (for now?)
-        // const { getTemplate = null } = await import(new URL(`./${filename}`, pagesDir));
+        // https://github.com/ProjectEvergreen/greenwood/issues/955
         const data = await executeRouteModule({ moduleUrl, compilation, page, prerender: false, htmlContents: null, scripts: [] });
         let staticHtml = '';
 
         staticHtml = data.template ? data.template : await getPageTemplate(staticHtml, compilation.context, template, []);
-        // console.log('+ page template', { staticHtml });
-
         staticHtml = await getAppTemplate(staticHtml, compilation.context, imports, [], false, title);
-        // console.log('+ app template', { staticHtml });
-
         staticHtml = await getUserScripts(staticHtml, compilation.context);
-        // console.log('+ user scripts', { staticHtml });
-
-        // TODO do we want to use http:// here for optimizer?
         staticHtml = await (await htmlOptimizer.optimize(new URL(`http://localhost:8080${route}`), new Response(staticHtml))).text();
-        // console.log('+ optimizer', { staticHtml });
 
         // better way to write out this inline code?
-        // TODO does executeRouteModule need to get bundled?
-        // TODO do we need to bundle this too since we reference executeModuleUrl.href directly?
         await fs.writeFile(entryFileUrl, `
           import { executeRouteModule } from '${normalizePathnameForWindows(executeModuleUrl)}';
 
@@ -246,7 +236,6 @@ async function bundleSsrPages(compilation) {
 
     const [rollupConfig] = await getRollupConfigForSsr(compilation, input);
 
-    // TODO do we need templates anymore?
     if (rollupConfig.input.length > 0) {
       const bundle = await rollup(rollupConfig);
       await bundle.write(rollupConfig.output);

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -220,15 +220,10 @@ async function bundleSsrPages(compilation) {
         await fs.writeFile(entryFileUrl, `
           import { executeRouteModule } from '${normalizePathnameForWindows(executeModuleUrl)}';
 
-          // use a function to explicitly resolve import.meta.url at _runtime_, not build time
-          function getEntryPointUrl(filename) {
-            return new URL(\`./_\${filename}\`, import.meta.url);
-          }
-
           export async function handler(request) {
             const compilation = JSON.parse('${JSON.stringify(compilation)}');
             const page = JSON.parse('${JSON.stringify(page)}');
-            const moduleUrl = getEntryPointUrl('${filename}');
+            const moduleUrl = '___GWD_ENTRY_FILE_URL=${filename}___';
             const data = await executeRouteModule({ moduleUrl, compilation, page });
             let staticHtml = \`${staticHtml}\`;
 

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -210,23 +210,44 @@ async function bundleSsrPages(compilation) {
 
         // TODO need to handle body as a string
         // TODO have to do this "manually" until import.meta.url is supported?
+        // await fs.writeFile(outputUrl, `
+        //   // import { renderToString } from 'wc-compiler';
+        //   import 'wc-compiler/src/dom-shim.js';
+        //   import Page from './_${filename}';
+
+        //   export async function handler(request) {
+        //     console.log('${JSON.stringify(page)}');          
+
+        //     let initBody = ${body};
+        //     let initHtml = \`${html}\`;
+
+        //     if (!initBody) {
+        //       const page = new Page();
+        //       await page.connectedCallback();
+        //       // const { html } = await renderToString(new URL(request.url), false);
+
+        //       initHtml = initHtml.replace(\/\<content-outlet>(.*)<\\/content-outlet>\/s, page.innerHTML);
+        //     }
+
+        //     return new Response(initHtml);
+        //   }
+        // `);
+
         await fs.writeFile(outputUrl, `
-          // import { renderToString } from 'wc-compiler';
-          import 'wc-compiler/src/dom-shim.js';
-          import Page from './_${filename}';
+          import { renderToString } from 'wc-compiler';
 
           export async function handler(request) {
-            console.log('${JSON.stringify(page)}');          
+            console.log('${JSON.stringify(page)}');
+            console.log({ request });      
 
             let initBody = ${body};
             let initHtml = \`${html}\`;
 
             if (!initBody) {
-              const page = new Page();
-              await page.connectedCallback();
-              // const { html } = await renderToString(new URL(request.url), false);
+              console.log('serve', new URL(\`./${filename}\`, import.meta.url));
+              const { html } = await renderToString(new URL(\`./_${filename}\`, import.meta.url), false);
 
-              initHtml = initHtml.replace(\/\<content-outlet>(.*)<\\/content-outlet>\/s, page.innerHTML);
+              initHtml = initHtml.replace(\/\<content-outlet>(.*)<\\/content-outlet>\/s, html);
             }
 
             return new Response(initHtml);

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -116,13 +116,13 @@ const generateGraph = async (compilation) => {
               }
               /* ---------End Menu Query-------------------- */
             } else if (isDynamic) {
-              const routeWorkerUrl = compilation.config.plugins.filter(plugin => plugin.type === 'renderer')[0].provider(compilation).workerUrl;
+              const routeWorkerUrl = compilation.config.plugins.filter(plugin => plugin.type === 'renderer')[0].provider(compilation).executeRouteModuleUrl;
               let ssrFrontmatter;
 
               filePath = route;
 
               await new Promise((resolve, reject) => {
-                const worker = new Worker(routeWorkerUrl);
+                const worker = new Worker(new URL('../lib/ssr-route-worker.js', import.meta.url));
 
                 worker.on('message', async (result) => {
                   if (result.frontmatter) {
@@ -139,6 +139,7 @@ const generateGraph = async (compilation) => {
                 });
 
                 worker.postMessage({
+                  executeRouteModuleUrl: routeWorkerUrl.href,
                   moduleUrl: filenameUrl.href,
                   compilation: JSON.stringify(compilation),
                   route

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -116,7 +116,7 @@ const generateGraph = async (compilation) => {
               }
               /* ---------End Menu Query-------------------- */
             } else if (isDynamic) {
-              const routeWorkerUrl = compilation.config.plugins.filter(plugin => plugin.type === 'renderer')[0].provider(compilation).executeRouteModuleUrl;
+              const routeWorkerUrl = compilation.config.plugins.filter(plugin => plugin.type === 'renderer')[0].provider(compilation).executeModuleUrl;
               let ssrFrontmatter;
 
               filePath = route;
@@ -139,10 +139,19 @@ const generateGraph = async (compilation) => {
                 });
 
                 worker.postMessage({
-                  executeRouteModuleUrl: routeWorkerUrl.href,
+                  executeModuleUrl: routeWorkerUrl.href,
                   moduleUrl: filenameUrl.href,
                   compilation: JSON.stringify(compilation),
-                  route
+                  // TODO need to get as many of these params as possible
+                  // or ignore completely?
+                  page: JSON.stringify({
+                    route,
+                    id,
+                    label: id.split('-')
+                      .map((idPart) => {
+                        return `${idPart.charAt(0).toUpperCase()}${idPart.substring(1)}`;
+                      }).join(' ')
+                  })
                 });
               });
 

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -55,7 +55,6 @@ async function preRenderCompilationWorker(compilation, workerPrerender) {
 
   console.info('pages to generate', `\n ${pages.map(page => page.route).join('\n ')}`);
 
-  console.log({ workerPrerender });
   const pool = new WorkerPool(os.cpus().length, new URL('../lib/ssr-route-worker.js', import.meta.url));
 
   for (const page of pages) {

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -55,7 +55,8 @@ async function preRenderCompilationWorker(compilation, workerPrerender) {
 
   console.info('pages to generate', `\n ${pages.map(page => page.route).join('\n ')}`);
 
-  const pool = new WorkerPool(os.cpus().length, workerPrerender.workerUrl);
+  console.log({ workerPrerender });
+  const pool = new WorkerPool(os.cpus().length, new URL('../lib/ssr-route-worker.js', import.meta.url));
 
   for (const page of pages) {
     const { route, outputPath, resources } = page;
@@ -76,9 +77,10 @@ async function preRenderCompilationWorker(compilation, workerPrerender) {
 
     body = await new Promise((resolve, reject) => {
       pool.runTask({
+        executeModuleUrl: workerPrerender.executeModuleUrl.href,
         modulePath: null,
         compilation: JSON.stringify(compilation),
-        route,
+        page: JSON.stringify(page),
         prerender: true,
         htmlContents: body,
         scripts: JSON.stringify(scripts)

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -300,7 +300,7 @@ async function getHybridServer(compilation) {
       });
 
       if (!config.prerender && matchingRoute.isSSR && !matchingRoute.data.static) {
-        const { handler } = await import(new URL(`./${matchingRoute.filename}`, outputDir));
+        const { handler } = await import(new URL(`./__${matchingRoute.filename}`, outputDir));
         // TODO passing compilation this way too hacky?
         // https://github.com/ProjectEvergreen/greenwood/issues/1008
         const response = await handler(request, compilation);

--- a/packages/cli/src/plugins/renderer/plugin-renderer-default.js
+++ b/packages/cli/src/plugins/renderer/plugin-renderer-default.js
@@ -3,7 +3,7 @@ const greenwoodPluginRendererDefault = {
   name: 'plugin-renderer-default',
   provider: () => {
     return {
-      executeRouteModuleUrl: new URL('../../lib/execute-route-module.js', import.meta.url)
+      executeModuleUrl: new URL('../../lib/execute-route-module.js', import.meta.url)
     };
   }
 };

--- a/packages/cli/src/plugins/renderer/plugin-renderer-default.js
+++ b/packages/cli/src/plugins/renderer/plugin-renderer-default.js
@@ -3,7 +3,7 @@ const greenwoodPluginRendererDefault = {
   name: 'plugin-renderer-default',
   provider: () => {
     return {
-      workerUrl: new URL('../../lib/ssr-route-worker.js', import.meta.url)
+      executeRouteModuleUrl: new URL('../../lib/execute-route-module.js', import.meta.url)
     };
   }
 };

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -213,7 +213,6 @@ class StandardHtmlResource extends ResourceInterface {
   }
 
   async shouldOptimize(url, response) {
-    // TOOD should be .indexOf(this.contentType) === 0
     return response.headers.get('Content-Type').indexOf(this.contentType) >= 0;
   }
 

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -105,7 +105,7 @@ class StandardHtmlResource extends ResourceInterface {
 
     if (matchingRoute.isSSR) {
       const routeModuleLocationUrl = new URL(`./${matchingRoute.filename}`, pagesDir);
-      const routeWorkerUrl = this.compilation.config.plugins.find(plugin => plugin.type === 'renderer').provider().executeRouteModuleUrl;
+      const routeWorkerUrl = this.compilation.config.plugins.find(plugin => plugin.type === 'renderer').provider().executeModuleUrl;
 
       await new Promise((resolve, reject) => {
         const worker = new Worker(new URL('../../lib/ssr-route-worker.js', import.meta.url));
@@ -143,10 +143,10 @@ class StandardHtmlResource extends ResourceInterface {
         });
 
         worker.postMessage({
-          executeRouteModuleUrl: routeWorkerUrl.href,
+          executeModuleUrl: routeWorkerUrl.href,
           moduleUrl: routeModuleLocationUrl.href,
           compilation: JSON.stringify(this.compilation),
-          route: matchingRoute.path
+          page: JSON.stringify(matchingRoute)
         });
       });
     }

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -105,10 +105,10 @@ class StandardHtmlResource extends ResourceInterface {
 
     if (matchingRoute.isSSR) {
       const routeModuleLocationUrl = new URL(`./${matchingRoute.filename}`, pagesDir);
-      const routeWorkerUrl = this.compilation.config.plugins.find(plugin => plugin.type === 'renderer').provider().workerUrl;
+      const routeWorkerUrl = this.compilation.config.plugins.find(plugin => plugin.type === 'renderer').provider().executeRouteModuleUrl;
 
       await new Promise((resolve, reject) => {
-        const worker = new Worker(routeWorkerUrl);
+        const worker = new Worker(new URL('../../lib/ssr-route-worker.js', import.meta.url));
 
         worker.on('message', (result) => {
           if (result.template) {
@@ -143,6 +143,7 @@ class StandardHtmlResource extends ResourceInterface {
         });
 
         worker.postMessage({
+          executeRouteModuleUrl: routeWorkerUrl.href,
           moduleUrl: routeModuleLocationUrl.href,
           compilation: JSON.stringify(this.compilation),
           route: matchingRoute.path
@@ -212,6 +213,7 @@ class StandardHtmlResource extends ResourceInterface {
   }
 
   async shouldOptimize(url, response) {
+    // TOOD should be .indexOf(this.contentType) === 0
     return response.headers.get('Content-Type').indexOf(this.contentType) >= 0;
   }
 

--- a/packages/cli/test/cases/build.default.ssr-static-export/src/pages/artists.js
+++ b/packages/cli/test/cases/build.default.ssr-static-export/src/pages/artists.js
@@ -1,4 +1,4 @@
-async function getTemplate(compilation, route) {
+async function getTemplate(compilation, { route }) {
   return `
     <html>
       <head>

--- a/packages/cli/test/cases/develop.ssr/src/pages/artists.js
+++ b/packages/cli/test/cases/develop.ssr/src/pages/artists.js
@@ -1,4 +1,4 @@
-async function getTemplate(compilation, route) {
+async function getTemplate(compilation, { route }) {
   return `
     <html>
       <head>
@@ -67,7 +67,7 @@ async function getBody(compilation) {
   `;
 }
 
-async function getFrontmatter(compilation, route) {
+async function getFrontmatter(compilation, { route }) {
   return {
     menu: 'navigation',
     index: 7,

--- a/packages/cli/test/cases/serve.config.static-router/serve.config.static-router.spec.js
+++ b/packages/cli/test/cases/serve.config.static-router/serve.config.static-router.spec.js
@@ -52,7 +52,7 @@ describe('Serve Greenwood With: ', function() {
       'hashing-utils',
       'node-modules-utils',
       'resource-utils',
-      'templating-utils'
+      'execute-route-module'
     ];
 
     before(async function() {
@@ -61,19 +61,19 @@ describe('Serve Greenwood With: ', function() {
         `${outputPath}/node_modules/@greenwood/cli/src/lib`
       );
       /*
-       * there is an odd issue seemingly due to needed lib/router.js tha causes tests to think files are CommonJS
+       * there is an odd issue seemingly due to needing lib/router.js that causes tests to think files are CommonJS
        * ```
        * file:///Users/owenbuckley/Workspace/project-evergreen/repos/greenwood/packages/cli/test/cases/serve.config.static-router/public/artists.js:3
-       * import { getAppTemplate, getPageTemplate, getUserScripts } from '@greenwood/cli/src/lib/templating-utils.js';
+       * import { executeRouteModule } from '@greenwood/cli/src/lib/execute-route-module.js';
        *         ^^^^^^^^^^^^^^
-       * SyntaxError: Named export 'getAppTemplate' not found. The requested module '@greenwood/cli/src/lib/templating-utils.js'
+       * SyntaxError: Named export 'executeRouteModule' not found. The requested module '@greenwood/cli/src/lib/templating-utils.js'
        * is a CommonJS module, which may not support all module.exports as named exports.
        * CommonJS modules can always be imported via the default export, for example using:
-       * import pkg from '@greenwood/cli/src/lib/templating-utils.js';
-       * const { getAppTemplate, getPageTemplate, getUserScripts } = pkg;
+       * import pkg from '@greenwood/cli/src/lib/execute-route-module.js';
+       * const { executeRouteModule } = pkg;
        * ```
        *
-       * however no other tests have this issue.  so as terrible hack we need to
+       * however no other tests have this issue.  so as a terrible hack we need to
        * - copy all lib files
        * - rename them to end in .mjs
        * - update references to these files in other imports

--- a/packages/cli/test/cases/serve.default.ssr-static-export/src/pages/artists.js
+++ b/packages/cli/test/cases/serve.default.ssr-static-export/src/pages/artists.js
@@ -1,4 +1,4 @@
-async function getTemplate(compilation, route) {
+async function getTemplate(compilation, { route }) {
   return `
     <html>
       <head>

--- a/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
@@ -139,12 +139,6 @@ describe('Serve Greenwood With: ', function() {
 
         expect(scriptFiles.length).to.equal(2);
       });
-
-      it('should have the expected _templates/ output directory for the app', async function() {
-        const templateFiles = await glob.promise(path.join(this.context.publicDir, '_templates/*'));
-
-        expect(templateFiles.length).to.equal(1);
-      });
     });
 
     describe('Serve command with HTML route response for artists page using "get" functions', function() {

--- a/packages/cli/test/cases/serve.default.ssr/src/pages/artists.js
+++ b/packages/cli/test/cases/serve.default.ssr/src/pages/artists.js
@@ -1,4 +1,4 @@
-async function getTemplate(compilation, route) {
+async function getTemplate(compilation, { route }) {
   return `
     <html>
       <head>
@@ -68,7 +68,7 @@ async function getBody(compilation) {
   `;
 }
 
-async function getFrontmatter(compilation, route) {
+async function getFrontmatter(compilation, { route }) {
   return {
     menu: 'navigation',
     title: route,

--- a/packages/plugin-renderer-lit/src/index.js
+++ b/packages/plugin-renderer-lit/src/index.js
@@ -4,7 +4,7 @@ const greenwoodPluginRendererLit = (options = {}) => {
     name: 'plugin-renderer-lit',
     provider: () => {
       return {
-        workerUrl: new URL('./ssr-route-worker-lit.js', import.meta.url),
+        executeModuleUrl: new URL('./execute-route-module.js', import.meta.url),
         prerender: options.prerender
       };
     }

--- a/packages/plugin-renderer-lit/test/cases/serve.default/serve.default.spec.js
+++ b/packages/plugin-renderer-lit/test/cases/serve.default/serve.default.spec.js
@@ -203,10 +203,13 @@ describe('Serve Greenwood With: ', function() {
         expect(styles.length).to.equal(1);
       });
 
-      it('should have no <script> tags in the <head>', function() {
+      // TODO this should be managed via a plugin, not in core
+      // https://github.com/ProjectEvergreen/greenwood/issues/728
+      it('should have one <script> tag in the <head> for lit polyfills', function() {
         const scripts = dom.window.document.querySelectorAll('head > script');
 
-        expect(scripts.length).to.equal(0);
+        expect(scripts.length).to.equal(1);
+        expect(scripts[0].getAttribute('src').startsWith('/polyfill-support')).to.equal(true);
       });
 
       it('should have the expected number of <tr> tags of content', function() {

--- a/packages/plugin-renderer-lit/test/cases/serve.default/src/pages/artists.js
+++ b/packages/plugin-renderer-lit/test/cases/serve.default/src/pages/artists.js
@@ -3,7 +3,7 @@ import { html } from 'lit';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 import '../components/greeting.js';
 
-async function getTemplate(compilation, route) {
+async function getTemplate(compilation, { route }) {
   return html`
     <html>
       <head>
@@ -65,7 +65,7 @@ async function getBody() {
   `;
 }
 
-async function getFrontmatter(compilation, route) {
+async function getFrontmatter(compilation, { route }) {
   return {
     menu: 'navigation',
     index: 7,

--- a/www/pages/plugins/renderer.md
+++ b/www/pages/plugins/renderer.md
@@ -7,11 +7,11 @@ index: 4
 
 ## Renderer
 
-Renderer plugins allow users to customize how Greenwood server renders (and prerenders) your project.  By default, Greenwood just supports using [(template) strings](/docs/server-rendering/) to return static HTML for the content and template of your server side routes.  For example, using [Lit SSR](https://github.com/lit/lit/tree/main/packages/labs/ssr) to render Lit Web Components server side.
+Renderer plugins allow users to customize how Greenwood server renders (and prerenders) your project.  By default, Greenwood supports using [**WCC** or (template) strings](/docs/server-rendering/) to return static HTML for the content and template of your server side routes.  With this plugin for example, you can use [Lit's SSR](https://github.com/lit/lit/tree/main/packages/labs/ssr) to render your Lit Web Components server side instead.
 
 ### API
 
-Given that rendering Web Components on the server side often involves implementations needing to patch the NodeJS globals space or more complex needs like running an entire headless browser, Greenwood provides a couple ways to manage the rendering lifecycle.
+This plugin expects to be given a path to a module that exports a function to execute the SSR content of a page by being given its HTML and related scripts.  For local development Greenwood will run this in a `Worker` thread for live reloading, and use it standalone for production bundling and serving.
 
 ```js
 const greenwoodPluginMyCustomRenderer = (options = {}) => {
@@ -20,7 +20,7 @@ const greenwoodPluginMyCustomRenderer = (options = {}) => {
     name: 'plugin-renderer-custom',
     provider: () => {
       return {
-        workerUrl: new URL('./my-ssr-route-worker.js', import.meta.url),
+        executeModuleUrl: new URL('./execute-route-module.js', import.meta.url),
         prerender: options.prerender
       };
     }
@@ -33,19 +33,18 @@ export {
 ```
 
 #### Options
-- `workerUrl` (recommended) - URL to the location of a file with a worker thread implementation to use for rendering.
-- `customUrl` - URL to a file that has a `default export` of a function for handling the _prerendering_ lifecyle of a Greenwood build, and running the provided `callback` function
+- `executeModuleUrl` (recommended) - `URL` to the location of a file with the SSR rendering implementation
+- `customUrl` - `URL` to a file that has a `default export` of a function for handling the _prerendering_ lifecyle of a Greenwood build, and running the provided `callback` function
 - `prerender` (optional) - Flag can be used to indicate if this custom renderer should be used to statically [prerender](/docs/configuration/#prerender) pages too.
 
 ## Examples
 
-### Workers
+### Default
 
-The recommended Greenwood API for executing server rendered code is in a [Worker](https://nodejs.org/api/worker_threads.html) thread, to avoid global namespace and API collisions.
-Each worker is expected to implement [the API](/docs/server-rendering/#api) of `default export`, `getBody`, `getTemplate`, and `getFrontmatter`.
+The recommended Greenwood API for executing server rendered code is in a function that is expected to implement any combination of [these APIs](/docs/server-rendering/#api); `default export`, `getBody`, `getTemplate`, and `getFrontmatter`.
 
-You can follow the [WCC default implementation for Greenwood](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/cli/src/lib/ssr-route-worker.js) as a reference.
+You can follow the [WCC default implementation for Greenwood](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/cli/src/lib/execute-route-module.js) as a reference.
 
 ### Custom Implementation
 
-This option is useful for exerting full control over the rendering lifecycle.  You can follow [Greenwood's implementation for Puppeteer](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/plugin-renderer-puppeteer/src/puppeteer-handler.js) as a reference.
+This option is useful for exerting full control over the rendering lifecycle, like running a headless browser.  You can follow [Greenwood's implementation for Puppeteer](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/plugin-renderer-puppeteer/src/puppeteer-handler.js) as a reference.


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1088 

## Summary of Changes
1. Refactor Workers out of serving SSR pages
1. Pre-compile static HTML templates as local variables at build time
1. Refactor renderer plugin to just be a function (not tied to Workers implementation)

References
- https://github.com/ProjectEvergreen/greenwood-demo-adapter-vercel/pull/1
- https://github.com/ProjectEvergreen/greenwood-demo-adapter-netlify/pull/3

## TODO
1. [x] confirm static templating works, e.g. _src/templates/_
1. [x] Will still need the concept of an `executeModule` for custom implementations like Lit (do we have to handle a renderer _and_ an adapter plugin at the same time?) and for development
1. [x] get `executeRouteModule` from config
1. [x] simplify `executeModule` signature (pass in entire `page`)
1. [x] Update static router serve spec per new implementation
1. [x] refactor lit renderer and get all specs passing
1. [x] Is it OK to reference `executeModuleUrl` in our wrapper bundles?  Can we bundle down into one file instead?
1. [x] Likely we don't need to output _templates/_ dir anymore?
1. [x] What about `os` / thread pooling for prerendering? - deferred to https://github.com/ProjectEvergreen/greenwood/issues/970 and #1117 
1. [x] Docs
    - prerender plugin
    - getTemplate is a "static" function - deprecating anyways?
    - make a discussion for how best encapsulate SSR?
1. [x] Test in adapter demo repos
1. [x] Test in Benchmarking repo - deferred to https://github.com/ProjectEvergreen/greenwood/issues/970
1. [x] Clean up TODOs / console logs

## Questions
1. [x] `getTemplate` has to be a "static" function (for now) but maybe we will deprecating anyways as part of #955 ? - deferred to https://github.com/ProjectEvergreen/greenwood/issues/1008
1. [x] Create a discussion to evaluate alternatives to Workers, or making it opt-in?  Or maybe I'm just over thinking it?  Would be good to cross reference as part of #1008 - https://github.com/ProjectEvergreen/greenwood/discussions/1117
1. [x] Can we ever "bundle down" to a single file executable for SSR pages? - https://github.com/ProjectEvergreen/greenwood/issues/1118
1. [x] How to handle something like Netlify which needs custom handling for `import.meta.url`? - deferred to - https://github.com/ProjectEvergreen/greenwood/issues/1008#issuecomment-1606287535
    ```js
    await fs.writeFile(outputUrl, `
      import 'wc-compiler/src/dom-shim.js';
      import Page from './_${filename}';
    
      export async function handler(request) {
        console.log('${JSON.stringify(page)}');          
    
        let initBody = ${body};
        let initHtml = \`${html}\`;
    
        if (!initBody) {
          const page = new Page();
          await page.connectedCallback();
    
          initHtml = initHtml.replace(\/\<content-outlet>(.*)<\\/content-outlet>\/s, page.innerHTML);
        }
    
        return new Response(initHtml);
      }
    `);
    ```