### PR TITLE
Bug/issue 1159 devServer proxy routing broken with content encoding header

### DIFF
--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -200,6 +200,8 @@ async function getStaticServer(compilation, composable) {
     await next();
   });
 
+  // TODO devServer.proxy is not really just for dev
+  // should it be renamed?  should this be a middleware?
   app.use(async (ctx, next) => {
     try {
       const url = new URL(`http://localhost:${port}${ctx.url}`);

--- a/packages/cli/src/plugins/resource/plugin-dev-proxy.js
+++ b/packages/cli/src/plugins/resource/plugin-dev-proxy.js
@@ -31,8 +31,18 @@ class DevProxyResource extends ResourceInterface {
       method: request.method,
       headers: request.header
     });
+    const response = await fetch(requestProxied);
+    const filteredResponseHeaders = new Headers();
 
-    return await fetch(requestProxied);
+    // filter out content-encoding to make sure browsers do not try and decode responses
+    // https://github.com/ProjectEvergreen/greenwood/issues/1159
+    response.headers.forEach((value, key) => {
+      if (key !== 'content-encoding') {
+        filteredResponseHeaders.set(key, value);
+      }
+    });
+
+    return new Response(response.body, { headers: filteredResponseHeaders });
   }
 }
 

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -1321,6 +1321,12 @@ describe('Develop Greenwood With: ', function() {
         done();
       });
 
+      // https://github.com/ProjectEvergreen/greenwood/issues/1159
+      it('should not return a content-encoding header', function(done) {
+        expect(response.headers['content-encoding']).to.equal(undefined);
+        done();
+      });
+
       it('should return the correct response body', function(done) {
         expect(response.body).to.have.lengthOf(1);
         done();


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1159 

## Summary of Changes
1. Filter out `content-encoding` fgrom dev server proxy requests

## TODO
1. [ ] Would be nice to narrow down the regression (my guess is in #1048 ?)
1. [x] Would be nice to get a test case to reproduce this 

> _Somewhat related, but should we rename it to just `devServer`?  Now that we're full stack, does it even matter?_ 🤔 