### PR TITLE
bug/website header nav not centered in Chrome

### DIFF
--- a/www/components/header/header.css
+++ b/www/components/header/header.css
@@ -41,7 +41,7 @@
 
       & ul {
         padding: 0;
-        margin: 0;
+        margin: 0 auto;
         list-style: none;
         text-align: center;
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
noticed just today (even though it was fine for a while) the header nav of the website is not centered anymore in Chrome (is fine in all other browsers through 🤷‍♂️ )

![Screenshot 2024-11-02 at 2 49 40 PM](https://github.com/user-attachments/assets/ac6bafac-6fb3-4d91-8805-dc0e51fe869f)

## Summary of Changes
1. Add `auto` to navigation `margin`

![Screenshot 2024-11-02 at 2 46 34 PM](https://github.com/user-attachments/assets/f9189b50-0720-4247-af0f-0688624c3b04)