### PR TITLE
Bug/issue 1190 remove broken import meta resolve implementation for node modules lookup

### DIFF
--- a/packages/cli/src/lib/node-modules-utils.js
+++ b/packages/cli/src/lib/node-modules-utils.js
@@ -1,51 +1,29 @@
-// TODO convert this to use / return URLs
-// https://github.com/ProjectEvergreen/greenwood/issues/953
-import { createRequire } from 'module'; // https://stackoverflow.com/a/62499498/417806
+import { createRequire } from 'module';
 import { checkResourceExists } from './resource-utils.js';
 import fs from 'fs/promises';
 
-// defer to NodeJS to find where on disk a package is located using import.meta.resolve
-// and return the root absolute location
 async function getNodeModulesLocationForPackage(packageName) {
   let nodeModulesUrl;
 
-  try {
-    const packageEntryLocation = (await import.meta.resolve(packageName)).replace(/\\/g, '/'); // force / for consistency and path matching
+  // require.resolve may fail in the event a package has no main in its package.json
+  // so as a fallback, ask for node_modules paths and find its location manually
+  // https://github.com/ProjectEvergreen/greenwood/issues/557#issuecomment-923332104
+  // // https://stackoverflow.com/a/62499498/417806
+  const require = createRequire(import.meta.url);
+  const locations = require.resolve.paths(packageName);
 
-    if (packageName.indexOf('@greenwood') === 0) {
-      const subPackage = packageEntryLocation.indexOf('@greenwood') > 0
-        ? packageName // we are in the user's node modules
-        : packageName.split('/')[1]; // else we are in our monorepo
-      const packageRootPath = packageEntryLocation.indexOf('@greenwood') > 0
-        ? packageEntryLocation.split(packageName)[0] // we are in the user's node modules
-        : packageEntryLocation.split(subPackage)[0]; // else we are in our monorepo
+  for (const location in locations) {
+    const nodeModulesPackageRoot = `${locations[location]}/${packageName}`;
+    const packageJsonLocation = `${nodeModulesPackageRoot}/package.json`;
 
-      nodeModulesUrl = `${packageRootPath}${subPackage}`;
-    } else {
-      const packageRootPath = packageEntryLocation.split(packageName)[0];
-
-      nodeModulesUrl = `${packageRootPath}${packageName}`;
+    if (await checkResourceExists(new URL(`file://${packageJsonLocation}`))) {
+      nodeModulesUrl = nodeModulesPackageRoot;
     }
-  } catch (e) {
-    // require.resolve may fail in the event a package has no main in its package.json
-    // so as a fallback, ask for node_modules paths and find its location manually
-    // https://github.com/ProjectEvergreen/greenwood/issues/557#issuecomment-923332104
-    const require = createRequire(import.meta.url);
-    const locations = require.resolve.paths(packageName);
+  }
 
-    for (const location in locations) {
-      const nodeModulesPackageRoot = `${locations[location]}/${packageName}`;
-      const packageJsonLocation = `${nodeModulesPackageRoot}/package.json`;
-
-      if (await checkResourceExists(new URL(`file://${packageJsonLocation}`))) {
-        nodeModulesUrl = nodeModulesPackageRoot;
-      }
-    }
-
-    if (!nodeModulesUrl) {
-      console.debug(`Unable to look up ${packageName} using NodeJS require.resolve.  Falling back to process.cwd()`);
-      nodeModulesUrl = new URL(`./node_modules/${packageName}`, `file://${process.cwd()}`).pathname;
-    }
+  if (!nodeModulesUrl) {
+    console.debug(`Unable to look up ${packageName} using NodeJS require.resolve.  Falling back to process.cwd()`);
+    nodeModulesUrl = new URL(`./node_modules/${packageName}`, `file://${process.cwd()}`).pathname;
   }
 
   return nodeModulesUrl;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1190 

## Summary of Changes
1. Remove `import.meta.resolve` implementation for node module lookup