### PR TITLE
Docs/issue 1004 document latest status for non standard import formats

### DIFF
--- a/packages/plugin-import-css/test/cases/exp-build.prerender/exp-build.prerender.spec.js
+++ b/packages/plugin-import-css/test/cases/exp-build.prerender/exp-build.prerender.spec.js
@@ -12,6 +12,7 @@
  * import { greenwoodPluginImportCss } from '@greenwood/plugin-import-css';
  *
  * {
+ *   prerender: true,
  *   plugins: [{
  *     greenwoodPluginImportCss()
  *   }]

--- a/packages/plugin-import-json/test/cases/exp-build.prerender/exp-build.prerender.spec.js
+++ b/packages/plugin-import-json/test/cases/exp-build.prerender/exp-build.prerender.spec.js
@@ -12,6 +12,7 @@
  * import { greenwoodPluginImportJson } from '@greenwood/plugin-import-json';
  *
  * {
+ *   prerender: true,
  *   plugins: [{
  *     greenwoodPluginImportJson()
  *   }]

--- a/packages/plugin-import-jsx/test/cases/exp-build.prerender/exp-build.prerender.spec.js
+++ b/packages/plugin-import-jsx/test/cases/exp-build.prerender/exp-build.prerender.spec.js
@@ -12,6 +12,7 @@
  * import { greenwoodPluginImportJsx } from '@greenwood/plugin-import-jsx';
  *
  * {
+ *   prerender: true,
  *   plugins: [{
  *     greenwoodPluginImportJsx()
  *   }]

--- a/packages/plugin-typescript/test/cases/exp-prerender.serve.ssr/exp-prerender.serve.ssr.spec.js
+++ b/packages/plugin-typescript/test/cases/exp-prerender.serve.ssr/exp-prerender.serve.ssr.spec.js
@@ -1,6 +1,6 @@
 /*
  * Use Case
- * Run Greenwood with an API and SSR routes that import TypeScript.
+ * Run Greenwood with a prerender HTML page that imports TypeScript.
  *
  * User Result
  * Should generate a Greenwood build that correctly builds and bundles all assets.

--- a/packages/plugin-typescript/test/cases/exp-prerender.serve.ssr/exp-prerender.serve.ssr.spec.js
+++ b/packages/plugin-typescript/test/cases/exp-prerender.serve.ssr/exp-prerender.serve.ssr.spec.js
@@ -10,6 +10,7 @@
  *
  * User Config
  * {
+ *   prerender: true,
  *   plugins: [
  *      greenwoodPluginTypeScript()
  *   ]
@@ -17,10 +18,10 @@
  *
  * User Workspace
  *  src/
- *   api/
- *     fragment.js
  *   components/
  *     card.ts
+ *   pages/
+ *     index.html
  */
 import chai from 'chai';
 import { JSDOM } from 'jsdom';
@@ -32,8 +33,10 @@ import { fileURLToPath } from 'url';
 
 const expect = chai.expect;
 
-describe('Serve Greenwood With: ', function() {
-  const LABEL = 'A Server Rendered Application (SSR) with API Routes importing TypeScript';
+// TODO - this should work after this issue is resolved
+// https://github.com/ProjectEvergreen/wcc/issues/122
+xdescribe('Serve Greenwood With: ', function() {
+  const LABEL = 'A Prerendered Application (SSR) with an HTML page importing a TypeScript component';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
   const hostname = 'http://127.0.0.1:8080';
@@ -62,13 +65,12 @@ describe('Serve Greenwood With: ', function() {
       });
     });
 
-    describe('Serve command with API specific behaviors for an HTML ("fragment") API', function() {
+    describe('Serve command with SSR prerender specific behaviors for an HTML page', function() {
       let response = {};
-      let fragmentsApiDom;
 
       before(async function() {
         return new Promise((resolve, reject) => {
-          request.get(`${hostname}/api/fragment`, (err, res, body) => {
+          request.get(`${hostname}/`, (err, res, body) => {
             if (err) {
               reject();
             }
@@ -92,20 +94,8 @@ describe('Serve Greenwood With: ', function() {
         done();
       });
 
-      it('should return the correct content type', function(done) {
-        expect(response.headers['content-type']).to.equal('text/html');
-        done();
-      });
-
-      it('should make sure to have the expected CSS inlined into the page for each <app-card>', function(done) {
-        const cardComponents = fragmentsApiDom.window.document.querySelectorAll('body > app-card');
-
-        expect(cardComponents.length).to.equal(2);
-        Array.from(cardComponents).forEach((card) => {
-          expect(card.innerHTML).contain('font-size: 1.85rem');
-        });
-        done();
-      });
+      // it should return the correct h1 contents
+      // it should return the correct app-card contents
     });
   });
 

--- a/packages/plugin-typescript/test/cases/exp-prerender.serve.ssr/greenwood.config.js
+++ b/packages/plugin-typescript/test/cases/exp-prerender.serve.ssr/greenwood.config.js
@@ -1,0 +1,8 @@
+import { greenwoodPluginTypeScript } from '../../../src/index.js';
+
+export default {
+  prerender: true,
+  plugins: [
+    greenwoodPluginTypeScript()
+  ]
+};

--- a/packages/plugin-typescript/test/cases/exp-prerender.serve.ssr/package.json
+++ b/packages/plugin-typescript/test/cases/exp-prerender.serve.ssr/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-plugin-exp-prerender-ts",
+  "type": "module"
+}

--- a/packages/plugin-typescript/test/cases/exp-prerender.serve.ssr/src/components/card/card.ts
+++ b/packages/plugin-typescript/test/cases/exp-prerender.serve.ssr/src/components/card/card.ts
@@ -1,0 +1,26 @@
+export default class Card extends HTMLElement {
+
+  selectItem() {
+    alert(`selected item is => ${this.getAttribute('title')}!`);
+  }
+
+  connectedCallback() {
+    if (!this.shadowRoot) {
+      const thumbnail: String = this.getAttribute('thumbnail');
+      const title: String = this.getAttribute('title');
+      const template: any = document.createElement('template');
+
+      template.innerHTML = `
+        <div>
+          <h3>${title}</h3>
+          <img src="${thumbnail}" alt="${title}" loading="lazy" width="100%">
+          <button onclick="this.parentNode.parentNode.host.selectItem()">View Item Details</button>
+        </div>
+      `;
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
+  }
+}
+
+customElements.define('app-card', Card);

--- a/packages/plugin-typescript/test/cases/exp-prerender.serve.ssr/src/pages/index.html
+++ b/packages/plugin-typescript/test/cases/exp-prerender.serve.ssr/src/pages/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en" prefix="og:http://ogp.me/ns#">
+
+  <head>
+    <script type="module" src="../components/card/card.ts"></script>    
+  </head>
+
+  <body>
+    <h1>Hello World!</h1>
+    <app-card
+      title="foo"
+      thumbnail="bar.png"
+    ></app-card>
+  </body>
+  
+</html>

--- a/www/pages/docs/server-rendering.md
+++ b/www/pages/docs/server-rendering.md
@@ -204,10 +204,10 @@ export async function getTemplate(compilation, route) {
 ### Custom Imports
 
 > ⚠️ _This feature is experimental._
+> 
+> _**Note**: At this time, [WCC can't handle non-standard javaScript formats](https://github.com/ProjectEvergreen/greenwood/issues/1004), though we hope to enable this by the 1.0 release._
 
-Through the support of the following plugins, Greenwood also supports loading custom file formats on the server side using ESM
-- [CSS](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/plugin-import-css/README.md#usage)
-- [JSON](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/plugin-import-json/README.md#usage)
+Combined with Greenwood's [custom import resource plugins](https://www.greenwoodjs.io/plugins/custom-plugins/) (or your own!), Greenwood can handle loading custom file extensions on the server side using ESM, like CSS and JSON!
 
 For example, you can now import JSON in your SSR pages and components.
 ```js
@@ -217,7 +217,7 @@ console.log(json); // { status: 200, message: 'some data' }
 ```
 
 **Steps**
-1. Make sure you are using Node `v18.12.1`
+1. Make sure you are using Node `v18.15.0`
 1. Run the Greenwood CLI using the `--experimental-loaders` flag and pass Greenwood's custom loader
     ```shell
     $ node --experimental-loader ./node_modules/@greenwood/cli/src/loader.js ./node_modules/.bin/greenwood <command>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
"resolves" #1004 

It seems coming out of #952 , using `import` even with _.gql_ files seems to be working just fine, and since this also works with JSX as evidenced in our test cases, I think this means everything is now compatible!
- ✅ _.json_
- ✅ _.css_
- ✅ _.gql_
- ✅ _.jsx_
- ✅ _.ts_ *

> There is a scenario in which we need to handle TypeScript (or any general form of non-standard JavaScript) in WCC - https://github.com/ProjectEvergreen/wcc/issues/122

## Summary of Changes
1. Update documentation (and test case comment) to clarify latest state of custom loaders and configuration
1. Add placeholder TypeScript <> WCC test case

----

Not sure what the specific fix was, but possibly as part #1151 ?