### PR TITLE
enhancement/issue 1178 support all remaining standard pseudo-class and element selectors for CSS bundling

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -21,7 +21,7 @@ function bundleCss(body, url, compilation) {
 
   walk(ast, {
     enter: function (node, item) { // eslint-disable-line complexity
-      const { type, name, value } = node;
+      const { type, name, value, children } = node;
 
       if ((type === 'String' || type === 'Url') && this.atrulePrelude && this.atrule.name === 'import') {
         const { value } = node;
@@ -83,23 +83,26 @@ function bundleCss(body, url, compilation) {
       } else if (type === 'PseudoClassSelector') {
         optimizedCss += `:${name}`;
 
-        switch (name) {
+        if (children) {
+          switch (name) {
 
-          case 'dir':
-          case 'is':
-          case 'has':
-          case 'lang':
-          case 'not':
-          case 'nth-child':
-          case 'nth-last-child':
-          case 'nth-of-type':
-          case 'nth-last-of-type':
-          case 'where':
-            optimizedCss += '(';
-            break;
-          default:
-            break;
+            case 'dir':
+            case 'host':
+            case 'is':
+            case 'has':
+            case 'lang':
+            case 'not':
+            case 'nth-child':
+            case 'nth-last-child':
+            case 'nth-of-type':
+            case 'nth-last-of-type':
+            case 'where':
+              optimizedCss += '(';
+              break;
+            default:
+              break;
 
+          }
         }
       } else if (type === 'PseudoElementSelector') {
         optimizedCss += `::${name}`;
@@ -208,23 +211,26 @@ function bundleCss(body, url, compilation) {
           optimizedCss += ')';
           break;
         case 'PseudoClassSelector':
-          switch (node.name) {
+          if (node.children) {
+            switch (node.name) {
 
-            case 'dir':
-            case 'is':
-            case 'has':
-            case 'lang':
-            case 'not':
-            case 'nth-child':
-            case 'nth-last-child':
-            case 'nth-last-of-type':
-            case 'nth-of-type':
-            case 'where':
-              optimizedCss += ')';
-              break;
-            default:
-              break;
+              case 'dir':
+              case 'host':
+              case 'is':
+              case 'has':
+              case 'lang':
+              case 'not':
+              case 'nth-child':
+              case 'nth-last-child':
+              case 'nth-last-of-type':
+              case 'nth-of-type':
+              case 'where':
+                optimizedCss += ')';
+                break;
+              default:
+                break;
 
+            }
           }
           break;
         case 'PseudoElementSelector':

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -85,6 +85,7 @@ function bundleCss(body, url, compilation) {
 
         switch (name) {
 
+          case 'dir':
           case 'is':
           case 'has':
           case 'lang':
@@ -93,6 +94,21 @@ function bundleCss(body, url, compilation) {
           case 'nth-last-child':
           case 'nth-of-type':
           case 'nth-last-of-type':
+          case 'where':
+            optimizedCss += '(';
+            break;
+          default:
+            break;
+
+        }
+      } else if (type === 'PseudoElementSelector') {
+        optimizedCss += `::${name}`;
+
+        switch (name) {
+
+          case 'highlight':
+          case 'part':
+          case 'slotted':
             optimizedCss += '(';
             break;
           default:
@@ -194,6 +210,7 @@ function bundleCss(body, url, compilation) {
         case 'PseudoClassSelector':
           switch (node.name) {
 
+            case 'dir':
             case 'is':
             case 'has':
             case 'lang':
@@ -202,6 +219,20 @@ function bundleCss(body, url, compilation) {
             case 'nth-last-child':
             case 'nth-last-of-type':
             case 'nth-of-type':
+            case 'where':
+              optimizedCss += ')';
+              break;
+            default:
+              break;
+
+          }
+          break;
+        case 'PseudoElementSelector':
+          switch (node.name) {
+
+            case 'highlight':
+            case 'part':
+            case 'slotted':
               optimizedCss += ')';
               break;
             default:

--- a/packages/cli/test/cases/build.config.optimization-default/fixtures/expected.css
+++ b/packages/cli/test/cases/build.config.optimization-default/fixtures/expected.css
@@ -70,6 +70,8 @@ h1{background-image:url('/foo/bar.baz')}
 
 :dir(rtl){background-color:red}
 
+:host(h1){color:red}
+
 ::slotted(.content){background-color:aqua}
 
 h2 ::slotted(span){background:silver}

--- a/packages/cli/test/cases/build.config.optimization-default/fixtures/expected.css
+++ b/packages/cli/test/cases/build.config.optimization-default/fixtures/expected.css
@@ -65,3 +65,15 @@ h1:has(+h2){margin:0 0 0.25rem 0}
 h1{background-image:url('/foo/bar.baz')}
 
 .has-success{background-image:url('data:image/svg+xml;...')}
+
+:where(html){--size-000:-.5rem}
+
+:dir(rtl){background-color:red}
+
+::slotted(.content){background-color:aqua}
+
+h2 ::slotted(span){background:silver}
+
+tabbed-custom-element::part(tab){color:#0c0dcc;border-bottom:transparent solid 2px;}
+
+::highlight(rainbow-color-1){color:#ad26ad;text-decoration:underline;}

--- a/packages/cli/test/cases/build.config.optimization-default/src/styles/main.css
+++ b/packages/cli/test/cases/build.config.optimization-default/src/styles/main.css
@@ -132,7 +132,6 @@ h1:has(+ h2) {
   color: green;
 }
 
-
 .snippet {
   margin: var(--size-4) 0;
   padding: 0 var(--size-4);
@@ -142,6 +141,32 @@ h1 {
   background-image: url('/foo/bar.baz');
 }
 
-.has-success{
+.has-success {
   background-image: url("data:image/svg+xml;...");
+}
+
+:where(html) {
+  --size-000: -.5rem;
+}
+
+:dir(rtl) {
+  background-color: red;
+}
+
+::slotted(.content) {
+  background-color: aqua;
+}
+
+h2 ::slotted(span) {
+  background: silver;
+}
+
+tabbed-custom-element::part(tab) {
+  color: #0c0dcc;
+  border-bottom: transparent solid 2px;
+}
+
+::highlight(rainbow-color-1) {
+  color: #ad26ad;
+  text-decoration: underline;
 }

--- a/packages/cli/test/cases/build.config.optimization-default/src/styles/main.css
+++ b/packages/cli/test/cases/build.config.optimization-default/src/styles/main.css
@@ -153,6 +153,10 @@ h1 {
   background-color: red;
 }
 
+:host(h1) {
+  color: red;
+}
+
 ::slotted(.content) {
   background-color: aqua;
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1178 

## Summary of Changes
1. Adds support for bundling these missing [pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/)
    - `dir`
    - `host`
    - `where`
1. Adds support for bundling these missing [pseudo-elements](https://developer.mozilla.org/en-US/docs/Web/CSS/)
    - `::highlight`
    - `::part`
    - `::slotted`

## TODO
1. [x] bundling gets `:host { }` and `:host() { }` confused and adds unexpected parens `()`
    ```css
    :host(){--primary-color:#16f;--secondary-color:#ff7;}
    :host{--primary-color:#16f;--secondary-color:#ff7;}
    ```
    
----

> Opened a discussion about potentially adopting Lightning CSS in a 2.0 version - https://github.com/ProjectEvergreen/greenwood/discussions/1238