### PR TITLE
clarify usage of `new URL` with directories in docs

### DIFF
--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -28,7 +28,7 @@ export default {
   staticRouter: false,
   optimization: 'default',
   plugins: [],
-  workspace: 'src', // assumes process.cwd()
+  workspace: new URL('./src/', import.meta.url),
   pagesDirectory: 'pages', // e.g. src/pages
   templatesDirectory: 'templates' // e.g. src/templates
 };
@@ -221,6 +221,8 @@ Setting the workspace path to be the _www/_ folder in the current directory from
 
 ```js
 export default {
-  workspace: new URL('./www', import.meta.url)
+  workspace: new URL('./www/', import.meta.url)
 };
 ```
+
+> Please note the trailing `/` here as for ESM, a path must end in a `/` for directories.

--- a/www/pages/guides/theme-packs.md
+++ b/www/pages/guides/theme-packs.md
@@ -63,7 +63,7 @@ const myThemePack = () => [{
       templates: [
         // import.meta.url will be located at _node_modules/your-package/_
         // when your plugin is run in a user's project
-        new URL('./dist/layouts', import.meta.url)
+        new URL('./dist/layouts/', import.meta.url)
       ]
     };
   }
@@ -129,7 +129,7 @@ const myThemePackPlugin = (options = {}) => [{
     // you can use other directory names besides templates/ this way!
     const templateLocation = options.__isDevelopment
       ? new URL('./layouts/', compilation.context.userWorkspace)
-      : new URL('dist/layouts', import.meta.url);
+      : new URL('dist/layouts/', import.meta.url);
 
     return {
       templates: [


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A (feedback from weekly meeting)

## Summary of Changes
1. Make sure all usages of `new URL` for directories end in a `/`
1. Update default configuration example to reference `new URL` usage (instead of `process.cwd()`)