### PR TITLE
bug/issue 1161 gracefully handle bare specifiers when resolve custom loader URLs

### DIFF
--- a/packages/cli/src/loader.js
+++ b/packages/cli/src/loader.js
@@ -48,14 +48,19 @@ export async function resolve(specifier, context, defaultResolve) {
   const { parentURL } = context;
   const url = specifier.startsWith('file://')
     ? new URL(specifier)
-    : new URL(specifier, parentURL);
-  const { shouldHandle } = await getCustomLoaderResponse(url, null, true);
+    : specifier.startsWith('.')
+      ? new URL(specifier, parentURL)
+      : undefined;
 
-  if (shouldHandle) {
-    return {
-      url: url.href,
-      shortCircuit: true
-    };
+  if (url) {
+    const { shouldHandle } = await getCustomLoaderResponse(url, null, true);
+
+    if (shouldHandle) {
+      return {
+        url: url.href,
+        shortCircuit: true
+      };
+    }
   }
 
   return defaultResolve(specifier, context, defaultResolve);


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1161 

## Summary of Changes
1. Gracefully handle bare specifiers when resolving URLs in custom loader resolve hook