### PR TITLE
enhancement/issue 1313 set `shamefully-hoist` pnpm flag in .npmrc for init scaffolding

### DIFF
--- a/packages/init/src/template/.npmrc
+++ b/packages/init/src/template/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+shamefully-hoist=true


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

#1313

## Documentation 

Already documented for the init step at least - https://greenwoodjs.dev/docs/introduction/setup/#install

## Summary of Changes

1. For now, this will at least ensure new project scaffolding interops reasonably well with pnpm even if it "ejects" out of pnpm's ideal setup (longer term solution will come later)