### PR TITLE
bug/issue 1241 prerendering formatting breaks bundle mapping optimization

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -208,12 +208,12 @@ class StandardHtmlResource extends ResourceInterface {
 
     for (const pageResource of pageResources) {
       const keyedResource = this.compilation.resources.get(pageResource);
-      const { contents, src, type, optimizationAttr, optimizedFileContents, optimizedFileName, rawAttributes } = keyedResource;
+      const { contents, src, type, optimizationAttr, optimizedFileContents, optimizedFileName } = keyedResource;
 
       if (src) {
-        const tag = root.querySelectorAll('script').find(script => script.getAttribute('src') === src);
-
         if (type === 'script') {
+          const tag = root.querySelectorAll('script').find(script => script.getAttribute('src') === src);
+
           if (!optimizationAttr && optimization === 'default') {
             const optimizedFilePath = `${basePath}/${optimizedFileName}`;
 
@@ -223,18 +223,19 @@ class StandardHtmlResource extends ResourceInterface {
               <link rel="modulepreload" href="${optimizedFilePath}" as="script">
             `);
           } else if (optimizationAttr === 'inline' || optimization === 'inline') {
-            const isModule = rawAttributes.indexOf('type="module') >= 0 ? ' type="module"' : '';
+            const isModule = tag.rawAttrs.indexOf('type="module') >= 0 ? ' type="module"' : '';
 
-            body = body.replace(`<script ${rawAttributes}></script>`, `
+            body = body.replace(`<script ${tag.rawAttrs}></script>`, `
               <script ${isModule}>
                 ${optimizedFileContents.replace(/\.\//g, `${basePath}/`).replace(/\$/g, '$$$')}
               </script>
             `);
           } else if (optimizationAttr === 'static' || optimization === 'static') {
-            // TODO could we not get these rawAttrs pre-formatted in modelResource the first time???
             body = body.replace(`<script ${tag.rawAttrs}></script>`, '');
           }
         } else if (type === 'link') {
+          const tag = root.querySelectorAll('link').find(link => link.getAttribute('href') === src);
+
           if (!optimizationAttr && (optimization !== 'none' && optimization !== 'inline')) {
             const optimizedFilePath = `${basePath}/${optimizedFileName}`;
 
@@ -248,11 +249,11 @@ class StandardHtmlResource extends ResourceInterface {
             // when pre-rendering, puppeteer normalizes everything to <link .../>
             // but if not using pre-rendering, then it could come out as <link ...></link>
             // not great, but best we can do for now until #742
-            body = body.replace(`<link ${rawAttributes}>`, `
+            body = body.replace(`<link ${tag.rawAttrs}>`, `
               <style>
                 ${optimizedFileContents}
               </style>
-            `).replace(`<link ${rawAttributes}/>`, `
+            `).replace(`<link ${tag.rawAttrs}/>`, `
               <style>
                 ${optimizedFileContents}
               </style>
@@ -261,8 +262,10 @@ class StandardHtmlResource extends ResourceInterface {
         }
       } else {
         if (type === 'script') {
+          const tag = root.querySelectorAll('script').find(script => script.innerHTML === contents);
+
           if (optimizationAttr === 'static' || optimization === 'static') {
-            body = body.replace(`<script ${rawAttributes}>${contents.replace(/\.\//g, '/').replace(/\$/g, '$$$')}</script>`, '');
+            body = body.replace(`<script ${tag.rawAttrs}>${contents.replace(/\.\//g, '/').replace(/\$/g, '$$$')}</script>`, '');
           } else if (optimizationAttr === 'none') {
             body = body.replace(contents, contents.replace(/\.\//g, `${basePath}/`).replace(/\$/g, '$$$'));
           } else {

--- a/packages/cli/test/cases/build.config.optimization-overrides/greenwood.config.js
+++ b/packages/cli/test/cases/build.config.optimization-overrides/greenwood.config.js
@@ -1,0 +1,5 @@
+// https://github.com/ProjectEvergreen/greenwood/issues/1241
+// to ensure formatting does not break bundle optimization linking
+export default {
+  prerender: true
+};

--- a/packages/cli/test/cases/build.config.optimization-overrides/src/pages/index.html
+++ b/packages/cli/test/cases/build.config.optimization-overrides/src/pages/index.html
@@ -2,8 +2,12 @@
 <html lang="en" prefix="og:http://ogp.me/ns#">
 
   <head>
-    <script type="module" src="/components/header.js" data-gwd-opt="static"></script>
     <script type="module" src="/components/footer.js" data-gwd-opt="inline"></script>
+    <script
+      type="module"
+      src="../components/header.js"
+      data-gwd-opt="static"
+    ></script>
     <link rel="stylesheet" href="/styles/theme.css" data-gwd-opt="inline"/>
   </head>
 

--- a/packages/cli/test/cases/build.config.optimization-overrides/src/pages/index.html
+++ b/packages/cli/test/cases/build.config.optimization-overrides/src/pages/index.html
@@ -8,7 +8,17 @@
       src="../components/header.js"
       data-gwd-opt="static"
     ></script>
-    <link rel="stylesheet" href="/styles/theme.css" data-gwd-opt="inline"/>
+    <link
+      rel="stylesheet"
+      href="/styles/theme.css"
+      data-gwd-opt="inline"
+    />
+    <script
+      data-gwd-opt="static"
+      type="module"
+    >
+      console.log('I should not be here');
+    </script>
   </head>
 
   <body>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1241 

## Summary of Changes
1. refactor bundle mapping for `<script>`, `<link>` and `<style>` tags
1. Validated through a test case

## TODO
1. [x] finish script bundle mapping
1. [x] style bundle mapping refactoring
1. [x] link bundle mapping refactoring
1. [x] open up an issue tracking a more programmatic way to do this throughout greenwood - already existed, so added there
1. [x] can we solve this in `modelResource`? - issue is that `modelResource` happens before any prerendering, so won't be formatted in time 😞 