### PR TITLE
docs/fix broken link in import JSX plugin README

### DIFF
--- a/packages/plugin-import-jsx/README.md
+++ b/packages/plugin-import-jsx/README.md
@@ -32,7 +32,7 @@ export default {
 }
 ```
 
-This will then allow you to use `import` to include [WCC]() compatible JSX rendering Web Components.
+This will then allow you to use `import` to include [WCC](https://merry-caramel-524e61.netlify.app/docs/#jsx) compatible JSX rendering Web Components.
 ```js
 export default class FooterComponent extends HTMLElement {
   connectedCallback() {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#972 

## Summary of Changes
1. Fix broken link in the README