### PR TITLE
feat(cli): #1232 dynamic sitemap generation

### DIFF
--- a/packages/cli/src/plugins/copy/plugin-copy-sitemap.js
+++ b/packages/cli/src/plugins/copy/plugin-copy-sitemap.js
@@ -1,4 +1,5 @@
 import { checkResourceExists } from "../../lib/resource-utils.js";
+import fs from "node:fs/promises";
 
 const greenwoodPluginCopySitemap = [
   {
@@ -6,13 +7,27 @@ const greenwoodPluginCopySitemap = [
     name: "plugin-copy-sitemap",
     provider: async (compilation) => {
       const fileName = "sitemap.xml";
-      const { outputDir, userWorkspace } = compilation.context;
+      const { outputDir, scratchDir, userWorkspace } = compilation.context;
       const sitemapPathUrl = new URL(`./${fileName}`, userWorkspace);
+      const sitemapModuleUrl = new URL(`./${fileName}.js`, userWorkspace);
       const assets = [];
 
       if (await checkResourceExists(sitemapPathUrl)) {
         assets.push({
           from: sitemapPathUrl,
+          to: new URL(`./${fileName}`, outputDir),
+        });
+      } else if (await checkResourceExists(sitemapModuleUrl)) {
+        // generate a dynamic sitemap from the user's sitemap.xml.js module
+        // https://github.com/ProjectEvergreen/greenwood/issues/1232
+        const { generateSitemap } = await import(sitemapModuleUrl.href);
+        const sitemap = await generateSitemap(compilation);
+        const sitemapScratchUrl = new URL(`./${fileName}`, scratchDir);
+
+        await fs.writeFile(sitemapScratchUrl, sitemap, "utf-8");
+
+        assets.push({
+          from: sitemapScratchUrl,
           to: new URL(`./${fileName}`, outputDir),
         });
       }

--- a/packages/cli/src/plugins/resource/plugin-resource-sitemap.js
+++ b/packages/cli/src/plugins/resource/plugin-resource-sitemap.js
@@ -1,0 +1,39 @@
+import { checkResourceExists } from "../../lib/resource-utils.js";
+
+class SitemapResource {
+  constructor(compilation) {
+    this.compilation = compilation;
+    this.contentType = "text/xml";
+  }
+
+  async shouldServe(url) {
+    const { userWorkspace } = this.compilation.context;
+
+    return (
+      url.pathname === "/sitemap.xml" &&
+      (await checkResourceExists(new URL("./sitemap.xml.js", userWorkspace)))
+    );
+  }
+
+  async serve() {
+    const { userWorkspace } = this.compilation.context;
+    // generate a dynamic sitemap from the user's sitemap.xml.js module
+    // https://github.com/ProjectEvergreen/greenwood/issues/1232
+    const { generateSitemap } = await import(new URL("./sitemap.xml.js", userWorkspace).href);
+    const body = await generateSitemap(this.compilation);
+
+    return new Response(body, {
+      headers: new Headers({
+        "Content-Type": this.contentType,
+      }),
+    });
+  }
+}
+
+const greenwoodPluginResourceSitemap = {
+  type: "resource",
+  name: "plugin-resource-sitemap",
+  provider: (compilation) => new SitemapResource(compilation),
+};
+
+export { greenwoodPluginResourceSitemap };

--- a/packages/cli/test/cases/build.default.sitemap-dynamic/build.default.sitemap-dynamic.spec.js
+++ b/packages/cli/test/cases/build.default.sitemap-dynamic/build.default.sitemap-dynamic.spec.js
@@ -1,0 +1,77 @@
+/*
+ * Use Case
+ * Run Greenwood build command with a dynamic sitemap module (src/sitemap.xml.js) and no static
+ * sitemap.xml file in the workspace.
+ *
+ * User Result
+ * Should generate a Greenwood build with a sitemap.xml in the output directory, generated from
+ * the generateSitemap export of the user's sitemap.xml.js module.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * (default)
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     about.html
+ *     index.html
+ *   sitemap.xml.js
+ */
+
+// https://github.com/ProjectEvergreen/greenwood/issues/1232
+import fs from "node:fs/promises";
+import { expect } from "chai";
+import path from "node:path";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Build Greenwood With: ", function () {
+  const LABEL = "Default Greenwood Configuration and Workspace with a dynamic sitemap module";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+    });
+
+    runSmokeTest(["public", "index"], LABEL);
+
+    describe("Dynamic sitemap.xml output", function () {
+      let sitemap;
+
+      before(async function () {
+        sitemap = await fs.readFile(path.resolve(this.context.publicDir, "./sitemap.xml"), "utf-8");
+      });
+
+      it("should generate a well formed sitemap document", function () {
+        expect(sitemap).to.contain('<?xml version="1.0" encoding="UTF-8"?>');
+        expect(sitemap).to.contain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+        expect(sitemap).to.contain("</urlset>");
+      });
+
+      it("should have a url entry for each page in the graph", function () {
+        expect(sitemap).to.contain("<loc>http://www.example.com/</loc>");
+        expect(sitemap).to.contain("<loc>http://www.example.com/about/</loc>");
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/cli/test/cases/build.default.sitemap-dynamic/package.json
+++ b/packages/cli/test/cases/build.default.sitemap-dynamic/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/cli/test/cases/build.default.sitemap-dynamic/src/pages/about.html
+++ b/packages/cli/test/cases/build.default.sitemap-dynamic/src/pages/about.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>About</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/build.default.sitemap-dynamic/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.sitemap-dynamic/src/pages/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>Home</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/build.default.sitemap-dynamic/src/sitemap.xml.js
+++ b/packages/cli/test/cases/build.default.sitemap-dynamic/src/sitemap.xml.js
@@ -1,0 +1,15 @@
+async function generateSitemap(compilation) {
+  const urls = compilation.graph.map((page) => {
+    return `    <url>
+      <loc>http://www.example.com${page.route}</loc>
+    </url>`;
+  });
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join("\n")}
+</urlset>
+`;
+}
+
+export { generateSitemap };

--- a/packages/cli/test/cases/develop.default.sitemap-dynamic/develop.default.sitemap-dynamic.spec.js
+++ b/packages/cli/test/cases/develop.default.sitemap-dynamic/develop.default.sitemap-dynamic.spec.js
@@ -1,0 +1,99 @@
+/*
+ * Use Case
+ * Run Greenwood develop command with a dynamic sitemap module (src/sitemap.xml.js) in the
+ * workspace.
+ *
+ * User Result
+ * Should start the development server and serve /sitemap.xml generated from the generateSitemap
+ * export of the user's sitemap.xml.js module.
+ *
+ * User Command
+ * greenwood develop
+ *
+ * User Config
+ * (default)
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     about.html
+ *     index.html
+ *   sitemap.xml.js
+ */
+
+// https://github.com/ProjectEvergreen/greenwood/issues/1232
+import { expect } from "chai";
+import path from "node:path";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Develop Greenwood With: ", function () {
+  const LABEL = "Default Greenwood Configuration and Workspace with a dynamic sitemap module";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  const hostname = "http://localhost";
+  const port = 1984;
+  let runner;
+
+  before(function () {
+    this.context = {
+      hostname: `${hostname}:${port}`,
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+
+      await new Promise((resolve, reject) => {
+        runner
+          .runCommand(cliPath, "develop", {
+            onStdOut: (message) => {
+              if (
+                message.includes(`Started local development server at http://localhost:${port}`)
+              ) {
+                resolve();
+              }
+            },
+          })
+          .catch(reject);
+      });
+    });
+
+    describe("Serve request for the dynamic sitemap.xml", function () {
+      let response;
+      let body;
+
+      before(async function () {
+        response = await fetch(`${this.context.hostname}/sitemap.xml`);
+        body = await response.text();
+      });
+
+      it("should return a 200 status", function () {
+        expect(response.status).to.equal(200);
+      });
+
+      it("should return the correct content type", function () {
+        expect(response.headers.get("Content-Type")).to.equal("text/xml");
+      });
+
+      it("should return a well formed sitemap document", function () {
+        expect(body).to.contain('<?xml version="1.0" encoding="UTF-8"?>');
+        expect(body).to.contain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+        expect(body).to.contain("</urlset>");
+      });
+
+      it("should have a url entry for each page in the graph", function () {
+        expect(body).to.contain("<loc>http://www.example.com/</loc>");
+        expect(body).to.contain("<loc>http://www.example.com/about/</loc>");
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.stopCommand();
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/cli/test/cases/develop.default.sitemap-dynamic/package.json
+++ b/packages/cli/test/cases/develop.default.sitemap-dynamic/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/cli/test/cases/develop.default.sitemap-dynamic/src/pages/about.html
+++ b/packages/cli/test/cases/develop.default.sitemap-dynamic/src/pages/about.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>About</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/develop.default.sitemap-dynamic/src/pages/index.html
+++ b/packages/cli/test/cases/develop.default.sitemap-dynamic/src/pages/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>Home</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/develop.default.sitemap-dynamic/src/sitemap.xml.js
+++ b/packages/cli/test/cases/develop.default.sitemap-dynamic/src/sitemap.xml.js
@@ -1,0 +1,15 @@
+async function generateSitemap(compilation) {
+  const urls = compilation.graph.map((page) => {
+    return `    <url>
+      <loc>http://www.example.com${page.route}</loc>
+    </url>`;
+  });
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join("\n")}
+</urlset>
+`;
+}
+
+export { generateSitemap };


### PR DESCRIPTION
Continuing work on https://github.com/ProjectEvergreen/greenwood/pull/1245 — reworked and rebased onto current master (July 2026).

## Related Issue

Resolves #1232

## Documentation

If the approach looks right, I'll add a docs section for `sitemap.xml.js` / `generateSitemap(compilation)` alongside the existing static sitemap docs.

## Summary of Changes

1. [x] `packages/cli/src/plugins/copy/plugin-copy-sitemap.js`: when no static `src/sitemap.xml` exists and the workspace has a `src/sitemap.xml.js` module, write its `generateSitemap(compilation)` output to the scratch dir and copy it to the output. The static file wins when both exist, so existing projects are unaffected.
2. [x] `packages/cli/src/plugins/resource/plugin-resource-sitemap.js` (new): serves `/sitemap.xml` from the same `generateSitemap` hook during `greenwood develop`.
3. [x] Tests, modeled on current test case conventions:
   - `packages/cli/test/cases/build.default.sitemap-dynamic/` — build emits the generated `sitemap.xml` with a `<loc>` per page in the graph
   - `packages/cli/test/cases/develop.default.sitemap-dynamic/` — dev server serves the generated `/sitemap.xml` as `text/xml`

### Changes from the previous revision

- Dropped the adapter-based approach per review — everything is in the out-of-the-box copy/resource plugins now.
- Reconciled with the static sitemap support that landed in #1240 (static copy behavior unchanged).
- `generateSitemap(compilation)` remains the user hook: Greenwood hands over the compilation and the user maps `compilation.graph` to XML. Pages generated via dynamic routing / `getStaticPaths` appear in the graph like any other page, so they flow into the sitemap with no extra API.
