### PR TITLE
enhancement/Issue 1171: Include protocol with logged urls in terminal output

### DIFF
--- a/packages/cli/src/commands/develop.js
+++ b/packages/cli/src/commands/develop.js
@@ -10,7 +10,7 @@ const runDevServer = async (compilation) => {
 
       (await getDevServer(compilation)).listen(port, () => {
 
-        console.info(`Started local development server at localhost:${port}`);
+        console.info(`Started local development server at http://localhost:${port}`);
 
         const servers = [...compilation.config.plugins.filter((plugin) => {
           return plugin.type === 'server';

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -12,7 +12,7 @@ const runProdServer = async (compilation) => {
       const server = (hasDynamicRoutes && !compilation.config.prerender) || hasApisDir ? getHybridServer : getStaticServer;
 
       (await server(compilation)).listen(port, () => {
-        console.info(`Started server at localhost:${port}`);
+        console.info(`Started server at http://localhost:${port}`);
       });
     } catch (err) {
       reject(err);

--- a/packages/plugin-renderer-puppeteer/src/plugins/server.js
+++ b/packages/plugin-renderer-puppeteer/src/plugins/server.js
@@ -12,7 +12,7 @@ class PuppeteerServer extends ServerInterface {
       const { port } = this.compilation.config.devServer;
 
       (await getDevServer(this.compilation)).listen(port, async () => {
-        console.info(`Started puppeteer prerender server at localhost:${port}`);
+        console.info(`Started puppeteer prerender server at http://localhost:${port}`);
       });
     } else {
       await Promise.resolve();


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
<!-- Include a link to the issue (e.g. Resolves #12) -->
https://github.com/ProjectEvergreen/greenwood/issues/1171

## Summary of Changes
<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->
- Include the `http://` protocol on console logs used during server startup.