### PR TITLE
docs/fix syntax highlighting language

### DIFF
--- a/www/pages/plugins/adapter.md
+++ b/www/pages/plugins/adapter.md
@@ -37,7 +37,7 @@ export {
 ## Build Output
 
 To provide a starting point, let's look at how Greenwood builds and outputs SSR pages and API routes.  Given this project structure
-```sh
+```shell
 src/
   api/
     greeting.js


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

https://github.com/ProjectEvergreen/greenwood/pull/1122

Got the syntax highlighting wrong, which is showing up in the build (though not breaking it)
```shell
Error: Unknown language: `sh` is not registered
    at Refractor.highlight (/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/refractor/core.js:115:13)
    at visitor (/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/@mapbox/rehype-prism/index.js:30:26)
    at overload (/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/unist-util-visit/index.js:27:12)
    at node (/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/unist-util-visit-parents/index.js:51:27)
    at children (/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/unist-util-visit-parents/index.js:77:42)
    at node (/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/unist-util-visit-parents/index.js:62:28)
    at children (/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/unist-util-visit-parents/index.js:77:42)
    at node (/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/unist-util-visit-parents/index.js:62:28)
    at visitParents (/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/unist-util-visit-parents/index.js:27:22)
    at visit (/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/unist-util-visit/index.js:22:3)
prerendering complete for page /plugins/adapter/.
```

## Summary of Changes
1. fix it