### PR TITLE
docs/Update PostCSS plugin README.md to correct case sensitive name

### DIFF
--- a/packages/plugin-postcss/README.md
+++ b/packages/plugin-postcss/README.md
@@ -80,13 +80,13 @@ _Eventually once [PostCSS adds support for ESM configuration files](https://gith
 
 If you would like to _extend_ the default configuration with your own custom _postcss.config.js_, you can enable the `extendConfig` option of this plugin
 ```js
-import { greenwoodPluginPostcss } from '@greenwood/plugin-postcss';
+import { greenwoodPluginPostCss } from '@greenwood/plugin-postcss';
 
 export default {
   // ...
 
   plugins: [
-    greenwoodPluginPostcss({
+    greenwoodPluginPostCss({
       extendConfig: true
     })
   ]


### PR DESCRIPTION
The export for the @greenwood/plugin-postcss was incorrectly capitalized causing the import to fail if copied directly from the documentation.

<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
<!-- Include a link to the issue (e.g. Resolves #12) -->

## Summary of Changes
<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->