### PR TITLE
bug/issue 1118 SSR pages are missing URL chunks of route chunk

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -400,8 +400,8 @@ const getRollupConfigForSsr = async (compilation, input) => {
     input: filepath,
     output: {
       dir: normalizePathnameForWindows(outputDir),
-      entryFileNames: '[name].route.js',
-      chunkFileNames: '[name].route.chunk.[hash].js'
+      entryFileNames: `${path.basename(filepath).split('.')[0]}.route.js`,
+      chunkFileNames: `${path.basename(filepath).split('.')[0]}.route.chunk.[hash].js`
     },
     plugins: [
       greenwoodResourceLoader(compilation),

--- a/packages/plugin-adapter-netlify/src/index.js
+++ b/packages/plugin-adapter-netlify/src/index.js
@@ -97,8 +97,8 @@ async function netlifyAdapter(compilation) {
     const { id } = page;
     const outputType = 'page';
     const outputRoot = new URL(`./${id}/`, adapterOutputUrl);
-    const files = (await fs.readdir(outputDir))
-      .filter(file => file.startsWith(`${id}.route.chunk.`) && file.endsWith('.js'));
+    const chunks = (await fs.readdir(outputDir))
+      .filter(file => file.startsWith(`${id}.route.chunk`) && file.endsWith('.js'));
 
     await setupOutputDirectory(id, outputRoot, outputType);
 
@@ -109,11 +109,11 @@ async function netlifyAdapter(compilation) {
       { recursive: true }
     );
 
-    // and the URL chunk for renderer plugin and executeRouteModule
-    for (const file of files) {
+    // and any (URL) chunks for the page
+    for (const chunk of chunks) {
       await fs.cp(
-        new URL(`./${file}`, outputDir),
-        new URL(`./${file}`, outputRoot),
+        new URL(`./${chunk}`, outputDir),
+        new URL(`./${chunk}`, outputRoot),
         { recursive: true }
       );
     }

--- a/packages/plugin-adapter-vercel/src/index.js
+++ b/packages/plugin-adapter-vercel/src/index.js
@@ -86,8 +86,8 @@ async function vercelAdapter(compilation) {
     const outputType = 'page';
     const { id } = page;
     const outputRoot = new URL(`./${basePath}/${id}.func/`, adapterOutputUrl);
-    const files = (await fs.readdir(outputDir))
-      .filter(file => file.indexOf('.route.chunk.') > 0 && file.endsWith('.js'));
+    const chunks = (await fs.readdir(outputDir))
+      .filter(file => file.startsWith(`${id}.route.chunk`) && file.endsWith('.js'));
 
     await setupFunctionBuildFolder(id, outputType, outputRoot);
 
@@ -98,11 +98,11 @@ async function vercelAdapter(compilation) {
       { recursive: true }
     );
 
-    // and the URL chunk for renderer plugin and executeRouteModule
-    for (const file of files) {
+    // and any (URL) chunks for the page
+    for (const chunk of chunks) {
       await fs.cp(
-        new URL(`./${file}`, outputDir),
-        new URL(`./${file}`, outputRoot),
+        new URL(`./${chunk}`, outputDir),
+        new URL(`./${chunk}`, outputRoot),
         { recursive: true }
       );
     }

--- a/packages/plugin-adapter-vercel/src/index.js
+++ b/packages/plugin-adapter-vercel/src/index.js
@@ -87,7 +87,7 @@ async function vercelAdapter(compilation) {
     const { id } = page;
     const outputRoot = new URL(`./${basePath}/${id}.func/`, adapterOutputUrl);
     const files = (await fs.readdir(outputDir))
-      .filter(file => file.indexOf(`.route.chunk.`) > 0 && file.endsWith('.js'));
+      .filter(file => file.indexOf('.route.chunk.') > 0 && file.endsWith('.js'));
 
     await setupFunctionBuildFolder(id, outputType, outputRoot);
 

--- a/packages/plugin-adapter-vercel/src/index.js
+++ b/packages/plugin-adapter-vercel/src/index.js
@@ -87,7 +87,7 @@ async function vercelAdapter(compilation) {
     const { id } = page;
     const outputRoot = new URL(`./${basePath}/${id}.func/`, adapterOutputUrl);
     const files = (await fs.readdir(outputDir))
-      .filter(file => file.startsWith(`${id}.route.chunk.`) && file.endsWith('.js'));
+      .filter(file => file.indexOf(`.route.chunk.`) > 0 && file.endsWith('.js'));
 
     await setupFunctionBuildFolder(id, outputType, outputRoot);
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
regression from #1118 

Noticed during upgrade testing that Rollup still seemed to be generating chunks of chunks and that ultimately these were not being tracked as part of Adapter code
https://github.com/thescientist13/greenwood-lit-ssr/pull/12
![Screenshot 2024-03-10 at 7 13 59 PM](https://github.com/ProjectEvergreen/greenwood/assets/895923/e8c13e33-a23c-423b-a2df-2a52d74b7979)

We can see that a chunk for lit-element was created, which belongs to the products.route.js entry point
```
```

And it was not in the Vercel build output
![Screenshot 2024-03-10 at 7 17 12 PM](https://github.com/ProjectEvergreen/greenwood/assets/895923/7f38e49a-3e9d-4ac5-af3b-fd817d31878c)
![Screenshot 2024-03-10 at 7 17 28 PM](https://github.com/ProjectEvergreen/greenwood/assets/895923/1a408dda-22f3-4ec8-be2f-7d963e50ad32)

## Summary of Changes
1. Copy over missing related route chunks by namespacing SSR page entry points and chunks

## TODO
1. [x] Need to fix the issue for good with a better convention
    - added as comment to - https://github.com/ProjectEvergreen/greenwood/discussions/1204
1. [x] Apply to Netlify implementation
1. [ ] Find a better way to reproduce this in test cases