### PR TITLE
bug/ensure minimum compatible version of wcc 0.12.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
     "remark-rehype": "^7.0.0",
     "rollup": "^3.29.4",
     "unified": "^9.2.0",
-    "wc-compiler": "~0.12.0"
+    "wc-compiler": "~0.12.1"
   },
   "devDependencies": {
     "@babel/runtime": "^7.10.4",

--- a/packages/plugin-import-jsx/package.json
+++ b/packages/plugin-import-jsx/package.json
@@ -27,7 +27,7 @@
     "@greenwood/cli": "^0.28.0-alpha.4"
   },
   "dependencies": {
-    "wc-compiler": "~0.12.0"
+    "wc-compiler": "~0.12.1"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.30.0-alpha.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16831,10 +16831,10 @@ wait-port@1.0.4:
     commander "^9.3.0"
     debug "^4.3.4"
 
-wc-compiler@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.12.0.tgz#f9d04b5bfca505f836487ce63040fdf30f1cea5b"
-  integrity sha512-eMgHEGhJGcyjSL9p6YIix0ReMViffhtabVEnNE1oRiNlNJL/Fd8e0GZ2gdWhIOV5ZvNMOocyAKFODKpg3CDMkg==
+wc-compiler@~0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.12.1.tgz#cf34a1a9758c0085580ddc82b5aa6312d3de20bf"
+  integrity sha512-+uEK9cL9MHIWnXoD11cQ77omBLekw1Oih2wqbrM2jBFGTPHvPauq3jtdWzlkg/0OwOJOyYqbBlQfZb/oA+HuNg==
   dependencies:
     "@projectevergreen/acorn-jsx-esm" "~0.1.0"
     "@projectevergreen/escodegen-esm" "~0.1.0"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
As part of the v0.30.0-alpha.0 release, WCC was upgrade to v0.12.0 and in that change, this error was discovered upgrading the following three repos.
- https://github.com/ProjectEvergreen/greenwood-template-blog/pull/12
- https://github.com/ProjectEvergreen/greenwood-demo-adapter-netlify/pull/20
- https://github.com/ProjectEvergreen/greenwood-demo-adapter-vercel/pull/22
```
➜  greenwood-demo-adapter-vercel git:(chore/upgrade-greenwood-0.30.0) ✗ npm run dev

> greenwood-demo-adapter-vercel@1.0.0 dev
> greenwood develop

-------------------------------------------------------
Welcome to Greenwood (v0.30.0-alpha.0) ♻️
-------------------------------------------------------
Initializing project config
Initializing project workspace contexts
Generating graph of workspace files...
building from local sources...

node:internal/process/promises:288
            triggerUncaughtException(err, true /* fromPromise */);
            ^
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'acorn-jsx' imported from /Users/owenbuckley/Workspace/project-evergreen/greenwood-demo-adapter-vercel/node_modules/wc-compiler/src/jsx-loader.js
    at new NodeError (node:internal/errors:393:5)
    at packageResolve (node:internal/modules/esm/resolve:860:9)
    at moduleResolve (node:internal/modules/esm/resolve:909:20)
    at defaultResolve (node:internal/modules/esm/resolve:1124:11)
    at nextResolve (node:internal/modules/esm/loader:163:28)
    at ESMLoader.resolve (node:internal/modules/esm/loader:841:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:40)
    at link (node:internal/modules/esm/module_job:75:36) {
  code: 'ERR_MODULE_NOT_FOUND'
```

## Summary of Changes
1. Any new users should be fine and / or can override, but this at least ensures the minimum compatible version in Greenwood to [**v0.12.1**](https://github.com/ProjectEvergreen/wcc/releases/tag/0.12.1)