### PR TITLE
bug/issue 1226 nested SSR pages release branch rebase and refactor

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -138,6 +138,30 @@ function greenwoodSyncPageResourceBundlesPlugin(compilation) {
   };
 }
 
+function greenwoodSyncSsrEntryPointsOutputPaths(compilation) {
+  return {
+    name: 'greenwood-sync-ssr-pages-entry-point-output-paths',
+    generateBundle(options, bundle) {
+      const { basePath } = compilation.config;
+      const { scratchDir } = compilation.context;
+
+      // map rollup bundle names back to original SSR pages for syncing input <> output bundle names
+      Object.keys(bundle).forEach((key) => {
+        if (bundle[key].exports?.find(exp => exp === 'handler')) {
+          const ext = bundle[key].facadeModuleId.split('.').pop();
+          const route = bundle[key].facadeModuleId.replace(scratchDir.pathname, `${basePath}/`).replace(`.${ext}`, '/').replace('/index/', '/');
+
+          compilation.graph.forEach((page, idx) => {
+            if (page.route === route) {
+              compilation.graph[idx].outputPath = key;
+            }
+          });
+        }
+      });
+    }
+  };
+}
+
 function getMetaImportPath(node) {
   return node.arguments[0].value.split('/').join(path.sep)
     .replace(/\\/g, '/'); // handle Windows style paths
@@ -427,44 +451,53 @@ const getRollupConfigForApis = async (compilation) => {
 const getRollupConfigForSsr = async (compilation, input) => {
   const { outputDir } = compilation.context;
 
-  return input.map(filepath => ({
-    input: filepath,
-    output: {
-      dir: normalizePathnameForWindows(outputDir),
-      entryFileNames: `${path.basename(filepath).split('.')[0]}.route.js`,
-      chunkFileNames: `${path.basename(filepath).split('.')[0]}.route.chunk.[hash].js`
-    },
-    plugins: [
-      greenwoodResourceLoader(compilation),
-      // support node export conditions for SSR pages
-      // https://github.com/ProjectEvergreen/greenwood/issues/1118
-      // https://github.com/rollup/plugins/issues/362#issuecomment-873448461
-      nodeResolve({
-        exportConditions: ['node'],
-        preferBuiltins: true
-      }),
-      commonjs(),
-      greenwoodImportMetaUrl(compilation)
-    ],
-    onwarn: (errorObj) => {
-      const { code, message } = errorObj;
+  console.log('getRollupConfigForSsr', { input });
+  return input.map((filepath) => {
+    const ext = filepath.split('.').pop();
+    const entryName = filepath.replace(compilation.context.scratchDir.pathname, '').replace('/', '-').replace(`.${ext}`, '');
+    console.log('filepath', { filepath });
+    console.log('name', path.basename(filepath).split('.')[0]);
+    console.log('entryName', { entryName });
+    return {
+      input: filepath,
+      output: {
+        dir: normalizePathnameForWindows(outputDir),
+        entryFileNames: `${entryName}.route.js`,
+        chunkFileNames: `${entryName}.route.chunk.[hash].js`
+      },
+      plugins: [
+        greenwoodResourceLoader(compilation),
+        // support node export conditions for SSR pages
+        // https://github.com/ProjectEvergreen/greenwood/issues/1118
+        // https://github.com/rollup/plugins/issues/362#issuecomment-873448461
+        nodeResolve({
+          exportConditions: ['node'],
+          preferBuiltins: true
+        }),
+        commonjs(),
+        greenwoodImportMetaUrl(compilation),
+        greenwoodSyncSsrEntryPointsOutputPaths(compilation)
+      ],
+      onwarn: (errorObj) => {
+        const { code, message } = errorObj;
 
-      switch (code) {
+        switch (code) {
 
-        case 'CIRCULAR_DEPENDENCY':
-          // TODO let this through for lit by suppressing it
-          // Error: the string "Circular dependency: ../../../../../node_modules/@lit-labs/ssr/lib/render-lit-html.js ->
-          // ../../../../../node_modules/@lit-labs/ssr/lib/lit-element-renderer.js -> ../../../../../node_modules/@lit-labs/ssr/lib/render-lit-html.js\n" was thrown, throw an Error :)
-          // https://github.com/lit/lit/issues/449
-          // https://github.com/ProjectEvergreen/greenwood/issues/1118
-          break;
-        default:
-          // otherwise, log all warnings from rollup
-          console.debug(message);
+          case 'CIRCULAR_DEPENDENCY':
+            // TODO let this through for lit by suppressing it
+            // Error: the string "Circular dependency: ../../../../../node_modules/@lit-labs/ssr/lib/render-lit-html.js ->
+            // ../../../../../node_modules/@lit-labs/ssr/lib/lit-element-renderer.js -> ../../../../../node_modules/@lit-labs/ssr/lib/render-lit-html.js\n" was thrown, throw an Error :)
+            // https://github.com/lit/lit/issues/449
+            // https://github.com/ProjectEvergreen/greenwood/issues/1118
+            break;
+          default:
+            // otherwise, log all warnings from rollup
+            console.debug(message);
 
+        }
       }
-    }
-  }));
+    };
+  });
 };
 
 export {

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -453,7 +453,8 @@ const getRollupConfigForSsr = async (compilation, input) => {
 
   return input.map((filepath) => {
     const ext = filepath.split('.').pop();
-    const entryName = filepath.replace(compilation.context.scratchDir.pathname, '').replace('/', '-').replace(`.${ext}`, '');
+    // account for windows pathname shenanigans first by "casting" filepath to URL first
+    const entryName = new URL(`file://${filepath}`).pathname.replace(compilation.context.scratchDir.pathname, '').replace('/', '-').replace(`.${ext}`, '');
 
     return {
       input: filepath,

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -149,7 +149,8 @@ function greenwoodSyncSsrEntryPointsOutputPaths(compilation) {
       Object.keys(bundle).forEach((key) => {
         if (bundle[key].exports?.find(exp => exp === 'handler')) {
           const ext = bundle[key].facadeModuleId.split('.').pop();
-          const route = bundle[key].facadeModuleId.replace(scratchDir.pathname, `${basePath}/`).replace(`.${ext}`, '/').replace('/index/', '/');
+          // account for windows pathname shenanigans by "casting" facadeModuleId to a URL first
+          const route = new URL(`file://${bundle[key].facadeModuleId}`).pathname.replace(scratchDir.pathname, `${basePath}/`).replace(`.${ext}`, '/').replace('/index/', '/');
 
           compilation.graph.forEach((page, idx) => {
             if (page.route === route) {
@@ -453,7 +454,7 @@ const getRollupConfigForSsr = async (compilation, input) => {
 
   return input.map((filepath) => {
     const ext = filepath.split('.').pop();
-    // account for windows pathname shenanigans first by "casting" filepath to URL first
+    // account for windows pathname shenanigans by "casting" filepath to a URL first
     const entryName = new URL(`file://${filepath}`).pathname.replace(compilation.context.scratchDir.pathname, '').replace('/', '-').replace(`.${ext}`, '');
 
     return {

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -451,13 +451,10 @@ const getRollupConfigForApis = async (compilation) => {
 const getRollupConfigForSsr = async (compilation, input) => {
   const { outputDir } = compilation.context;
 
-  console.log('getRollupConfigForSsr', { input });
   return input.map((filepath) => {
     const ext = filepath.split('.').pop();
     const entryName = filepath.replace(compilation.context.scratchDir.pathname, '').replace('/', '-').replace(`.${ext}`, '');
-    console.log('filepath', { filepath });
-    console.log('name', path.basename(filepath).split('.')[0]);
-    console.log('entryName', { entryName });
+
     return {
       input: filepath,
       output: {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
as part of rebasing master into the release branch, need to handle a conflict between #1226 / #1186, but mainly wanted to isolate this to a PR to better track the refactor for the benefit of #1226

> Note: the release branch CI process will fail until this PR lands - https://github.com/ProjectEvergreen/greenwood/actions/runs/9330931781

## Summary of Changes
1. Reintroduce SSR page bundle mapping in _rollup.config.js_ to better remove ambiguity around similar bundle outputs, e.g.
    ```sh
    pages/
      index.js
      blog/
        index.js
   ```

----

Will file a separate PR for actually wrapping up #1226 though after I merge this.