### PR TITLE
bug/issue 1048 handle URL encoded Netlify form params

### DIFF
--- a/packages/plugin-adapter-netlify/src/index.js
+++ b/packages/plugin-adapter-netlify/src/index.js
@@ -18,10 +18,12 @@ function generateOutputFormat(id) {
       if (['GET', 'HEAD'].includes(httpMethod.toUpperCase())) {
         format = null
       } else if (contentType.includes('application/x-www-form-urlencoded')) {
+        const searchParams = new URLSearchParams(body);
         const formData = new FormData();
 
-        for (const key of Object.keys(body)) {
-          formData.append(key, body[key]);
+        for (const key of searchParams.keys()) {
+          const value = searchParams.get(key);
+          formData.append(key, value);
         }
 
         // when using FormData, let Request set the correct headers

--- a/packages/plugin-adapter-netlify/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-adapter-netlify/test/cases/build.default/build.default.spec.js
@@ -215,7 +215,7 @@ describe('Build Greenwood With: ', function() {
         const { handler } = await import(new URL(`./${name}/${name}.js`, netlifyFunctionsOutputUrl));
         const response = await handler({
           rawUrl: 'http://localhost:8080/api/submit-form-data',
-          body: { name: param },
+          body: `name=${param}`,
           httpMethod: 'POST',
           headers: {
             'content-type': 'application/x-www-form-urlencoded'


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
relates to #1048 

Upon testing https://github.com/ProjectEvergreen/greenwood-demo-adapter-netlify/pull/9, saw that Netlify was providing form data as `key=value` for `body`
![Screen Shot 2023-08-26 at 8 48 21 PM](https://github.com/ProjectEvergreen/greenwood/assets/895923/9600e78a-00f3-421f-9b13-0741ff8976b4)
![Screen Shot 2023-08-26 at 8 48 32 PM](https://github.com/ProjectEvergreen/greenwood/assets/895923/ec6f5d32-76bc-44e7-ae1d-1597c60a526f)

## Summary of Changes
1. Match how Netlify provides `application/x-www-form-urlencoded` params
1. Updated test case accordingly