### PR TITLE
bug/issue 1234 refine  spa local dev routing for html requests

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -27,12 +27,12 @@ class StandardHtmlResource extends ResourceInterface {
     this.contentType = 'text/html';
   }
 
-  async shouldServe(url) {
+  async shouldServe(url, request) {
     const { protocol, pathname } = url;
     const hasMatchingPageRoute = this.compilation.graph.find(node => node.route === pathname);
     const isSPA = this.compilation.graph.find(node => node.isSPA) && pathname.indexOf('.') < 0;
 
-    return protocol.startsWith('http') && (hasMatchingPageRoute || isSPA);
+    return protocol.startsWith('http') && (hasMatchingPageRoute || (isSPA && request.headers.get('Accept').indexOf('text/html') >= 0));
   }
 
   async serve(url, request) {

--- a/packages/cli/test/cases/develop.spa/develop.spa.spec.js
+++ b/packages/cli/test/cases/develop.spa/develop.spa.spec.js
@@ -77,7 +77,7 @@ describe('Develop Greenwood With: ', function() {
       let body;
 
       before(async function() {
-        response = await fetch(`${hostname}:${port}/`);
+        response = await fetch(`${hostname}:${port}/`, { headers: { 'Accept': 'text/html' } });
         body = await response.clone().text();
       });
 
@@ -103,7 +103,7 @@ describe('Develop Greenwood With: ', function() {
       let body;
 
       before(async function() {
-        response = await fetch(`http://127.0.0.1:${port}/artists/`);
+        response = await fetch(`http://127.0.0.1:${port}/artists/`, { headers: { 'Accept': 'text/html' } });
         body = await response.clone().text();
       });
 
@@ -129,7 +129,7 @@ describe('Develop Greenwood With: ', function() {
       let body;
 
       before(async function() {
-        response = await fetch(`http://127.0.0.1:${port}/artists/1`);
+        response = await fetch(`http://127.0.0.1:${port}/artists/1`, { headers: { 'Accept': 'text/html' } });
         body = await response.clone().text();
       });
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #1234 

Observed in https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/98 that with the removal of the `break` in the linked PR, API routes were getting caught by the SPA handler during development

![Screenshot 2024-06-22 at 3 33 34 PM](https://github.com/ProjectEvergreen/greenwood/assets/895923/d6be362c-5b7e-4392-99ab-5243a00e55e5)
![Screenshot 2024-06-22 at 3 33 45 PM](https://github.com/ProjectEvergreen/greenwood/assets/895923/0745a791-6765-4373-9624-a7d05d82b2cc)

## Summary of Changes
1. Make sure SPA routes are actually HTML requests
1. Update test cases accordingly