### PR TITLE
remove import maps shim from development workflow

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -14,7 +14,7 @@ export default {
   interpolateFrontmatter: true,
   plugins: [
     greenwoodPluginGraphQL(),
-    greenwoodPluginPolyfills(),
+    // greenwoodPluginPolyfills(),
     greenwoodPluginPostCss(),
     greenwoodPluginImportJson(),
     greenwoodPluginImportCss(),

--- a/packages/cli/src/lib/walker-package-ranger.js
+++ b/packages/cli/src/lib/walker-package-ranger.js
@@ -216,7 +216,7 @@ async function walkPackageJson(packageJson = {}) {
 }
 
 function mergeImportMap(html = '', map = {}) {
-  // es-modules-shims breaks on dangling commas in an importMap :/
+  // just like with JSON, importmaps break on dangling commas
   const danglingComma = html.indexOf('"imports": {}') > 0 ? '' : ',';
   const importMap = JSON.stringify(map).replace('}', '').replace('{', '');
 

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -110,9 +110,9 @@ async function preRenderCompilationCustom(compilation, customPrerender) {
 
     // clean up special Greenwood dev only assets that would come through if prerendering with a headless browser
     body = body.replace(/<script src="(.*lit\/polyfill-support.js)"><\/script>/, '');
-    body = body.replace(/<script type="importmap-shim">.*?<\/script>/s, '');
-    body = body.replace(/<script defer="" src="(.*es-module-shims.js)"><\/script>/, '');
-    body = body.replace(/type="module-shim"/g, 'type="module"');
+    // body = body.replace(/<script type="importmap-shim">.*?<\/script>/s, '');
+    // body = body.replace(/<script defer="" src="(.*es-module-shims.js)"><\/script>/, '');
+    // body = body.replace(/type="module-shim"/g, 'type="module"');
 
     // clean this up here to avoid sending webcomponents-bundle to rollup
     body = body.replace(/<script src="(.*webcomponents-bundle.js)"><\/script>/, '');

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -72,13 +72,6 @@ class NodeModulesResource extends ResourceInterface {
   async intercept(url, request, response) {
     const { context } = this.compilation;
     let body = await response.text();
-    const hasHead = body.match(/\<head>(.*)<\/head>/s);
-
-    if (hasHead && hasHead.length > 0) {
-      const contents = hasHead[0].replace(/type="module"/g, 'type="module-shim"');
-
-      body = body.replace(/\<head>(.*)<\/head>/s, contents.replace(/\$/g, '$$$')); // https://github.com/ProjectEvergreen/greenwood/issues/656);
-    }
 
     const userPackageJson = await getPackageJson(context);
     
@@ -94,8 +87,7 @@ class NodeModulesResource extends ResourceInterface {
     // apply import map and shim for users
     body = body.replace('<head>', `
       <head>
-        <script defer src="/node_modules/es-module-shims/dist/es-module-shims.js"></script>
-        <script type="importmap-shim">
+        <script type="importmap">
           {
             "imports": ${JSON.stringify(importMap, null, 1)}
           }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1114 

## Summary of Changes
1. Remove import maps shims and attributes from development

Tested against the following browsers

|Chrome|Firefox|Safari `15.x`|Safari `16.x` (16.1) | Safari TP|
|--------|-------|------------|------------|--------- |
|     ✅    |     ✅   |      🚫       |     🚫           |      ✅       |    

  
## TODO
1. [x] Safari Browser Testing
1. [ ] Confirm we're not missing anything important - https://github.com/tc39/proposal-import-attributes/issues/135
1. [ ] clean up from Lit SSR hydration implementation - #1201 
1. [ ] test against #923 
1. [ ] Validate test cases
1. [ ] Clean up deps / prerender tests / commented out code
1. [ ] Update docs if applicable  
1. [ ] Move it to be a plugin + upgrade to latest version