### PR TITLE
enhancement/issue 923 real production import attributes

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -528,7 +528,7 @@ function greenwoodSyncImportAttributes(compilation) {
 }
 
 // TODO should rename this to something like getRollupConfigForBrowser
-const getRollupConfigForScriptResources = async (compilation) => {
+const getRollupConfigForBrowserScripts = async (compilation) => {
   const { outputDir } = compilation.context;
   const input = [...compilation.resources.values()]
     .filter(resource => resource.type === 'script')
@@ -588,7 +588,7 @@ const getRollupConfigForScriptResources = async (compilation) => {
   }];
 };
 
-const getRollupConfigForApis = async (compilation) => {
+const getRollupConfigForApiRoutes = async (compilation) => {
   const { outputDir, pagesDir, apisDir } = compilation.context;
 
   return [...compilation.manifest.apis.values()]
@@ -642,7 +642,7 @@ const getRollupConfigForApis = async (compilation) => {
     });
 };
 
-const getRollupConfigForSsr = async (compilation, input) => {
+const getRollupConfigForSsrPages = async (compilation, input) => {
   const { outputDir } = compilation.context;
 
   return input.map((filepath) => {
@@ -694,7 +694,7 @@ const getRollupConfigForSsr = async (compilation, input) => {
 };
 
 export {
-  getRollupConfigForApis,
-  getRollupConfigForScriptResources,
-  getRollupConfigForSsr
+  getRollupConfigForApiRoutes,
+  getRollupConfigForBrowserScripts,
+  getRollupConfigForSsrPages
 };

--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -424,6 +424,7 @@ function greenwoodImportMetaUrl(compilation) {
 // - sync externalized import attribute paths with bundled CSS paths
 function greenwoodSyncImportAttributes(compilation) {
   const unbundledAssetsRefMapper = {};
+  const { basePath } = compilation.config;
 
   return {
     name: 'greenwood-sync-import-attributes',
@@ -475,7 +476,7 @@ function greenwoodSyncImportAttributes(compilation) {
                 const ref = that.emitFile(emitConfig);
                 const importRef = `import.meta.ROLLUP_ASSET_URL_${ref}`;
 
-                bundles[bundle].code = bundles[bundle].code.replace(value, `/${importRef}`);
+                bundles[bundle].code = bundles[bundle].code.replace(value, `${basePath}/${importRef}`);
 
                 if (!unbundledAssetsRefMapper[emitConfig.name]) {
                   unbundledAssetsRefMapper[emitConfig.name] = {

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-depth, max-len */
 import fs from 'fs/promises';
-import { getRollupConfigForApis, getRollupConfigForScriptResources, getRollupConfigForSsr } from '../config/rollup.config.js';
+import { getRollupConfigForApiRoutes, getRollupConfigForBrowserScripts, getRollupConfigForSsrPages } from '../config/rollup.config.js';
 import { getAppLayout, getPageLayout, getUserScripts } from '../lib/layout-utils.js';
 import { hashString } from '../lib/hashing-utils.js';
 import { checkResourceExists, mergeResponse, normalizePathnameForWindows, trackResourcesForRoute } from '../lib/resource-utils.js';
@@ -216,7 +216,7 @@ async function bundleStyleResources(compilation, resourcePlugins) {
 
 async function bundleApiRoutes(compilation) {
   // https://rollupjs.org/guide/en/#differences-to-the-javascript-api
-  const apiConfigs = await getRollupConfigForApis(compilation);
+  const apiConfigs = await getRollupConfigForApiRoutes(compilation);
 
   if (apiConfigs.length > 0 && apiConfigs[0].input.length !== 0) {
     for (const configIndex in apiConfigs) {
@@ -314,7 +314,7 @@ async function bundleSsrPages(compilation, optimizePlugins) {
       input.push(normalizePathnameForWindows(entryFileUrl));
     }
 
-    const ssrConfigs = await getRollupConfigForSsr(compilation, input);
+    const ssrConfigs = await getRollupConfigForSsrPages(compilation, input);
 
     if (ssrConfigs.length > 0 && ssrConfigs[0].input !== '') {
       console.info('bundling dynamic pages...');
@@ -329,7 +329,7 @@ async function bundleSsrPages(compilation, optimizePlugins) {
 
 async function bundleScriptResources(compilation) {
   // https://rollupjs.org/guide/en/#differences-to-the-javascript-api
-  const [rollupConfig] = await getRollupConfigForScriptResources(compilation);
+  const [rollupConfig] = await getRollupConfigForBrowserScripts(compilation);
 
   if (rollupConfig.input.length !== 0) {
     const bundle = await rollup(rollupConfig);

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -353,10 +353,12 @@ const bundleCompilation = async (compilation) => {
 
       console.info('bundling static assets...');
 
+      // need styles bundled first for usage with import attributes syncing in Rollup
+      await bundleStyleResources(compilation, optimizeResourcePlugins);
+
       await Promise.all([
         await bundleApiRoutes(compilation),
-        await bundleScriptResources(compilation),
-        await bundleStyleResources(compilation, optimizeResourcePlugins)
+        await bundleScriptResources(compilation)
       ]);
 
       // bundleSsrPages depends on bundleScriptResources having run first

--- a/packages/cli/src/loader.js
+++ b/packages/cli/src/loader.js
@@ -7,6 +7,7 @@ const resourcePlugins = config.plugins
   .filter(plugin => plugin.name !== 'plugin-node-modules:resource' && plugin.name !== 'plugin-user-workspace')
   .map(plugin => plugin.provider({
     context: {
+      outputDir: new URL(`file://${process.cwd()}/public`), // TODO get from config
       projectDirectory: new URL(`file://${process.cwd()}/`),
       scratchDir: new URL(`file://${process.cwd()}/.greenwood/`)
     },

--- a/packages/cli/src/loader.js
+++ b/packages/cli/src/loader.js
@@ -7,7 +7,6 @@ const resourcePlugins = config.plugins
   .filter(plugin => plugin.name !== 'plugin-node-modules:resource' && plugin.name !== 'plugin-user-workspace')
   .map(plugin => plugin.provider({
     context: {
-      outputDir: new URL(`file://${process.cwd()}/public`), // TODO get from config
       projectDirectory: new URL(`file://${process.cwd()}/`),
       scratchDir: new URL(`file://${process.cwd()}/.greenwood/`)
     },

--- a/packages/cli/test/cases/loaders-build.import-attributes/loaders-build.import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-build.import-attributes/loaders-build.import-attributes.spec.js
@@ -53,17 +53,28 @@ describe('Build Greenwood With: ', function() {
       runner.runCommand(cliPath, 'build');
     });
 
-    describe('Importing CSS w/ Constructable Stylesheets', function() {
+    describe('Custom Element Importing CSS w/ Constructable Stylesheet', function() {
+      const cssFileHash = 'bcdce3a3';
       let scripts;
+      let styles;
 
       before(async function() {
         scripts = await glob.promise(path.join(outputPath, 'public/card.*.js'));
+        styles = await glob.promise(path.join(outputPath, `public/card.${cssFileHash}.css`));
       });
 
-      it('should have the expected output from importing hero.css as a Constructable Stylesheet', function() {
+      it('should have the expected import attribute for importing card.css as a Constructable Stylesheet in the card.js bundle', function() {
         const scriptContents = fs.readFileSync(scripts[0], 'utf-8');
 
-        expect(scriptContents).to.contain('import e from"/card.bcdce3a3.css"with{type:"css"}');
+        expect(scripts.length).to.equal(1);
+        expect(scriptContents).to.contain(`import e from"/card.${cssFileHash}.css"with{type:"css"}`);
+      });
+
+      it('should have the expected CSS output bundle for card.css', function() {
+        const styleContents = fs.readFileSync(styles[0], 'utf-8');
+
+        expect(styles.length).to.equal(1);
+        expect(styleContents).to.contain(':host {\n  color: red;\n}');
       });
     });
   });

--- a/packages/cli/test/cases/loaders-build.import-attributes/loaders-build.import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-build.import-attributes/loaders-build.import-attributes.spec.js
@@ -27,6 +27,7 @@ import fs from 'fs';
 import glob from 'glob-promise';
 import path from 'path';
 import { Runner } from 'gallinago';
+import { getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
@@ -62,16 +63,13 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected output from importing hero.css as a Constructable Stylesheet', function() {
         const scriptContents = fs.readFileSync(scripts[0], 'utf-8');
 
-        expect(scriptContents).to.contain('const e=new CSSStyleSheet;e.replaceSync(":host {   color: red; }");');
+        expect(scriptContents).to.contain('import e from"/card.bcdce3a3.css"with{type:"css"}');
       });
     });
   });
 
   after(function() {
     runner.stopCommand();
-    runner.teardown([
-      path.join(outputPath, '.greenwood'),
-      path.join(outputPath, 'node_modules')
-    ]);
+    runner.teardown(getOutputTeardownFiles(outputPath));
   });
 });

--- a/packages/cli/test/cases/loaders-build.prerender-import-attributes/loaders-build.prerender-import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-build.prerender-import-attributes/loaders-build.prerender-import-attributes.spec.js
@@ -57,19 +57,28 @@ describe('Build Greenwood With: ', function() {
 
     runSmokeTest(['public'], LABEL);
 
-    describe('Importing CSS w/ Constructable Stylesheets', function() {
+    describe('Custom Element Importing CSS w/ Constructable Stylesheet', function() {
+      const cssFileHash = '93e8cf36';
       let scripts;
+      let styles;
 
       before(async function() {
-        scripts = await glob.promise(path.join(this.context.publicDir, '*.js'));
+        scripts = await glob.promise(path.join(outputPath, 'public/hero.*.js'));
+        styles = await glob.promise(path.join(outputPath, `public/hero.${cssFileHash}.css`));
       });
 
-      // TODO is this actually the output we want here?
-      // https://github.com/ProjectEvergreen/greenwood/discussions/1216
-      it('should have the expected output from importing hero.css as a Constructable Stylesheet', function() {
+      it('should have the expected import attribute for importing hero.css as a Constructable Stylesheet in the hero.js bundle', function() {
         const scriptContents = fs.readFileSync(scripts[0], 'utf-8');
 
+        expect(scripts.length).to.equal(1);
         expect(scriptContents).to.contain('import e from"/hero.93e8cf36.css"with{type:"css"}');
+      });
+
+      it('should have the expected CSS output bundle for hero.css', function() {
+        const styleContents = fs.readFileSync(styles[0], 'utf-8');
+
+        expect(styles.length).to.equal(1);
+        expect(styleContents).to.contain(':host {\n  text-align: center;');
       });
     });
 

--- a/packages/cli/test/cases/loaders-build.prerender-import-attributes/loaders-build.prerender-import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-build.prerender-import-attributes/loaders-build.prerender-import-attributes.spec.js
@@ -69,7 +69,7 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected output from importing hero.css as a Constructable Stylesheet', function() {
         const scriptContents = fs.readFileSync(scripts[0], 'utf-8');
 
-        expect(scriptContents).to.contain('const t=new CSSStyleSheet;t.replaceSync(":host {   text-align: center');
+        expect(scriptContents).to.contain('import e from"/hero.93e8cf36.css"with{type:"css"}');
       });
     });
 

--- a/packages/cli/test/cases/loaders-serve.default.ssr-import-attributes/loaders-serve.default.ssr-import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-serve.default.ssr-import-attributes/loaders-serve.default.ssr-import-attributes.spec.js
@@ -30,6 +30,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { Runner } from 'gallinago';
+import { getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { fileURLToPath, URL } from 'url';
 
 const expect = chai.expect;
@@ -159,9 +160,6 @@ describe('Serve Greenwood With: ', function() {
 
   after(function() {
     runner.stopCommand();
-    runner.teardown([
-      path.join(outputPath, '.greenwood'),
-      path.join(outputPath, 'node_modules')
-    ]);
+    runner.teardown(getOutputTeardownFiles(outputPath));
   });
 });

--- a/packages/plugin-import-raw/test/cases/build.matchers/build.matchers.spec.js
+++ b/packages/plugin-import-raw/test/cases/build.matchers/build.matchers.spec.js
@@ -39,7 +39,7 @@ import { fileURLToPath, URL } from 'url';
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
-  const LABEL = 'Import Raw Plugin with default options';
+  const LABEL = 'Import Raw Plugin with matchers configuration';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;

--- a/packages/plugin-import-raw/test/cases/default/default.spec.js
+++ b/packages/plugin-import-raw/test/cases/default/default.spec.js
@@ -71,7 +71,7 @@ describe('Build Greenwood With: ', function() {
         const contents = fs.readFileSync(scripts[0], 'utf-8');
 
         // TODO minify CSS-in-JS?
-        expect(contents).to.contain('import from styles.css: p {   color: red; }"');
+        expect(contents).to.contain('import from styles.css: ${s}');
       });
     });
   });

--- a/packages/plugin-import-raw/test/cases/default/default.spec.js
+++ b/packages/plugin-import-raw/test/cases/default/default.spec.js
@@ -70,8 +70,7 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected output from importing styles.css in main.js', function() {
         const contents = fs.readFileSync(scripts[0], 'utf-8');
 
-        // TODO minify CSS-in-JS?
-        expect(contents).to.contain('import from styles.css: ${s}');
+        expect(contents).to.contain('import from styles.css: p {   color: red; }');
       });
     });
   });

--- a/packages/plugin-import-raw/test/cases/default/greenwood.config.js
+++ b/packages/plugin-import-raw/test/cases/default/greenwood.config.js
@@ -1,7 +1,6 @@
 import { greenwoodPluginImportRaw } from '../../../src/index.js';
 
 export default {
-
   plugins: [
     greenwoodPluginImportRaw()
   ]

--- a/www/pages/docs/css-and-images.md
+++ b/www/pages/docs/css-and-images.md
@@ -7,10 +7,12 @@ linkheadings: 3
 ---
 
 ## Styles and Assets
+
 **Greenwood** generally does not have any opinion on how you structure your site, aside from the pre-determined _pages/_ and (optional) _layouts/_ directories.  It supports all standard files that you can open in a web browser.
 
 
 ### Styles
+
 Styles can be done in any standards compliant way that will work in a browser.  So just as in HTML, you can do anything you need like below:
 
 ```html
@@ -30,7 +32,7 @@ Styles can be done in any standards compliant way that will work in a browser.  
       }
     </style>
 
-    <link rel="stylesheet" href="/styles/some-page.css"/>
+    <link rel="stylesheet" href="/styles/theme.css"/>
   </head>
 
   <body>
@@ -41,6 +43,38 @@ Styles can be done in any standards compliant way that will work in a browser.  
 ```
 
 > _In the above example, Greenwood will also bundle any `url` references in your CSS automatically._
+
+### Import Attributes
+
+[Import Attributes](https://github.com/tc39/proposal-import-attributes) with [Constructable Stylesheets and `adoptedStyleSheets`](https://web.dev/articles/constructable-stylesheets) are of course supported.  This can allow you to share styles across both Light and Shadow DOM boundaries.
+
+```js
+import themeSheet from '../styles/theme.css' with { type: 'css' };
+import cardSheet from './card.css' with { type: 'css' }
+
+export default class Card extends HTMLElement {
+  connectedCallback() {
+    if (!this.shadowRoot) {
+      const name = this.getAttribute('name') || 'World';
+      const template = document.createElement('template');
+
+      template.innerHTML = `
+        <div class="card">
+          <h2>Hello, ${name}!</h2>
+        </div>
+      `;
+
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
+
+    this.shadowRoot.adoptedStyleSheets = [themeSheet, cardSheet];
+  }
+}
+
+customElements.define('x-card', Card);
+```
+
 
 ### Assets
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#923 / #1216 

> See a prototype here - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/74

## Summary of Changes
1. Support "real" import attributes for production browser bundles
1. Add documentation

> This is mainly a breaking change to plugins.

## TODOs
1. [x] get all test cases back to passing for SSR bundles
1. [x] website not bundling correctly on `?type=raw` resources in a production build
    <details>
      ![Screenshot 2024-07-20 at 9 38 58 AM](https://github.com/user-attachments/assets/cb425532-7ce7-4dfa-88bc-69ba0a4656a4)
    </details>
1. [x] smoke this and #1258 with downstreams
    - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/74/commits/329a2d8d3bd02d43a580bc94b6f81e535dcd537f
    - https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/98/commits/6dd2ddd3c11e3e3c28c71b3d7ecfe86e4ce0dfc2
1. [x] update tests for new behavior for browser bundles 
    -  ~~`import` instead of "raw" CSS~~
    - test for output file bundles now (no more in lining / import ref mapping)
1. [x] need to handle inline optimization bundle mapping edge case (see https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/98)
1. [x] should rename this to something like `getRollupConfigForBrowser`
1. [x] clean up console logging / commented out code / add clarifying comments to _rollup.config.js_
1. [x] documentation updates with an example of Constructable Stylesheets in styles and assets section
1. [x] update https://github.com/ProjectEvergreen/greenwood/discussions/1216#discussioncomment-10035297 with the latest state of this implementation - https://github.com/ProjectEvergreen/greenwood/discussions/1216#discussioncomment-10137489
1. [x] handle `basePath`
1. [ ] how to exclude _module.css_? (nice to have)