### PR TITLE
chore/upgrade gallinago 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint": "^8.51.0",
     "eslint-plugin-markdown": "^3.0.0",
     "eslint-plugin-no-only-tests": "^2.6.0",
-    "gallinago": "^0.8.0",
+    "gallinago": "^0.8.1",
     "glob-promise": "^3.4.0",
     "jsdom": "^16.5.0",
     "lerna": "^3.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8475,10 +8475,10 @@ fuzzy@0.1.3:
   resolved "https://registry.yarnpkg.com/fuzzy/-/fuzzy-0.1.3.tgz#4c76ec2ff0ac1a36a9dccf9a00df8623078d4ed8"
   integrity sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==
 
-gallinago@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/gallinago/-/gallinago-0.8.0.tgz#b918c497b8fe05df84521c2cb4b85aac2f3fc984"
-  integrity sha512-bTAptESmUCq6OZCWKJGLQ4+vzDbKmLCrGurhgCNxMtitYaGn1dkXmUY1Gceniew/m14R8GbeizjlTC1hxJBqHA==
+gallinago@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/gallinago/-/gallinago-0.8.1.tgz#47eb2358bf27f5d16d2755df36577f03caddfd80"
+  integrity sha512-uE7LyJHtfl650PAZUQiZLzxuYcJAVMJ7p32cEDEskfYrCmHKDu5KkuBqMnwKEcJTDOdWEvhlii/o0pvucX0CgQ==
 
 gauge@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

## Summary of Changes
1. Upgrade **gallinago** to restore missing terminal output that would have been missing for folks when trying to enable it during testing - https://github.com/thescientist13/gallinago/issues/44