### PR TITLE
bug/issue 1137 have adapted SSR pages return `text/html` content type

### DIFF
--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -221,7 +221,11 @@ async function bundleSsrPages(compilation) {
               staticHtml = staticHtml.replace(\/\<content-outlet>(.*)<\\/content-outlet>\/s, data.body);
             }
 
-            return new Response(staticHtml);
+            return new Response(staticHtml, {
+              headers: {
+                'Content-Type': 'text/html'
+              }
+            });
           }
         `);
 

--- a/packages/cli/test/cases/build.plugins.adapter/build.config.plugins-adapter.spec.js
+++ b/packages/cli/test/cases/build.plugins.adapter/build.config.plugins-adapter.spec.js
@@ -56,17 +56,20 @@ describe('Build Greenwood With: ', function() {
       await runner.runCommand(cliPath, 'build');
     });
 
-    // test SSR page
     describe('Adapting an SSR Page', function() {
       let dom;
+      let response;
 
       before(async function() {
         const req = new Request(new URL('http://localhost:8080/index'));
         const { handler } = await import(new URL('./adapter-output/index.js', pathToFileURL(outputPath)));
-        const response = await handler(req);
-        const html = await response.text();
 
-        dom = new JSDOM(html);
+        response = await handler(req);
+        dom = new JSDOM(await response.text());
+      });
+
+      it('should have the expected content-type for the response', function() {
+        expect(response.headers.get('content-type')).to.be.equal('text/html');
       });
 
       it('should have the expected number of <app-card> components on the page', function() {
@@ -92,13 +95,18 @@ describe('Build Greenwood With: ', function() {
 
     describe('Adapting an API Route', function() {
       let data;
+      let response;
 
       before(async function() {
         const handler = (await import(new URL('./adapter-output/greeting.js', pathToFileURL(outputPath)))).handler;
         const req = new Request(new URL('http://localhost:8080/api/greeting?name=Greenwood'));
-        const res = await handler(req);
 
-        data = await res.json();
+        response = await handler(req);
+        data = await response.json();
+      });
+
+      it('should have the expected content-type for the response', function() {
+        expect(response.headers.get('content-type')).to.be.equal('application/json');
       });
 
       it('should have the expected message from the API when a query is passed', function() {

--- a/packages/cli/test/cases/build.plugins.adapter/generic-adapter.js
+++ b/packages/cli/test/cases/build.plugins.adapter/generic-adapter.js
@@ -29,8 +29,6 @@ async function genericAdapter(compilation) {
     await fs.mkdir(adapterOutputUrl);
   }
 
-  console.log({ ssrPages, apiRoutes });
-
   for (const page of ssrPages) {
     const { id } = page;
     const outputFormat = generateOutputFormat(id, 'page');


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1137 

## Summary of Changes
1. Make sure SSR pages return a `text/html` content type

## TODO
1. [x] Add test cases