### PR TITLE
bug/issue 1223 handle incorrect nested SSR page bundle output name mapping

### DIFF
--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -191,6 +191,7 @@ const generateGraph = async (compilation) => {
              * data: custom page frontmatter
              * filename: base filename of the page
              * id: filename without the extension
+             * relativeWorkspacePagePath: the file path relative to the user's workspace directory
              * label: "pretty" text representation of the filename
              * imports: per page JS or CSS file imports to be included in HTML output from frontmatter
              * resources: sum of all resources for the entire page
@@ -206,6 +207,7 @@ const generateGraph = async (compilation) => {
               data: customData || {},
               filename,
               id,
+              relativeWorkspacePagePath: relativePagePath,
               label: id.split('-')
                 .map((idPart) => {
                   return `${idPart.charAt(0).toUpperCase()}${idPart.substring(1)}`;

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -294,7 +294,7 @@ async function getHybridServer(compilation) {
       const request = transformKoaRequestIntoStandardRequest(url, ctx.request);
 
       if (!config.prerender && matchingRoute.isSSR && !matchingRoute.prerender) {
-        const { handler } = await import(new URL(`./__${matchingRoute.filename}`, outputDir));
+        const { handler } = await import(new URL(`./${matchingRoute.outputPath}`, outputDir));
         const response = await handler(request, compilation);
 
         ctx.body = Readable.from(response.body);

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -105,7 +105,7 @@ class StandardHtmlResource extends ResourceInterface {
     }
 
     if (matchingRoute.isSSR) {
-      const routeModuleLocationUrl = new URL(`./${matchingRoute.filename}`, pagesDir);
+      const routeModuleLocationUrl = new URL(`.${matchingRoute.relativeWorkspacePagePath}`, pagesDir);
       const routeWorkerUrl = this.compilation.config.plugins.find(plugin => plugin.type === 'renderer').provider().executeModuleUrl;
 
       await new Promise(async (resolve, reject) => {

--- a/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
+++ b/packages/cli/test/cases/build.plugins.context/theme-pack-context-plugin.js
@@ -1,20 +1,15 @@
 import fs from 'fs/promises';
-import os from 'os';
-import { spawnSync } from 'child_process';
 
 const packageJson = JSON.parse(await fs.readFile(new URL('./package.json', import.meta.url), 'utf-8'));
-const myThemePackPlugin = () => [{
+const myThemePackPlugin = (options = {}) => [{
   type: 'context',
   name: 'my-theme-pack:context',
   provider: () => {
     const { name } = packageJson;
-    const command = os.platform() === 'win32' ? 'npm.cmd' : 'npm';
-    const ls = spawnSync(command, ['ls', name]);
 
-    const isInstalled = ls.stdout.toString().indexOf('(empty)') < 0;
-    const templateLocation = isInstalled
-      ? new URL(`./node_modules/${name}/dist/layouts/`, import.meta.url)
-      : new URL('./fixtures/layouts/', import.meta.url);
+    const templateLocation = options.__isDevelopment // eslint-disable-line no-underscore-dangle
+      ? new URL('./fixtures/layouts/', import.meta.url)
+      : new URL(`./node_modules/${name}/dist/layouts/`, import.meta.url);
 
     return {
       templates: [

--- a/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
+++ b/packages/cli/test/cases/develop.plugins.context/greenwood.config.js
@@ -24,7 +24,9 @@ class MyThemePackDevelopmentResource extends ResourceInterface {
 
 export default {
   plugins: [
-    ...myThemePackPlugin(),
+    ...myThemePackPlugin({
+      __isDevelopment: true
+    }),
     {
       type: 'resource',
       name: 'my-theme-pack:resource',

--- a/packages/cli/test/cases/develop.ssr/develop.ssr.spec.js
+++ b/packages/cli/test/cases/develop.ssr/develop.ssr.spec.js
@@ -16,6 +16,9 @@
  *   components/
  *     footer.js
  *   pages/
+ *     blog
+ *       first-post.js
+ *       index.js
  *     artists.js
  *     post.js
  *   templates/
@@ -282,6 +285,94 @@ describe('Develop Greenwood With: ', function() {
 
         expect(paragraph.length).to.equal(1);
         expect(paragraph[0].textContent).to.not.be.undefined;
+      });
+    });
+
+    describe('Develop command with HTML route response using default export and nested SSR Blog Index page', function() {
+      let response = {};
+      let dom = {};
+      let body;
+
+      before(async function() {
+        response = await fetch(`${hostname}/blog/`);
+        body = await response.clone().text();
+        dom = new JSDOM(body);
+      });
+
+      it('should return a 200 status', function(done) {
+        expect(response.status).to.equal(200);
+        done();
+      });
+
+      it('should return the correct content type', function(done) {
+        expect(response.headers.get('content-type')).to.equal('text/html');
+        done();
+      });
+
+      it('should return a response body', function(done) {
+        expect(body).to.not.be.undefined;
+        done();
+      });
+
+      it('should be valid HTML from JSDOM', function(done) {
+        expect(dom).to.not.be.undefined;
+        done();
+      });
+
+      it('should be valid HTML from JSDOM', function(done) {
+        expect(dom).to.not.be.undefined;
+        done();
+      });
+
+      it('should have the expected postId as an <h1> tag in the body', function() {
+        const heading = dom.window.document.querySelectorAll('body > h1');
+
+        expect(heading.length).to.equal(1);
+        expect(heading[0].textContent).to.equal('Nested SSR page should work!');
+      });
+    });
+
+    describe('Develop command with HTML route response using default export and nested SSR Blog First Post page', function() {
+      let response = {};
+      let dom = {};
+      let body;
+
+      before(async function() {
+        response = await fetch(`${hostname}/blog/first-post/`);
+        body = await response.clone().text();
+        dom = new JSDOM(body);
+      });
+
+      it('should return a 200 status', function(done) {
+        expect(response.status).to.equal(200);
+        done();
+      });
+
+      it('should return the correct content type', function(done) {
+        expect(response.headers.get('content-type')).to.equal('text/html');
+        done();
+      });
+
+      it('should return a response body', function(done) {
+        expect(body).to.not.be.undefined;
+        done();
+      });
+
+      it('should be valid HTML from JSDOM', function(done) {
+        expect(dom).to.not.be.undefined;
+        done();
+      });
+
+      it('should be valid HTML from JSDOM', function(done) {
+        expect(dom).to.not.be.undefined;
+        done();
+      });
+
+      it('should have the expected postId as an <h1> tag in the body', function() {
+        const heading = dom.window.document.querySelectorAll('body > h1');
+
+        expect(heading.length).to.equal(1);
+        expect(heading[0].textContent).to.equal('Nested SSR First Post page should work!');
       });
     });
   });

--- a/packages/cli/test/cases/develop.ssr/src/pages/blog/first-post.js
+++ b/packages/cli/test/cases/develop.ssr/src/pages/blog/first-post.js
@@ -1,0 +1,7 @@
+export default class BlogFirstPostPage extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
+      <h1>Nested SSR First Post page should work!</h1>
+    `;
+  }
+}

--- a/packages/cli/test/cases/develop.ssr/src/pages/blog/index.js
+++ b/packages/cli/test/cases/develop.ssr/src/pages/blog/index.js
@@ -1,0 +1,7 @@
+export default class BlogPage extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
+      <h1>Nested SSR page should work!</h1>
+    `;
+  }
+}

--- a/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
@@ -23,6 +23,9 @@
  *   pages/
  *     about.md
  *     artists.js
+ *     blog/
+ *       first-post.js
+ *       index.js
  *     index.js
  *     post.js
  *     users.js
@@ -269,6 +272,94 @@ describe('Serve Greenwood With: ', function() {
           .filter(file => file.indexOf('users.js') >= 0);
 
         expect(scriptFiles.length).to.equal(2);
+      });
+    });
+
+    describe('Serve command with HTML route response using default export and nested SSR Blog Index page', function() {
+      let response = {};
+      let dom = {};
+      let body;
+
+      before(async function() {
+        response = await fetch(`${hostname}/blog/`);
+        body = await response.clone().text();
+        dom = new JSDOM(body);
+      });
+
+      it('should return a 200 status', function(done) {
+        expect(response.status).to.equal(200);
+        done();
+      });
+
+      it('should return the correct content type', function(done) {
+        expect(response.headers.get('content-type')).to.equal('text/html');
+        done();
+      });
+
+      it('should return a response body', function(done) {
+        expect(body).to.not.be.undefined;
+        done();
+      });
+
+      it('should be valid HTML from JSDOM', function(done) {
+        expect(dom).to.not.be.undefined;
+        done();
+      });
+
+      it('should be valid HTML from JSDOM', function(done) {
+        expect(dom).to.not.be.undefined;
+        done();
+      });
+
+      it('should have the expected postId as an <h1> tag in the body', function() {
+        const heading = dom.window.document.querySelectorAll('body > h1');
+
+        expect(heading.length).to.equal(1);
+        expect(heading[0].textContent).to.equal('Nested SSR page should work!');
+      });
+    });
+
+    describe('Develop command with HTML route response using default export and nested SSR Blog First Post page', function() {
+      let response = {};
+      let dom = {};
+      let body;
+
+      before(async function() {
+        response = await fetch(`${hostname}/blog/first-post/`);
+        body = await response.clone().text();
+        dom = new JSDOM(body);
+      });
+
+      it('should return a 200 status', function(done) {
+        expect(response.status).to.equal(200);
+        done();
+      });
+
+      it('should return the correct content type', function(done) {
+        expect(response.headers.get('content-type')).to.equal('text/html');
+        done();
+      });
+
+      it('should return a response body', function(done) {
+        expect(body).to.not.be.undefined;
+        done();
+      });
+
+      it('should be valid HTML from JSDOM', function(done) {
+        expect(dom).to.not.be.undefined;
+        done();
+      });
+
+      it('should be valid HTML from JSDOM', function(done) {
+        expect(dom).to.not.be.undefined;
+        done();
+      });
+
+      it('should have the expected postId as an <h1> tag in the body', function() {
+        const heading = dom.window.document.querySelectorAll('body > h1');
+
+        expect(heading.length).to.equal(1);
+        expect(heading[0].textContent).to.equal('Nested SSR First Post page should work!');
       });
     });
 

--- a/packages/cli/test/cases/serve.default.ssr/src/pages/blog/first-post.js
+++ b/packages/cli/test/cases/serve.default.ssr/src/pages/blog/first-post.js
@@ -1,0 +1,7 @@
+export default class BlogFirstPostPage extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
+      <h1>Nested SSR First Post page should work!</h1>
+    `;
+  }
+}

--- a/packages/cli/test/cases/serve.default.ssr/src/pages/blog/index.js
+++ b/packages/cli/test/cases/serve.default.ssr/src/pages/blog/index.js
@@ -1,0 +1,7 @@
+export default class BlogPage extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
+      <h1>Nested SSR page should work!</h1>
+    `;
+  }
+}

--- a/www/pages/docs/data.md
+++ b/www/pages/docs/data.md
@@ -62,6 +62,8 @@ graph {
 
   outputPath, // (string) the relative path to write to when generating static HTML
 
+  relativeWorkspacePagePath, // the file path relative to the user's workspace directory
+
   path, // (string) path to the file
 
   route,  // (string) A URL, typically derived from the filesystem path, e.g. /blog/2019/first-post/


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1223 

## Summary of Changes
1. Map SSR page output paths and bundle names to Rollup bundle names
1. Added `relativeWorkspacePagePath` as convenience to the graph for each page, should track as part of #1167 
1. Incorporated [this change](https://github.com/ProjectEvergreen/greenwood/pull/1215/commits/42d6ac8b6db9ac7d77cea11f91d1913a015c9769) to handle a change in behavior in latest Node `18.20.x`

> Will make to align with work being done in https://github.com/ProjectEvergreen/greenwood/pull/1212

## TODO
1. [x] fix windows build failures
1. [x] Phantom _.greenwood/__ directory?
1. [x] Downstream testing
    - https://github.com/AnalogStudiosRI/www.blissri.com/pull/21/commits/f0f0fe444396a710a8376dfe0c28f25c4adf81ae
    - https://66356e162788c46b161f40ab--thriving-kataifi-2b287f.netlify.app/photos/blissfest-2023/
1. [x] Create an enhancement issue for making sure we have better control over output map naming - https://github.com/ProjectEvergreen/greenwood/issues/1226

----

Main issue was with very loose enforcement of output naming, such that when running this sort of pages through Rollup
```sh
src/
  pages/
    blog/
      index.js
    index.js
```

Both of those will come out of the same name to Rollup, and because they will be duplicates, you'll be getting unexpected names, like
- __index.js_
- __index2.js_
- __index3.js_
- ...

So the main fix here is to map our bundle names to whatever Rollup spits out for now just keep things working and in sync.