### PR TITLE
bug/issue 1257 refine standard CSS plugin intercepting

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -530,8 +530,8 @@ function greenwoodSyncImportAttributes(compilation) {
               // since we can't do async work inside a sync AST operation
               if (!asset.preBundled) {
                 const assetUrl = unbundledAssetsRefMapper[asset].sourceURL;
-                const request = new Request(assetUrl, { headers: { 'Content-Type': 'text/css' } });
-                let response = new Response(unbundledAssetsRefMapper[asset].source);
+                const request = new Request(assetUrl, { headers: { 'Accept': 'text/css' } });
+                let response = new Response(unbundledAssetsRefMapper[asset].source, { headers: { 'Content-Type': 'text/css' } });
 
                 for (const plugin of resourcePlugins) {
                   if (plugin.shouldPreIntercept && await plugin.shouldPreIntercept(assetUrl, request, response.clone())) {

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -306,11 +306,13 @@ class StandardCssResource extends ResourceInterface {
     });
   }
 
-  async shouldIntercept(url) {
+  async shouldIntercept(url, request, response) {
     const { pathname } = url;
     const ext = pathname.split('.').pop();
 
-    return url.protocol === 'file:' && ext === this.extensions[0];
+    return url.protocol === 'file:'
+      && ext === this.extensions[0]
+      && (response.headers.get('Content-Type')?.indexOf('text/css') >= 0 || request.headers.get('Accept')?.indexOf('text/javascript') >= 0);
   }
 
   async intercept(url, request, response) {

--- a/packages/cli/test/cases/loaders-build.prerender-import-attributes/src/components/hero/hero.js
+++ b/packages/cli/test/cases/loaders-build.prerender-import-attributes/src/components/hero/hero.js
@@ -29,11 +29,6 @@ export default class HeroBanner extends HTMLElement {
     }
 
     this.shadowRoot.adoptedStyleSheets = [sheet];
-    // TODO upstream to WCC?
-    // this.shadowRoot.querySelectorAll('button')
-    //   .forEach(button => {
-    //     button.addEventListener('click', () => this.clickButton(button))
-    //   });
   }
 }
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#1257 / #1258 

Noticed in the [website project](https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/76) that CSS module scripts were getting treated as standard CSS files
```sh
Parse error: Identifier is expected
1 |export default {"footer":"footer-257057953-footer","logo":"footer-257057953-logo","socialTray":"fo…
-----------------------^
^C
```

## Summary of Changes
1. Improve "guard" for only standard CSS resources before intercepting in Greenwood's standards CSS plugin

## TODO
1. [ ] ~~Should probably add a test case for this~~ - this will be easier to reproduce as part of #1233 