### PR TITLE
enhancement/issue 1167 content as data leftovers cleanup

### DIFF
--- a/packages/cli/src/lib/content-utils.js
+++ b/packages/cli/src/lib/content-utils.js
@@ -1,5 +1,19 @@
 const activeFrontmatterKeys = ['route', 'label', 'title', 'id'];
 
+function pruneGraph(pages) {
+  return pages.map(page => {
+    const p = {
+      ...page,
+      title: page.title ?? page.label
+    };
+
+    delete p.resources;
+    delete p.imports;
+
+    return p;
+  });
+}
+
 function cleanContentCollection(collection = []) {
   return collection.map((page) => {
     let prunedPage = {};
@@ -18,6 +32,7 @@ function cleanContentCollection(collection = []) {
 }
 
 export {
+  pruneGraph,
   activeFrontmatterKeys,
   cleanContentCollection
 };

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -116,7 +116,6 @@ const generateGraph = async (compilation) => {
                 id: getIdFromRelativePathPath(relativePagePath, `.${extension}`).replace('api-', ''),
                 pageHref: new URL(relativePagePath, pagesDir).href,
                 outputHref: new URL(relativePagePath, outputDir).href,
-                // outputPath: relativePagePath,
                 route: `${basePath}${route}`,
                 isolation
               });
@@ -191,8 +190,6 @@ const generateGraph = async (compilation) => {
                     executeModuleUrl: routeWorkerUrl.href,
                     moduleUrl: filenameUrl.href,
                     compilation: JSON.stringify(compilation),
-                    // TODO need to get as many of these params as possible
-                    // or ignore completely?
                     page: JSON.stringify({
                       servePage: isCustom,
                       route,
@@ -274,9 +271,6 @@ const generateGraph = async (compilation) => {
                 outputHref: route === '/404/'
                   ? new URL('./404.html', outputDir).href
                   : new URL(`.${route}index.html`, outputDir).href,
-                // outputPath: route === '/404/'
-                //   ? '/404.html'
-                //   : `${route}index.html`,
                 isSSR: !isStatic,
                 prerender,
                 isolation,
@@ -337,7 +331,6 @@ const generateGraph = async (compilation) => {
             {
               ...oldGraph,
               id: '404',
-              // outputPath: '/404.html',
               outputHref: new URL('./404.html', outputDir).href,
               pageHref: new URL('./404.html', pagesDir).href,
               route: `${basePath}/404/`,

--- a/packages/cli/src/plugins/resource/plugin-active-content.js
+++ b/packages/cli/src/plugins/resource/plugin-active-content.js
@@ -1,22 +1,8 @@
 import { mergeImportMap } from '../../lib/walker-package-ranger.js';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 import { checkResourceExists } from '../../lib/resource-utils.js';
-import { activeFrontmatterKeys, cleanContentCollection } from '../../lib/content-utils.js';
+import { activeFrontmatterKeys, cleanContentCollection, pruneGraph } from '../../lib/content-utils.js';
 import fs from 'fs/promises';
-
-function pruneGraph(pages) {
-  return pages.map(page => {
-    const p = {
-      ...page,
-      title: page.title ?? page.label
-    };
-
-    delete p.resources;
-    delete p.imports;
-
-    return p;
-  });
-}
 
 const importMap = {
   '@greenwood/cli/src/data/client.js': '/node_modules/@greenwood/cli/src/data/client.js'


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
related to #1167 

## Summary of Changes
Some leftovers from the previous PR - #1266

1. Remove stale comments
1. Move `pruneGraph` to a util
1. Make sure default content as data client port aligns with default greenwood value