### PR TITLE
bug/issue 1048 handle shared adapter bundles missing for API routes

### DIFF
--- a/packages/plugin-adapter-netlify/src/index.js
+++ b/packages/plugin-adapter-netlify/src/index.js
@@ -171,6 +171,17 @@ async function netlifyAdapter(compilation) {
       );
     }
 
+    const ssrApiAssets = (await fs.readdir(new URL('./api/', outputDir)))
+      .filter(file => new RegExp(/^[\w][\w-]*\.[a-zA-Z0-9]{4,20}\.[\w]{2,4}$/).test(path.basename(file)));
+
+    for (const asset of ssrApiAssets) {
+      await fs.cp(
+        new URL(`./${asset}`, new URL('./api/', outputDir)),
+        new URL(`./${asset}`, outputRoot),
+        { recursive: true }
+      );
+    }
+
     // NOTE: All functions must live at the top level
     // https://github.com/netlify/netlify-lambda/issues/90#issuecomment-486047201
     await createOutputZip(id, outputType, outputRoot, projectDirectory);

--- a/packages/plugin-adapter-netlify/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-adapter-netlify/test/cases/build.default/build.default.spec.js
@@ -23,7 +23,9 @@
  *   api/
  *     fragment.js
  *     greeting.js
- *     submit.js
+ *     search.js
+ *     submit-form-data.js
+ *     submit-json.js
  *   components/
  *     card.js
  *   pages/
@@ -76,11 +78,11 @@ describe('Build Greenwood With: ', function() {
       });
 
       it('should output the expected number of serverless function zip files', function() {
-        expect(zipFiles.length).to.be.equal(6);
+        expect(zipFiles.length).to.be.equal(7);
       });
 
       it('should output the expected number of serverless function API zip files', function() {
-        expect(zipFiles.filter(file => path.basename(file).startsWith('api-')).length).to.be.equal(4);
+        expect(zipFiles.filter(file => path.basename(file).startsWith('api-')).length).to.be.equal(5);
       });
 
       it('should output the expected number of serverless function SSR page zip files', function() {

--- a/packages/plugin-adapter-netlify/test/cases/build.default/src/api/search.js
+++ b/packages/plugin-adapter-netlify/test/cases/build.default/src/api/search.js
@@ -1,0 +1,41 @@
+import { renderFromHTML } from 'wc-compiler';
+import { getArtists } from '../services/artists.js';
+
+export async function handler(request) {
+  const formData = await request.formData();
+  const term = formData.has('term') ? formData.get('term') : '';
+  const artists = (await getArtists())
+    .filter((artist) => {
+      return term !== '' && artist.name.toLowerCase().includes(term.toLowerCase());
+    });
+  let body = '';
+
+  if (artists.length === 0) {
+    body = 'No results found.';
+  } else {
+    const { html } = await renderFromHTML(`
+      ${
+        artists.map((item, idx) => {
+          const { name, imageUrl } = item;
+
+          return `
+            <app-card
+              title="${idx + 1}) ${name}"
+              thumbnail="${imageUrl}"
+            ></app-card>
+          `;
+        }).join('')
+      }
+    `, [
+      new URL('../components/card.js', import.meta.url)
+    ]);
+
+    body = html;
+  }
+
+  return new Response(body, {
+    headers: new Headers({
+      'Content-Type': 'text/html'
+    })
+  });
+}

--- a/packages/plugin-adapter-vercel/src/index.js
+++ b/packages/plugin-adapter-vercel/src/index.js
@@ -149,6 +149,17 @@ async function vercelAdapter(compilation) {
       new URL('./assets/', outputRoot),
       { recursive: true }
     );
+
+    const ssrApiAssets = (await fs.readdir(new URL('./api/', outputDir)))
+      .filter(file => new RegExp(/^[\w][\w-]*\.[a-zA-Z0-9]{4,20}\.[\w]{2,4}$/).test(path.basename(file)));
+
+    for (const asset of ssrApiAssets) {
+      await fs.cp(
+        new URL(`./${asset}`, new URL('./api/', outputDir)),
+        new URL(`./${asset}`, outputRoot),
+        { recursive: true }
+      );
+    }
   }
 
   // static assets / build

--- a/packages/plugin-adapter-vercel/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.default/build.default.spec.js
@@ -23,7 +23,9 @@
  *   api/
  *     fragment.js
  *     greeting.js
- *     submit.js
+ *     search.js
+ *     submit-form-data.js
+ *     submit-json.js
  *   components/
  *     card.js
  *   pages/
@@ -77,7 +79,7 @@ describe('Build Greenwood With: ', function() {
       });
 
       it('should output the expected number of serverless function output folders', function() {
-        expect(functionFolders.length).to.be.equal(6);
+        expect(functionFolders.length).to.be.equal(7);
       });
 
       it('should output the expected configuration file for the build output', function() {

--- a/packages/plugin-adapter-vercel/test/cases/build.default/src/api/search.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.default/src/api/search.js
@@ -1,0 +1,41 @@
+import { renderFromHTML } from 'wc-compiler';
+import { getArtists } from '../services/artists.js';
+
+export async function handler(request) {
+  const formData = await request.formData();
+  const term = formData.has('term') ? formData.get('term') : '';
+  const artists = (await getArtists())
+    .filter((artist) => {
+      return term !== '' && artist.name.toLowerCase().includes(term.toLowerCase());
+    });
+  let body = '';
+
+  if (artists.length === 0) {
+    body = 'No results found.';
+  } else {
+    const { html } = await renderFromHTML(`
+      ${
+        artists.map((item, idx) => {
+          const { name, imageUrl } = item;
+
+          return `
+            <app-card
+              title="${idx + 1}) ${name}"
+              thumbnail="${imageUrl}"
+            ></app-card>
+          `;
+        }).join('')
+      }
+    `, [
+      new URL('../components/card.js', import.meta.url)
+    ]);
+
+    body = html;
+  }
+
+  return new Response(body, {
+    headers: new Headers({
+      'Content-Type': 'text/html'
+    })
+  });
+}


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #1048 

Observed in downstream demo PRs that when there are modules across API Routes and SSR pages, they were missing in the adapter upload bundles for API routes
- https://github.com/ProjectEvergreen/greenwood-demo-adapter-vercel/pull/14
- https://github.com/ProjectEvergreen/greenwood-demo-adapter-netlify/pull/9
- https://github.com/thescientist13/greenwood-htmx/pull/3

![Screen Shot 2023-08-26 at 8 21 53 PM](https://github.com/ProjectEvergreen/greenwood/assets/895923/3f9b7309-88b9-4b87-b003-0b1231209d10)
![Screen Shot 2023-08-26 at 5 58 34 PM](https://github.com/ProjectEvergreen/greenwood/assets/895923/c1018d0a-009f-4a0c-bf65-3c99ff96ad46)

## Summary of Changes
1. Copy over all bundled assets to API routes serverless bundle output locations
1. Update test cases to cover this use case