### PR TITLE
bug/check for api assets build output directory before copying for vercel adapter

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -287,7 +287,7 @@ function greenwoodPatchSsrPagesEntryPointRuntimeImport() {
 
             bundle[key].code = bundle[key].code.replace(/'___GWD_ENTRY_FILE_URL=(.*.)___'/, `new URL('./_${entryPathMatch}', import.meta.url)`);
           } else {
-            console.warn(`Could not find entry path match for bundle => ${ley}`);
+            console.warn(`Could not find entry path match for bundle => ${key}`);
           }
         }
       });

--- a/packages/plugin-adapter-vercel/src/index.js
+++ b/packages/plugin-adapter-vercel/src/index.js
@@ -144,11 +144,14 @@ async function vercelAdapter(compilation) {
       new URL(`./${id}.js`, outputRoot),
       { recursive: true }
     );
-    await fs.cp(
-      new URL('./api/assets/', outputDir),
-      new URL('./assets/', outputRoot),
-      { recursive: true }
-    );
+
+    if (await checkResourceExists(new URL('./api/assets/', outputDir))) {
+      await fs.cp(
+        new URL('./api/assets/', outputDir),
+        new URL('./assets/', outputRoot),
+        { recursive: true }
+      );
+    }
 
     const ssrApiAssets = (await fs.readdir(new URL('./api/', outputDir)))
       .filter(file => new RegExp(/^[\w][\w-]*\.[a-zA-Z0-9]{4,20}\.[\w]{2,4}$/).test(path.basename(file)));


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
Observed in https://github.com/thescientist13/greenwood-demo-adapter-vercel-lit/pull/7 that we need to check for _public/api/assets_ directory _before_ trying to copy, otherwise an error will occur
```sh
[Error: ENOENT: no such file or directory, lstat '/Users/owenbuckley/Workspace/github/greenwood-demo-adapter-vercel-lit/public/api/assets/'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'lstat',
  path: '/Users/owenbuckley/Workspace/github/greenwood-demo-adapter-vercel-lit/public/api/assets/'
}
```

This is being done in the [Netlify adapter](https://github.com/ProjectEvergreen/greenwood/blob/release/0.29.0/packages/plugin-adapter-netlify/src/index.js#L168( so seems like it was just something I missed for the Vercel one.

## Summary of Changes
1. Check for _public/api/assets_ directory before trying to copy bundles
1. Fix a variable typo in a `console.warn` in _rollup.config.js_