### PR TITLE
enhancement/issue 955 support multiple custom page formats at once

### DIFF
--- a/packages/cli/test/cases/loaders-build.plugins.resource-page/greenwood.config.js
+++ b/packages/cli/test/cases/loaders-build.plugins.resource-page/greenwood.config.js
@@ -27,6 +27,33 @@ class FooResource {
   }
 }
 
+class BarResource {
+  constructor(compilation, options) {
+    this.compilation = compilation;
+    this.options = options;
+    this.servePage = options.servePage;
+
+    this.extensions = ['bar'];
+    this.contentType = 'text/javascript';
+  }
+
+  async shouldServe(url) {
+    return url.pathname.split('.').pop() === this.extensions[0] && this.servePage;
+  }
+
+  async serve(url) {
+    let body = await fs.readFile(url, 'utf-8');
+
+    body = body.replace(/interface (.*){(.*)}/s, '');
+
+    return new Response(body, {
+      headers: new Headers({
+        'Content-Type': this.contentType
+      })
+    });
+  }
+}
+
 const greenwoodPluginFooResource = (options = {}) => {
   return [{
     type: 'resource',
@@ -35,10 +62,21 @@ const greenwoodPluginFooResource = (options = {}) => {
   }];
 };
 
+const greenwoodPluginBarResource = (options = {}) => {
+  return [{
+    type: 'resource',
+    name: 'plugin-import-bar:resource',
+    provider: (compilation) => new BarResource(compilation, options)
+  }];
+};
+
 export default {
   plugins: [
     greenwoodPluginFooResource({
       servePage: 'static'
+    }),
+    greenwoodPluginBarResource({
+      servePage: 'dynamic'
     })
   ]
 };

--- a/packages/cli/test/cases/loaders-build.plugins.resource-page/greenwood.config.js
+++ b/packages/cli/test/cases/loaders-build.plugins.resource-page/greenwood.config.js
@@ -7,7 +7,7 @@ class FooResource {
     this.servePage = options.servePage;
 
     this.extensions = ['foo'];
-    this.contentType = 'text/javascript';
+    this.contentType = 'text/html';
   }
 
   async shouldServe(url) {
@@ -15,9 +15,7 @@ class FooResource {
   }
 
   async serve(url) {
-    let body = await fs.readFile(url, 'utf-8');
-
-    body = body.replace(/interface (.*){(.*)}/s, '');
+    const body = await fs.readFile(url, 'utf-8');
 
     return new Response(body, {
       headers: new Headers({
@@ -44,7 +42,7 @@ class BarResource {
   async serve(url) {
     let body = await fs.readFile(url, 'utf-8');
 
-    body = body.replace(/interface (.*){(.*)}/s, '');
+    body = body.replace(/interface (.*){(.*)}/, '');
 
     return new Response(body, {
       headers: new Headers({

--- a/packages/cli/test/cases/loaders-build.plugins.resource-page/loaders-build.plugins.resource-page.spec.js
+++ b/packages/cli/test/cases/loaders-build.plugins.resource-page/loaders-build.plugins.resource-page.spec.js
@@ -1,9 +1,9 @@
 /*
  * Use Case
- * Run Greenwood with a custom resource plugin and default workspace with a custom page format.
+ * Run Greenwood with a custom resource plugin and default workspace with a custom page formats.
  *
  * User Result
- * Should generate a bare bones Greenwood build with expected custom file (.foo) behavior.
+ * Should generate a bare bones Greenwood build with expected custom page format behaviors.
  *
  * User Command
  * greenwood build
@@ -32,6 +32,8 @@
  * Custom Workspace
  * src/
  *   pages/
+ *     api
+ *       greeting.bar
  *     about.foo
  *     contact.bar
  *     index.html
@@ -47,7 +49,7 @@ import { fileURLToPath, URL } from 'url';
 const expect = chai.expect;
 
 describe('Build Greenwood With: ', function() {
-  const LABEL = 'Custom FooResource Plugin and Default Workspace';
+  const LABEL = 'Custom Static and Dynamic Page Loaders';
   const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
   const outputPath = fileURLToPath(new URL('.', import.meta.url));
   let runner;
@@ -115,7 +117,21 @@ describe('Build Greenwood With: ', function() {
       });
     });
 
-    // TODO test an API route with a dynamic format plugin
+    describe('Custom Format Dynamic API Route', function() {
+      let handler;
+
+      before(async function() {
+        handler = (await import(new URL('./public/api/greeting.js', import.meta.url))).handler;
+      });
+
+      it('should have the expected output from the API route', async function() {
+        const response = await handler(new Request(new URL('http://localhost:8080/api/greeting')));
+        const data = await response.json();
+
+        expect(data.message).to.equal('Hello World!!!');
+      });
+
+    });
   });
 
   after(function() {

--- a/packages/cli/test/cases/loaders-build.plugins.resource-page/loaders-build.plugins.resource-page.spec.js
+++ b/packages/cli/test/cases/loaders-build.plugins.resource-page/loaders-build.plugins.resource-page.spec.js
@@ -13,11 +13,19 @@
  *   // see complete implementation in the greenwood.config.js file used for this spec
  * }
  *
+ * class BarResource extends ResourceInterface {
+ *   // see complete implementation in the greenwood.config.js file used for this spec
+ * }
+ *
  * {
  *   plugins: [{
  *     type: 'resource',
  *     name: 'plugin-foo',
  *     provider: (compilation, options) => new FooResource(compilation, options)
+ *   },{
+ *     type: 'resource',
+ *     name: 'plugin-bar',
+ *     provider: (compilation, options) => new BarResource(compilation, options)
  *   }]
  * }
  *
@@ -48,7 +56,7 @@ describe('Build Greenwood With: ', function() {
     this.context = {
       publicDir: path.join(outputPath, 'public')
     };
-    runner = new Runner();
+    runner = new Runner(false, true);
   });
 
   describe(LABEL, function() {
@@ -89,24 +97,25 @@ describe('Build Greenwood With: ', function() {
       });
     });
 
-    // TODO not sure why this was disabled, but should enable this test case
-    xdescribe('Custom Format Dynamic Contact Page', function() {
-      let aboutPage;
+    describe('Custom Format Dynamic Contact Page (exported with prerendering)', function() {
+      let contactPage;
 
       before(async function() {
-        aboutPage = await glob.promise(path.join(this.context.publicDir, 'contact.html'));
+        contactPage = await glob.promise(path.join(this.context.publicDir, 'contact/index.html'));
       });
 
-      it('should have the expected JavaScript equivalent file in the output directory', function() {
-        expect(aboutPage).to.have.lengthOf(1);
+      it('should have the expected pre-rendered HTML file in the output directory', function() {
+        expect(contactPage).to.have.lengthOf(1);
       });
 
-      it('should have expected text from from my-other-custom-file.foo in the script output file', function() {
-        const contents = fs.readFileSync(aboutPage[0], 'utf-8');
+      it('should have expected text from the output HTML file', function() {
+        const contents = fs.readFileSync(contactPage[0], 'utf-8');
 
-        expect(contents).to.contain('Welcome to our About page!');
+        expect(contents).to.contain('Welcome to our Contact page!');
       });
     });
+
+    // TODO test an API route with a dynamic format plugin
   });
 
   after(function() {

--- a/packages/cli/test/cases/loaders-build.plugins.resource-page/src/pages/api/greeting.bar
+++ b/packages/cli/test/cases/loaders-build.plugins.resource-page/src/pages/api/greeting.bar
@@ -1,0 +1,13 @@
+interface User { }
+
+export async function handler(request) {
+  const params = new URLSearchParams(request.url.slice(request.url.indexOf('?')));
+  const name = params.has('name') ? params.get('name') : 'World';
+  const body = { message: `Hello ${name}!!!` };
+
+  return new Response(JSON.stringify(body), {
+    headers: new Headers({
+      'Content-Type': 'application/json'
+    })
+  });
+}

--- a/packages/cli/test/cases/loaders-build.plugins.resource-page/src/pages/contact.bar
+++ b/packages/cli/test/cases/loaders-build.plugins.resource-page/src/pages/contact.bar
@@ -1,3 +1,5 @@
+interface User { }
+
 export default class ContactPage extends HTMLElement {
   connectedCallback() {
     this.innerHTML = `

--- a/packages/cli/test/cases/loaders-build.plugins.resource-page/src/pages/contact.bar
+++ b/packages/cli/test/cases/loaders-build.plugins.resource-page/src/pages/contact.bar
@@ -5,3 +5,5 @@ export default class ContactPage extends HTMLElement {
     `;
   }
 }
+
+export const prerender = true;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
carry over from #955

## Summary of Changes
1. Enable multiple simultaneous page formats in the graph (like if you wanted to do markdown _and_ typescript) and added test case
1. Added CLI test case for custom dynamic page routes and API routes

## TODO
1. [x] Confirm custom API format