### PR TITLE
bug/issue-1253 misleading init scaffolding instructions

### DIFF
--- a/packages/init/src/index.js
+++ b/packages/init/src/index.js
@@ -255,11 +255,13 @@ const run = async () => {
   try {
     const firstArg = process.argv[process.argv.length - 1].split(' ')[0];
     const taskRunner = program.yarn ? 'yarn' : 'npm run';
+    // bypassing commander here for my-app directory option, since I couldn't get it to work as an argument :/
+    // https://github.com/tj/commander.js?tab=readme-ov-file#command-arguments
     const shouldChangeDirectory = !firstArg.startsWith('--') && firstArg !== '';
     const shouldInstallDeps = program.install || program.yarn;
     const instructions = [];
 
-    if (!firstArg.startsWith('--') && firstArg !== '') {
+    if (shouldChangeDirectory) {
       TARGET_DIR = path.join(TARGET_DIR, `./${firstArg}`);
 
       if (!fs.existsSync(TARGET_DIR)) {

--- a/packages/init/src/index.js
+++ b/packages/init/src/index.js
@@ -256,6 +256,8 @@ const run = async () => {
     const firstArg = process.argv[process.argv.length - 1].split(' ')[0];
     const taskRunner = program.yarn ? 'yarn' : 'npm run';
     const shouldChangeDirectory = !firstArg.startsWith('--') && firstArg !== '';
+    const shouldInstallDeps = program.install || program.yarn;
+    const instructions = [];
 
     if (!firstArg.startsWith('--') && firstArg !== '') {
       TARGET_DIR = path.join(TARGET_DIR, `./${firstArg}`);
@@ -283,7 +285,7 @@ const run = async () => {
     console.log('Creating package.json...');
     await npmInit();
 
-    if (program.install || program.yarn) {
+    if (shouldInstallDeps) {
       console.log('Installing project dependencies...');
       await install();
     }
@@ -291,12 +293,24 @@ const run = async () => {
     await cleanUp();
 
     console.log(`${chalk.rgb(175, 207, 71)('Initializing new project complete!')}`);
+    console.log(`${chalk.rgb(175, 207, 71)('Complete the follow steps to get started:')}`);
 
     if (shouldChangeDirectory) {
-      console.log(`Change directories by running => cd ${firstArg}`);
+      instructions.push(`Change directories by running => cd ${firstArg}`);
     }
 
-    console.log(`To start developing run => ${taskRunner} dev`);
+    if (!shouldInstallDeps) {
+      instructions.push('Install dependencies with your package manager, e.g. => npm i');
+    }
+
+    instructions.push(`To start developing run => ${taskRunner} dev`);
+
+    // output all instructions in step-based order
+    instructions.forEach((instruction, idx) => {
+      const step = idx += 1;
+
+      console.log(`${step}) ${instruction}`);
+    });
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
#1253 

Noticed the custom app directory option was providing broken instructions
```sh
➜  test npx @greenwood/init@alpha my-app
-------------------------------------------------------
Initialize a Greenwood Project ♻️
-------------------------------------------------------
Initializing into project directory... /Users/owenbuckley/Desktop/test/my-app
Initializing project with files...
Creating package.json...
Initializing new project complete!
Change directories by running => cd my-app
To start developing run => npm run dev
➜  test cd my-app
➜  my-app npm run dev

> my-app@1.0.0 dev
> greenwood develop

sh: greenwood: command not found
```

## Summary of Changes
1. Properly instruct user on next steps (specifically to make sure to install deps)

```sh
-------------------------------------------------------
Initialize a Greenwood Project ♻️
-------------------------------------------------------
Initializing into project directory... /Users/owenbuckley/Workspace/project-evergreen/greenwood/packages/init/test/cases/init.project-name/output/my-app
Initializing project with files...
Creating package.json...
Initializing new project complete!
Complete the follow steps to get started:
1) Change directories by running => cd my-app
2) Install dependencies with your package manager, e.g. => npm i
3) To start developing run => npm run dev
```