### PR TITLE
bug/issue 1295 preserve default TypeScript plugin options when merging additional user provided options

### DIFF
--- a/packages/plugin-typescript/README.md
+++ b/packages/plugin-typescript/README.md
@@ -101,9 +101,11 @@ If you would like to extend / override these options:
 
 This will then process your JavaScript with TypeScript with the additional configuration settings you provide.  This also allows you to configure the rest of _tsconfig.json_ to support your IDE and local development environment settings.
 
-### Custom Pages
+### Pages
 
-By default, this plugin extends TypeScript support to processing SSR pages and API routes.  If you would like to _disable_ this, set the `servePage` option to `false`
+By default, this plugin extends TypeScript support for processing [SSR pages](https://www.greenwoodjs.dev/docs/pages/server-rendering/) and [API routes](https://www.greenwoodjs.dev/docs/pages/api-routes/).  For this feature, you will need to enable [custom imports](https://www.greenwoodjs.dev/docs/pages/server-rendering/#custom-imports).
+
+If you would like to _disable_ this feature completely, set the `servePage` option to `false`:
 
 ```js
 import { greenwoodPluginTypeScript } from '@greenwood/plugin-typescript';

--- a/packages/plugin-typescript/README.md
+++ b/packages/plugin-typescript/README.md
@@ -99,7 +99,7 @@ If you would like to extend / override these options:
     };
     ```
 
-This will then process your JavaScript with TypeScript with the additional configuration settings you provide.  This also allows you to configure the rest of _tsconfig.json_ to support your IDE and local development environment settings.
+This will then process your JavaScript with TypeScript with the additional configuration settings you provide.  This also allows you to configure the rest of your _tsconfig.json_ to support your project specific IDE and local development environment settings.
 
 ### Pages
 

--- a/packages/plugin-typescript/src/index.js
+++ b/packages/plugin-typescript/src/index.js
@@ -55,11 +55,14 @@ class TypeScriptResource extends ResourceInterface {
   }
 }
 
-const greenwoodPluginTypeScript = (options = { servePage: 'dynamic' }) => {
+const greenwoodPluginTypeScript = (options = {}) => {
   return [{
     type: 'resource',
     name: 'plugin-import-typescript:resource',
-    provider: (compilation) => new TypeScriptResource(compilation, options)
+    provider: (compilation) => new TypeScriptResource(compilation, {
+      servePage: 'dynamic',
+      ...options
+    })
   }];
 };
 

--- a/packages/plugin-typescript/test/cases/loaders-build.resource-page/greenwood.config.js
+++ b/packages/plugin-typescript/test/cases/loaders-build.resource-page/greenwood.config.js
@@ -3,6 +3,10 @@ import { greenwoodPluginTypeScript } from '../../../src/index.js';
 export default {
   prerender: true,
   plugins: [
-    greenwoodPluginTypeScript()
+    greenwoodPluginTypeScript({
+      // make sure we don't lose default value of servePage
+      // https://github.com/ProjectEvergreen/greenwood/issues/1295
+      foo: 'bar'
+    })
   ]
 };

--- a/packages/plugin-typescript/test/cases/loaders-build.resource-page/loaders-build.resource-page.spec.js
+++ b/packages/plugin-typescript/test/cases/loaders-build.resource-page/loaders-build.resource-page.spec.js
@@ -12,9 +12,7 @@
  * {
  *   prerender: true,
  *   plugins: [
- *      greenwoodPluginTypeScript({
- *        servePage: 'dynamic'
- *      })
+ *      greenwoodPluginTypeScript()
  *   ]
  * }
  *


### PR DESCRIPTION
… custom imports

<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #1295 

## Summary of Changes
1. Merge user configuration after default plugin configuration
1. Better document need for using custom imports when using the plugin for Pages