### PR TITLE
bug/issue 1126 handle string replace replacement patterns breaking markdown rendering when content has a $1 in it 

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -182,7 +182,8 @@ class StandardHtmlResource extends ResourceInterface {
         });
       }
 
-      body = body.replace(/\<content-outlet>(.*)<\/content-outlet>/s, processedMarkdown.contents);
+      // https://github.com/ProjectEvergreen/greenwood/issues/1126
+      body = body.replace(/\<content-outlet>(.*)<\/content-outlet>/s, processedMarkdown.contents.replace(/\$/g, '$$$'));
     } else if (matchingRoute.external) {
       body = body.replace(/\<content-outlet>(.*)<\/content-outlet>/s, matchingRoute.body);
     } else if (ssrBody) {

--- a/packages/cli/test/cases/build.default.markdown/build.default.markdown.spec.js
+++ b/packages/cli/test/cases/build.default.markdown/build.default.markdown.spec.js
@@ -52,7 +52,15 @@ describe('Build Greenwood With: ', function() {
         dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, 'index.html'));
       });
 
-      it('should correctly rendering an <h3> tag', function() {
+      // https://github.com/ProjectEvergreen/greenwood/issues/1126
+      it('should correctly render an <h2> tag with a $1 in the text content', function() {
+        const heading = dom.window.document.querySelectorAll('body h2');
+
+        expect(heading.length).to.equal(1);
+        expect(heading[0].textContent).to.equal('Posters $10');
+      });
+
+      it('should correctly render an <h3> tag', function() {
         const heading = dom.window.document.querySelectorAll('body h3');
 
         expect(heading.length).to.equal(1);

--- a/packages/cli/test/cases/build.default.markdown/src/pages/index.md
+++ b/packages/cli/test/cases/build.default.markdown/src/pages/index.md
@@ -2,6 +2,8 @@
 title: 'this is a custom markdown title'
 ---
 
+## Posters $10
+
 ### Greenwood Markdown Test
 
 This is some markdown being rendered by Greenwood.


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1126 

## Summary of Changes
1. handle string replace replacement patterns breaking markdown rendering when content has a _$1_ in it 
1. Add test case

----

Should probably at least open a discussion for this to find a better way to handle this, since it happens a lot in the codebase.
- https://github.com/ProjectEvergreen/greenwood/pull/743
- https://github.com/ProjectEvergreen/greenwood/pull/657