### PR TITLE
enhancement/optimize graphql server for production builds

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -18,10 +18,10 @@
 
   "checkCoverage": true,
 
-  "statements": 80,
+  "statements": 75,
   "branches": 85,
   "functions": 85,
-  "lines": 80,
+  "lines": 75,
 
   "watermarks": {
     "statements": [75, 85],

--- a/packages/plugin-graphql/src/core/server.js
+++ b/packages/plugin-graphql/src/core/server.js
@@ -4,19 +4,26 @@ const graphqlServer = async (compilation) => {
   const { config, graph, context } = compilation;
   const { createSchema } = await import('../schema/schema.js');
   const { createCache } = await import('./cache.js');
+  // disable playground for production builds
+  const playground = process.env.__GWD_COMMAND__ === 'develop'
+    ? {
+        endpoint: '/graphql',
+        settings: {
+          'editor.theme': 'light'
+        }
+      }
+    : {};
 
   const server = new ApolloServer({
     schema: await createSchema(compilation),
-    playground: {
-      endpoint: '/graphql',
-      settings: {
-        'editor.theme': 'light'
-      }
-    },
+    playground,
+    introspection: process.env.__GWD_COMMAND__ === 'develop',
     context: async (integrationContext) => {
       const { req } = integrationContext;
 
-      if (req.query.q !== 'internal') {
+      // make sure to ignore introspection requests from being generated as an output cache file
+      // https://stackoverflow.com/a/58040379/417806
+      if (req.query.q !== 'internal' && req.body.operationName !== 'IntrospectionQuery') {
         await createCache(req, context);
       }
 

--- a/packages/plugin-graphql/src/core/server.js
+++ b/packages/plugin-graphql/src/core/server.js
@@ -2,22 +2,23 @@ import { ApolloServer } from 'apollo-server';
 
 const graphqlServer = async (compilation) => {
   const { config, graph, context } = compilation;
+  const isDev = process.env.__GWD_COMMAND__ === 'develop'; // eslint-disable-line no-underscore-dangle
   const { createSchema } = await import('../schema/schema.js');
   const { createCache } = await import('./cache.js');
   // disable playground for production builds
-  const playground = process.env.__GWD_COMMAND__ === 'develop'
-    ? {
-        endpoint: '/graphql',
-        settings: {
-          'editor.theme': 'light'
-        }
+  const playground = isDev ?
+    {
+      endpoint: '/graphql',
+      settings: {
+        'editor.theme': 'light'
       }
+    }
     : {};
 
   const server = new ApolloServer({
     schema: await createSchema(compilation),
     playground,
-    introspection: process.env.__GWD_COMMAND__ === 'develop',
+    introspection: isDev,
     context: async (integrationContext) => {
       const { req } = integrationContext;
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
N / A

Noticed that tests were intermittently failing due to an extra _-cache.json_ file being generated.  (i think maybe it was always there?)
```sh
1) Build Greenwood With: 
      Children from GraphQL
        Home Page output w/ ChildrenQuery
          should output a single (partial) *-cache.json file, one per each query made:

    AssertionError: expected [ Array(2) ] to have a length of 1 but got 2
    + expected - actual

    -2
    +1
    
    at Context.<anonymous> (file:///Users/owenbuckley/Desktop/greenwood/packages/plugin-graphql/test/cases/query-children/query-children.spec.js:171:97)
```

 Not really causing any harm, but extra work nonetheless, and threw off our tests.   Seems like an `IntrospectionQuery` is being run and causing the extra cache file to be generated, perhaps something only manifesting now since this introspection seems to happen on a polling interval?
```sh
➜  greenwood git:(enhancement/optimize-graphql-server-for-production) ✗ ls -l public/
total 272
-rw-r--r--  1 owenbuckley  staff    454 Sep  4 20:54 1689629932-cache.json
-rw-r--r--  1 owenbuckley  staff  29099 Sep  4 20:54 231435726-cache.json
-rw-r--r--  1 owenbuckley  staff   1008 Sep  4 20:54 404.html
-rw-r--r--  1 owenbuckley  staff    234 Sep  4 20:54 758806547.4ef0df00.js.map
drwxr-xr-x  4 owenbuckley  staff    128 Sep  4 20:54 blog
-rw-r--r--  1 owenbuckley  staff   2579 Sep  4 20:54 graph.json
-rw-r--r--  1 owenbuckley  staff   1878 Sep  4 20:54 index.html
-rw-r--r--  1 owenbuckley  staff     38 Sep  4 20:54 manifest.json
-rw-r--r--  1 owenbuckley  staff  16168 Sep  4 20:54 posts-list.1f790240.js
-rw-r--r--  1 owenbuckley  staff  43135 Sep  4 20:54 posts-list.1f790240.js.map
-rw-r--r--  1 owenbuckley  staff  19717 Sep  4 20:54 resources.json
```

<details>
  <pre>
    write cache {
      query: 'query IntrospectionQuery {\n' +
        '  __schema {\n' +
        '    queryType {\n' +
        '      name\n' +
        '    }\n' +
        '    mutationType {\n' +
        '      name\n' +
        '    }\n' +
        '    subscriptionType {\n' +
        '      name\n' +
        '    }\n' +
        '    types {\n' +
        '      ...FullType\n' +
        '    }\n' +
        '    directives {\n' +
        '      name\n' +
        '      description\n' +
        '      locations\n' +
        '      args {\n' +
        '        ...InputValue\n' +
        '      }\n' +
        '    }\n' +
        '  }\n' +
        '}\n' +
        '\n' +
        'fragment FullType on __Type {\n' +
        '  kind\n' +
        '  name\n' +
        '  description\n' +
        '  fields(includeDeprecated: true) {\n' +
        '    name\n' +
        '    description\n' +
        '    args {\n' +
        '      ...InputValue\n' +
        '    }\n' +
        '    type {\n' +
        '      ...TypeRef\n' +
        '    }\n' +
        '    isDeprecated\n' +
        '    deprecationReason\n' +
        '  }\n' +
        '  inputFields {\n' +
        '    ...InputValue\n' +
        '  }\n' +
        '  interfaces {\n' +
        '    ...TypeRef\n' +
        '  }\n' +
        '  enumValues(includeDeprecated: true) {\n' +
        '    name\n' +
        '    description\n' +
        '    isDeprecated\n' +
        '    deprecationReason\n' +
        '  }\n' +
        '  possibleTypes {\n' +
        '    ...TypeRef\n' +
        '  }\n' +
        '}\n' +
        '\n' +
        'fragment InputValue on __InputValue {\n' +
        '  name\n' +
        '  description\n' +
        '  type {\n' +
        '    ...TypeRef\n' +
        '  }\n' +
        '  defaultValue\n' +
        '}\n' +
        '\n' +
        'fragment TypeRef on __Type {\n' +
        '  kind\n' +
        '  name\n' +
        '  ofType {\n' +
        '    kind\n' +
        '    name\n' +
        '    ofType {\n' +
        '      kind\n' +
        '      name\n' +
        '      ofType {\n' +
        '        kind\n' +
        '        name\n' +
        '        ofType {\n' +
        '          kind\n' +
        '          name\n' +
        '          ofType {\n' +
        '            kind\n' +
        '            name\n' +
        '            ofType {\n' +
        '              kind\n' +
        '              name\n' +
        '              ofType {\n' +
        '                kind\n' +
        '                name\n' +
        '              }\n' +
        '            }\n' +
        '          }\n' +
        '        }\n' +
        '      }\n' +
        '    }\n' +
        '  }\n' +
        '}\n',
      variables: {}
    }
  </pre>
</details>

## Summary of Changes
1. Ignore [introspection queries](https://www.apollographql.com/blog/why-you-should-disable-graphql-introspection-in-production) from caching
1. Disable the [playground](https://www.apollographql.com/blog/why-you-should-disable-graphql-introspection-in-production) for production builds

----

Ultimately I had to resort to just blocking the `IntrospectionQuery` operation since even turning `introspection` off and disabling the playground would cause weird Apollo server errors or would make the call anyway.  🤷‍♂️ 