### PR TITLE
Bug/issue 1154 inline template strings in SSR page templates break bundling

### DIFF
--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -202,6 +202,7 @@ async function bundleSsrPages(compilation) {
         staticHtml = await getAppTemplate(staticHtml, compilation.context, imports, [], false, title);
         staticHtml = await getUserScripts(staticHtml, compilation.context);
         staticHtml = await (await htmlOptimizer.optimize(new URL(`http://localhost:8080${route}`), new Response(staticHtml))).text();
+        staticHtml = staticHtml.replace(/[`\\$]/g, '\\$&'); // https://stackoverflow.com/a/75688937/417806
 
         // better way to write out this inline code?
         await fs.writeFile(entryFileUrl, `

--- a/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
@@ -180,7 +180,7 @@ describe('Serve Greenwood With: ', function() {
       it('should have the expected number of <script> tags in the <head>', function() {
         const scripts = artistsPageDom.window.document.querySelectorAll('head > script');
 
-        expect(scripts.length).to.equal(3);
+        expect(scripts.length).to.equal(4);
       });
 
       it('should have the expected <app-header> tag from the app template in the <head>', function() {
@@ -194,8 +194,8 @@ describe('Serve Greenwood With: ', function() {
         const scripts = Array.from(artistsPageDom.window.document.querySelectorAll('head > script'))
           .filter(tag => !tag.getAttribute('type'));
 
-        expect(scripts.length).to.equal(1);
-        expect(scripts[0].textContent).to.contain('console.log');
+        expect(scripts.length).to.equal(2);
+        expect(scripts[1].textContent).to.contain('console.log');
       });
 
       it('should have the expected number of table rows of content', function() {
@@ -251,7 +251,7 @@ describe('Serve Greenwood With: ', function() {
       it('should append the expected graph resource scripts for the page from a template', function() {
         const { resources } = artistsPageGraphData;
 
-        expect(resources.length).to.equal(4);
+        expect(resources.length).to.equal(5);
         expect(resources.find(resource => resource.endsWith('/header.js'))).to.not.be.undefined;
       });
 

--- a/packages/cli/test/cases/serve.default.ssr/src/templates/app.html
+++ b/packages/cli/test/cases/serve.default.ssr/src/templates/app.html
@@ -5,6 +5,12 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <script type="module" src="../components/header.js"></script>
+    <script>
+      // https://github.com/ProjectEvergreen/greenwood/issues/1154
+      const message = `The current time is ${new Date().getTime()}`;
+
+      alert(message);
+    </script>
   </head>
   <body>
     <app-header></app-header>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1154 

## Summary of Changes
1. Proper escaping for packing / bundling of template contents in SSR page bundles
1. Added / updates test cases