### PR TITLE
enhancement/bump plugins peer dependencies to match latest minor release range

### DIFF
--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0"
+    "@greenwood/cli": "^0.30.0"
   },
   "dependencies": {
     "@babel/core": "^7.10.4",

--- a/packages/plugin-css-modules/package.json
+++ b/packages/plugin-css-modules/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0"
+    "@greenwood/cli": "^0.30.0"
   },
   "dependencies": {
     "acorn": "^8.0.1",

--- a/packages/plugin-google-analytics/package.json
+++ b/packages/plugin-google-analytics/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0"
+    "@greenwood/cli": "^0.30.0"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.30.0"

--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0"
+    "@greenwood/cli": "^0.30.0"
   },
   "dependencies": {
     "@apollo/client": "^3.7.14",

--- a/packages/plugin-import-commonjs/package.json
+++ b/packages/plugin-import-commonjs/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0"
+    "@greenwood/cli": "^0.30.0"
   },
   "dependencies": {
     "@rollup/plugin-commonjs": "^25.0.0",

--- a/packages/plugin-import-css/package.json
+++ b/packages/plugin-import-css/package.json
@@ -22,7 +22,7 @@
     "src/"
   ],
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0"
+    "@greenwood/cli": "^0.30.0"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.30.0"

--- a/packages/plugin-import-raw/package.json
+++ b/packages/plugin-import-raw/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0"
+    "@greenwood/cli": "^0.30.0"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.30.0"

--- a/packages/plugin-include-html/package.json
+++ b/packages/plugin-include-html/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0"
+    "@greenwood/cli": "^0.30.0"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.30.0"

--- a/packages/plugin-polyfills/package.json
+++ b/packages/plugin-polyfills/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0"
+    "@greenwood/cli": "^0.30.0"
   },
   "dependencies": {
     "@webcomponents/webcomponentsjs": "^2.6.0"

--- a/packages/plugin-postcss/package.json
+++ b/packages/plugin-postcss/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0"
+    "@greenwood/cli": "^0.30.0"
   },
   "dependencies": {
     "postcss": "^8.3.11",

--- a/packages/plugin-renderer-lit/package.json
+++ b/packages/plugin-renderer-lit/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.22.1",
+    "@greenwood/cli": "^0.30.0",
     "lit": "^3.1.0"
   },
   "dependencies": {

--- a/packages/plugin-renderer-puppeteer/package.json
+++ b/packages/plugin-renderer-puppeteer/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0"
+    "@greenwood/cli": "^0.30.0"
   },
   "dependencies": {
     "@webcomponents/webcomponentsjs": "^2.6.0",

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.4.0"
+    "@greenwood/cli": "^0.30.0"
   },
   "dependencies": {
     "typescript": "^5.1.6"


### PR DESCRIPTION
peer dependencies need to match dev dependencies or package managers will occasionally (pnpm will always) complain

## Related Issue
I didn't file an issue about this, because it was easy enough to fix the couple of plugins I've used so far

## Summary of Changes

I updated the peer dependency line to match the dev dependency line in the package.json for several of the plugins.  I should have gone through and done them all, but I don't currently have time. 