### PR TITLE
bug/issue 1302 install fails when no args are provided

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint": "^8.51.0",
     "eslint-plugin-markdown": "^3.0.0",
     "eslint-plugin-no-only-tests": "^2.6.0",
-    "gallinago": "^0.8.1",
+    "gallinago": "^0.8.2",
     "glob-promise": "^3.4.0",
     "jsdom": "^16.5.0",
     "lerna": "^3.16.4",

--- a/packages/init/src/index.js
+++ b/packages/init/src/index.js
@@ -253,18 +253,21 @@ const cleanUp = async () => {
 
 const run = async () => {
   try {
-    const firstArg = process.argv[process.argv.length - 1].split(' ')[0];
-    const taskRunner = program.yarn ? 'yarn' : 'npm run';
     // bypassing commander here for my-app directory option, since I couldn't get it to work as an argument :/
     // https://github.com/tj/commander.js?tab=readme-ov-file#command-arguments
-    // hacky little work around to solve this issue until we can get this behavior integrated directly into inquirer
+    // bit of a hack job for now and its known custom directory and additional flags don't well together right now
     // https://github.com/ProjectEvergreen/greenwood/issues/1302
-    const shouldChangeDirectory = !firstArg.startsWith('--') && !firstArg.endsWith('/init/src/index.js');
+    // https://stackoverflow.com/a/31643053/417806
+    const args = process.argv;
+    const noArgs = args.length === 2;
+    const lastArg = args[args.length - 1].split(' ')[0];
+    const hasCustomDirectoryArg = !noArgs && !lastArg.startsWith('--');
+    const taskRunner = program.yarn ? 'yarn' : 'npm run';
     const shouldInstallDeps = program.install || program.yarn;
     const instructions = [];
 
-    if (shouldChangeDirectory) {
-      TARGET_DIR = path.join(TARGET_DIR, `./${firstArg}`);
+    if (hasCustomDirectoryArg) {
+      TARGET_DIR = path.join(TARGET_DIR, `./${lastArg}`);
 
       if (!fs.existsSync(TARGET_DIR)) {
         fs.mkdirSync(TARGET_DIR);
@@ -299,8 +302,8 @@ const run = async () => {
     console.log(`${chalk.rgb(175, 207, 71)('Initializing new project complete!')}`);
     console.log(`${chalk.rgb(175, 207, 71)('Complete the follow steps to get started:')}`);
 
-    if (shouldChangeDirectory) {
-      instructions.push(`Change directories by running => cd ${firstArg}`);
+    if (hasCustomDirectoryArg) {
+      instructions.push(`Change directories by running => cd ${lastArg}`);
     }
 
     if (!shouldInstallDeps) {

--- a/packages/init/src/index.js
+++ b/packages/init/src/index.js
@@ -257,7 +257,9 @@ const run = async () => {
     const taskRunner = program.yarn ? 'yarn' : 'npm run';
     // bypassing commander here for my-app directory option, since I couldn't get it to work as an argument :/
     // https://github.com/tj/commander.js?tab=readme-ov-file#command-arguments
-    const shouldChangeDirectory = !firstArg.startsWith('--') && firstArg !== '';
+    // hacky little work around to solve this issue until we can get this behavior integrated directly into inquirer
+    // https://github.com/ProjectEvergreen/greenwood/issues/1302
+    const shouldChangeDirectory = !firstArg.startsWith('--') && !firstArg.endsWith('/init/src/index.js');
     const shouldInstallDeps = program.install || program.yarn;
     const instructions = [];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8768,10 +8768,10 @@ fuzzy@0.1.3:
   resolved "https://registry.yarnpkg.com/fuzzy/-/fuzzy-0.1.3.tgz#4c76ec2ff0ac1a36a9dccf9a00df8623078d4ed8"
   integrity sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==
 
-gallinago@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/gallinago/-/gallinago-0.8.1.tgz#47eb2358bf27f5d16d2755df36577f03caddfd80"
-  integrity sha512-uE7LyJHtfl650PAZUQiZLzxuYcJAVMJ7p32cEDEskfYrCmHKDu5KkuBqMnwKEcJTDOdWEvhlii/o0pvucX0CgQ==
+gallinago@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/gallinago/-/gallinago-0.8.2.tgz#c719c28700b3a354a2f5e4b0c10160c29ba72180"
+  integrity sha512-OGKhpSVFQUw953tWrqRSgOuPteDqftoH5I01qDzQSDOYfeWCoBcnVNEGO0zZHjzS0vJsGVClsVWoJJsJbCdRig==
 
 gauge@^3.0.0:
   version "3.0.2"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolve #1302 

## Summary of Changes
1. A bit hacky *, this should now check to make sure the last arg is not the script entry filename, and if so, assume no args have been passed
1. Upgrades to latest version of gallinago to fix forwarding args implementation

> \* I know this is all a bit of a hack and the previous work around for #1280 are a bit ugly (only because I could not shoe-horn the feature into inquirer), and so a proper refactor / re-write will be coming soon via https://github.com/ProjectEvergreen/greenwood/issues/1279