### PR TITLE
feature/issue 1232 static sitemap

### DIFF
--- a/packages/cli/src/plugins/copy/plugin-copy-sitemap.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-sitemap.js
@@ -1,0 +1,23 @@
+import { checkResourceExists } from '../../lib/resource-utils.js';
+
+const greenwoodPluginCopySitemap = [{
+  type: 'copy',
+  name: 'plugin-copy-sitemap',
+  provider: async (compilation) => {
+    const fileName = 'sitemap.xml';
+    const { outputDir, userWorkspace } = compilation.context;
+    const sitemapPathUrl = new URL(`./${fileName}`, userWorkspace);
+    const assets = [];
+
+    if (await checkResourceExists(sitemapPathUrl)) {
+      assets.push({
+        from: sitemapPathUrl,
+        to: new URL(`./${fileName}`, outputDir)
+      });
+    }
+
+    return assets;
+  }
+}];
+
+export { greenwoodPluginCopySitemap };

--- a/packages/cli/test/cases/build.default.meta-files/build.default.meta-files.spec.js
+++ b/packages/cli/test/cases/build.default.meta-files/build.default.meta-files.spec.js
@@ -71,6 +71,18 @@ describe('Build Greenwood With: ', function() {
         expect(robots.length).to.equal(1);
       });
     });
+
+    describe('Default output for project level sitemap.xml', function() {
+      let sitemaps;
+
+      before(async function() {
+        sitemaps = await glob(`${this.context.publicDir}/sitemap.xml`);
+      });
+
+      it('should have one sitemap.xml file in the output directory', function() {
+        expect(sitemaps.length).to.equal(1);
+      });
+    });
   });
 
   after(function() {

--- a/packages/cli/test/cases/build.default.meta-files/src/sitemap.xml
+++ b/packages/cli/test/cases/build.default.meta-files/src/sitemap.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.example.com/</loc>
+    <lastmod>2024-06-04T00:00:00Z</lastmod>
+    <priority>1.0</priority>
+  </url>
+
+  <url>
+    <loc>https://www.example.com/about/</loc>
+    <lastmod>2023-12-15T16:20:00Z</lastmod>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://www.example.com/contact/</loc>
+
+    <priority>0.5</priority>
+  </url>
+</urlset>

--- a/www/pages/docs/configuration.md
+++ b/www/pages/docs/configuration.md
@@ -270,7 +270,7 @@ export default {
 ```
 
 ### Workspace
-Path to where all your project files will be located.  Using an absolute path is recommended.
+Path to where all your project files will be located.  Using an absolute path is recommended.  Default is _src/_.
 
 #### Example
 
@@ -282,4 +282,4 @@ export default {
 };
 ```
 
-> Please note the trailing `/` here as for ESM, a path must end in a `/` for directories.
+> Please note the trailing `/` here as for ESM, as paths must end in a `/` for directories.

--- a/www/pages/docs/css-and-images.md
+++ b/www/pages/docs/css-and-images.md
@@ -110,3 +110,20 @@ customElements.define('x-header', HeaderComponent);
 >
 > customElements.define('x-header', HeaderComponent);
 > ```
+
+
+### Meta files
+
+The build includes a few [default copy plugins](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/cli/src/plugins/copy) for common meta files.   Typically, they support copying the files from the source directory to the build directory.
+
+* `plugin-copy-favicon.js` - copies favicon.ico.  NOTE:  Does not support multiple favicons.  For multiple support, use the manifest.json or make a custom plugin
+* `plugin-copy-manifest-json.js` - copies manifest.json
+* `plugin-copy-robots.js` - copies robots.txt
+* `plugin-copy-sitemap.js` - copies sitemap.xml
+
+If you need to generate these files dynamically, build a custom copy plugin.  The [build.default.meta-files.spec.js](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/cli/test/cases/build.default.meta-files/build.default.meta-files.spec.js) is a good example of how to test.  The test lifecycle is:
+
+* Read config
+* Build site using fixtures (fake files) in the test directory
+* Assert the copy executed properly
+

--- a/www/pages/docs/css-and-images.md
+++ b/www/pages/docs/css-and-images.md
@@ -112,18 +112,21 @@ customElements.define('x-header', HeaderComponent);
 > ```
 
 
-### Meta files
+### Meta Files
 
-The build includes a few [default copy plugins](https://github.com/ProjectEvergreen/greenwood/tree/master/packages/cli/src/plugins/copy) for common meta files.   Typically, they support copying the files from the source directory to the build directory.
+By default, Greenwood will automatically detect these "meta" files from the top-level of your [workspace directory](docs/configuration/#workspace) and automatically copy them over to the root of the build output directory.
 
-* `plugin-copy-favicon.js` - copies favicon.ico.  NOTE:  Does not support multiple favicons.  For multiple support, use the manifest.json or make a custom plugin
-* `plugin-copy-manifest-json.js` - copies manifest.json
-* `plugin-copy-robots.js` - copies robots.txt
-* `plugin-copy-sitemap.js` - copies sitemap.xml
+- _favicon.ico_
+- _robots.txt_
+- _sitemap.xml_
 
-If you need to generate these files dynamically, build a custom copy plugin.  The [build.default.meta-files.spec.js](https://github.com/ProjectEvergreen/greenwood/blob/master/packages/cli/test/cases/build.default.meta-files/build.default.meta-files.spec.js) is a good example of how to test.  The test lifecycle is:
+Example:
 
-* Read config
-* Build site using fixtures (fake files) in the test directory
-* Assert the copy executed properly
+```shell
+src/
+  favicon.ico
+  robots.txt
+  sitemap.xml
+```
 
+> If you need support for more custom copying of static files like this, please check out our docs on creating your own [copy plugin](plugins/copy/).


### PR DESCRIPTION


## Related Issue
#1232 - Static sitemap copy plugin

## Summary of Changes
Created a greenwood default copy plugin to copy a sitemap.xml from the source folder

1. [x] Created plugin
1. [x] Updated relevant spec file
1. [x] Provided example sitemap.xml
2. [x] Thought about documentation in configuration.md or plugins.md (Happy to help given direction)