### PR TITLE
docs/remove reference to old `mode` configuration option

### DIFF
--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -146,7 +146,7 @@ export default {
 
 ### Optimization
 
-Greenwood provides a number of different ways to send hints to Greenwood as to how JavaScript and CSS tags in your HTML should get loaded by the browser.  Greenwood supplements, and builds up on top of existing [resource "hints" like `preload` and `prefetch`](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content).  These optimization settings are intended to compliment any `mode` setting you may have selected.
+Greenwood provides a number of different ways to send hints to Greenwood as to how JavaScript and CSS tags in your HTML should get loaded by the browser.  Greenwood supplements, and builds up on top of existing [resource "hints" like `preload` and `prefetch`](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content).
 
 | Option | Description | Use Cases |
 | ------ | ----------- | --------- |


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Remove reference to old `mode` configuration setting