### PR TITLE
enhancement/issue 1218 native import attributes parsing

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -12,7 +12,8 @@ ls:
   .woff2: lowercase
 
 ignore: 
-  - .git 
+  - .git
+  - public
   - node_modules
   - packages/plugin-babel/node_modules
   - packages/init/node_modules

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,13 +32,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@rollup/plugin-commonjs": "^25.0.0",
+    "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",
-    "acorn": "^8.0.1",
-    "acorn-import-attributes": "^1.9.5",
-    "acorn-walk": "^8.0.0",
+    "acorn": "^8.14.0",
+    "acorn-walk": "^8.3.4",
     "commander": "^2.20.0",
     "css-tree": "^3.0.0",
     "es-module-shims": "^1.8.3",
@@ -53,7 +52,7 @@
     "remark-frontmatter": "^2.0.0",
     "remark-parse": "^8.0.3",
     "remark-rehype": "^7.0.0",
-    "rollup": "^3.29.4",
+    "rollup": "^4.26.0",
     "unified": "^9.2.0",
     "wc-compiler": "~0.15.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,7 @@
     "remark-rehype": "^7.0.0",
     "rollup": "^4.26.0",
     "unified": "^9.2.0",
-    "wc-compiler": "~0.15.0"
+    "wc-compiler": "~0.15.1"
   },
   "devDependencies": {
     "@babel/runtime": "^7.10.4",

--- a/packages/cli/src/lib/parsing-utils.js
+++ b/packages/cli/src/lib/parsing-utils.js
@@ -1,0 +1,8 @@
+const acornOptions = {
+  ecmaVersion: 'latest',
+  sourceType: 'module'
+};
+
+export {
+  acornOptions
+};

--- a/packages/cli/src/lib/walker-package-ranger.js
+++ b/packages/cli/src/lib/walker-package-ranger.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { getNodeModulesLocationForPackage } from './node-modules-utils.js';
 import path from 'path';
 import * as walk from 'acorn-walk';
+import { acornOptions } from './parsing-utils.js';
 
 const importMap = {};
 
@@ -46,10 +47,7 @@ async function getPackageEntryPath(packageJson) {
 async function walkModule(modulePath, dependency) {
   const moduleContents = fs.readFileSync(modulePath, 'utf-8');
 
-  walk.simple(acorn.parse(moduleContents, {
-    ecmaVersion: 'latest',
-    sourceType: 'module'
-  }), {
+  walk.simple(acorn.parse(moduleContents, acornOptions), {
     async ImportDeclaration(node) {
       let { value: sourceValue } = node.source;
       const absoluteNodeModulesLocation = await getNodeModulesLocationForPackage(dependency);

--- a/packages/cli/src/lib/walker-package-ranger.js
+++ b/packages/cli/src/lib/walker-package-ranger.js
@@ -47,7 +47,7 @@ async function walkModule(modulePath, dependency) {
   const moduleContents = fs.readFileSync(modulePath, 'utf-8');
 
   walk.simple(acorn.parse(moduleContents, {
-    ecmaVersion: '2020',
+    ecmaVersion: 'latest',
     sourceType: 'module'
   }), {
     async ImportDeclaration(node) {

--- a/packages/cli/src/plugins/resource/plugin-standard-javascript.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-javascript.js
@@ -9,7 +9,6 @@ import { ResourceInterface } from '../../lib/resource-interface.js';
 import terser from '@rollup/plugin-terser';
 import * as acorn from 'acorn';
 import * as walk from 'acorn-walk';
-import { importAttributes } from 'acorn-import-attributes';
 
 class StandardJavaScriptResource extends ResourceInterface {
   constructor(compilation, options) {
@@ -43,7 +42,7 @@ class StandardJavaScriptResource extends ResourceInterface {
     const body = await response.clone().text();
     let polyfilled = body;
 
-    walk.simple(acorn.Parser.extend(importAttributes).parse(body, {
+    walk.simple(acorn.parse(body, {
       ecmaVersion: 'latest',
       sourceType: 'module'
     }), {

--- a/packages/cli/src/plugins/resource/plugin-standard-javascript.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-javascript.js
@@ -9,6 +9,7 @@ import { ResourceInterface } from '../../lib/resource-interface.js';
 import terser from '@rollup/plugin-terser';
 import * as acorn from 'acorn';
 import * as walk from 'acorn-walk';
+import { acornOptions } from '../../lib/parsing-utils.js';
 
 class StandardJavaScriptResource extends ResourceInterface {
   constructor(compilation, options) {
@@ -42,10 +43,7 @@ class StandardJavaScriptResource extends ResourceInterface {
     const body = await response.clone().text();
     let polyfilled = body;
 
-    walk.simple(acorn.parse(body, {
-      ecmaVersion: 'latest',
-      sourceType: 'module'
-    }), {
+    walk.simple(acorn.parse(body, acornOptions), {
       async ImportDeclaration(node) {
         const line = body.slice(node.start, node.end);
         const { value } = node.source;

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -241,7 +241,7 @@ describe('Build Greenwood With: ', function() {
         const inlineScriptTag = Array.from(dom.window.document.querySelectorAll('head > script:not([src])')).filter(tag => !tag.getAttribute('data-gwd'))[0];
 
         expect(inlineScriptTag.textContent.replace(/\n/g, '')).to
-          .equal('import"/116321042.4f3171e3.js";import"/lit-html.31ea57aa.js";//# sourceMappingURL=116321042.69f46fc1.js.map');
+          .equal('import"/116321042.dlaVsmnb.js";import"/lit-html.CYd3Xodq.js";//# sourceMappingURL=116321042.SNvCd9wk.js.map');
       });
     });
 

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -58,7 +58,7 @@ describe('Build Greenwood With: ', function() {
       it('should have one <script> tag for other.js loaded in the <head>', function() {
         const scriptTags = dom.window.document.querySelectorAll('head > script[type="module"]');
         const mainScriptTags = Array.prototype.slice.call(scriptTags).filter(script => {
-          return (/other.*[a-z0-9].js/).test(script.src);
+          return (/other.*[a-zA-Z0-9].js/).test(script.src);
         });
 
         expect(mainScriptTags.length).to.be.equal(1);
@@ -66,11 +66,11 @@ describe('Build Greenwood With: ', function() {
 
       // this includes the non module file in a spec below
       it('should have the expected number of bundled .js files in the output directory', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, '*.*[a-z0-9].js'))).to.have.lengthOf(3);
+        expect(await glob.promise(path.join(this.context.publicDir, '*.*[a-zA-Z0-9].js'))).to.have.lengthOf(3);
       });
 
       it('should have the expected other.js file in the output directory', async function() {
-        expect(await glob.promise(path.join(this.context.publicDir, 'other.*[a-z0-9].js'))).to.have.lengthOf(1);
+        expect(await glob.promise(path.join(this.context.publicDir, 'other.*[a-zA-Z0-9].js'))).to.have.lengthOf(1);
       });
     });
 

--- a/packages/cli/test/cases/loaders-build.import-attributes/loaders-build.import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-build.import-attributes/loaders-build.import-attributes.spec.js
@@ -54,7 +54,7 @@ describe('Build Greenwood With: ', function() {
     });
 
     describe('Custom Element Importing CSS w/ Constructable Stylesheet', function() {
-      const cssFileHash = 'bcdce3a3';
+      const cssFileHash = 'YPhf6BPs';
       let scripts;
       let styles;
 

--- a/packages/cli/test/cases/loaders-build.prerender-import-attributes/loaders-build.prerender-import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-build.prerender-import-attributes/loaders-build.prerender-import-attributes.spec.js
@@ -57,7 +57,7 @@ describe('Build Greenwood With: ', function() {
     runSmokeTest(['public'], LABEL);
 
     describe('Custom Element Importing CSS w/ Constructable Stylesheet', function() {
-      const cssFileHash = '93e8cf36';
+      const cssFileHash = 'Cg2xlj-Z';
       let scripts;
       let styles;
 
@@ -70,7 +70,7 @@ describe('Build Greenwood With: ', function() {
         const scriptContents = fs.readFileSync(scripts[0], 'utf-8');
 
         expect(scripts.length).to.equal(1);
-        expect(scriptContents).to.contain('import e from"/hero.93e8cf36.css"with{type:"css"}');
+        expect(scriptContents).to.contain('import e from"/hero.Cg2xlj-Z.css"with{type:"css"}');
       });
 
       it('should have the expected CSS output bundle for hero.css', function() {

--- a/packages/cli/test/cases/loaders-serve.config.polyfill-import-attributes/loaders-serve.config.polyfills-import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-serve.config.polyfill-import-attributes/loaders-serve.config.polyfills-import-attributes.spec.js
@@ -119,7 +119,7 @@ describe('Serve Greenwood With: ', function() {
     });
 
     describe('Import Attributes Polyfill Behaviors for the initiating JavaScript file (hero.js) being served and bundled', function() {
-      const jsHash = '9acf7b4c';
+      const jsHash = 'B7j93uYq';
       let response = {};
       let text;
       let contents;

--- a/packages/cli/test/cases/serve.config.base-path/serve.config.base-path.spec.js
+++ b/packages/cli/test/cases/serve.config.base-path/serve.config.base-path.spec.js
@@ -48,7 +48,7 @@ describe('Serve Greenwood With: ', function() {
   const publicPath = path.join(outputPath, 'public/');
   const hostname = 'http://127.0.0.1:8080';
   const basePath = '/my-path';
-  const jsHash = '2ce3f02d';
+  const jsHash = 'eCbOYUm_';
   const cssHash = '2106293974';
   let runner;
 

--- a/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
@@ -361,7 +361,7 @@ describe('Serve Greenwood With: ', function() {
     });
 
     describe('Bundled image using new URL and import.meta.url', function() {
-      const bundledName = 'assets/logo-619de195.svg';
+      const bundledName = 'assets/logo-DQvO5Aou.svg';
       let response = {};
       let body;
       let usersResponse = {};

--- a/packages/cli/test/cases/serve.default.ssr/src/components/counter.js
+++ b/packages/cli/test/cases/serve.default.ssr/src/components/counter.js
@@ -13,9 +13,12 @@ template.innerHTML = `
 `;
 
 class MyCounter extends HTMLElement {
+  static staticProperty = 'foo';
+  #count;
+
   constructor() {
     super();
-    this.count = 0;
+    this.#count = 0;
     this.attachShadow({ mode: 'open' });
   }
 
@@ -23,19 +26,20 @@ class MyCounter extends HTMLElement {
     this.shadowRoot.appendChild(template.content.cloneNode(true));
     this.shadowRoot.getElementById('inc').onclick = () => this.inc();
     this.shadowRoot.getElementById('dec').onclick = () => this.dec();
+    this.#count = this.getAttribute('count') ?? this.#count;
     this.update();
   }
 
   inc() {
-    this.update(++this.count); // eslint-disable-line
+    this.update(++this.#count); // eslint-disable-line
   }
 
   dec() {
-    this.update(--this.count); // eslint-disable-line
+    this.update(--this.#count); // eslint-disable-line
   }
 
   update(count) {
-    this.shadowRoot.getElementById('count').innerHTML = count || this.count;
+    this.shadowRoot.getElementById('count').innerHTML = count || this.#count;
   }
 }
 

--- a/packages/plugin-css-modules/package.json
+++ b/packages/plugin-css-modules/package.json
@@ -27,9 +27,8 @@
     "@greenwood/cli": "^0.30.0"
   },
   "dependencies": {
-    "acorn": "^8.0.1",
-    "acorn-import-attributes": "^1.9.5",
-    "acorn-walk": "^8.0.0",
+    "acorn": "^8.14.0",
+    "acorn-walk": "^8.3.4",
     "css-tree": "^3.0.0",
     "node-html-parser": "^1.2.21",
     "sucrase": "^3.35.0"

--- a/packages/plugin-css-modules/src/index.js
+++ b/packages/plugin-css-modules/src/index.js
@@ -10,7 +10,6 @@ import { ResourceInterface } from '@greenwood/cli/src/lib/resource-interface.js'
 import * as acornWalk from 'acorn-walk';
 import * as acorn from 'acorn';
 import { hashString } from '@greenwood/cli/src/lib/hashing-utils.js';
-import { importAttributes } from 'acorn-import-attributes';
 import { transform } from 'sucrase';
 
 const MODULES_MAP_FILENAME = '__css-modules-map.json';
@@ -40,7 +39,7 @@ function walkAllImportsForCssModules(scriptUrl, sheets, compilation) {
   });
 
   acornWalk.simple(
-    acorn.Parser.extend(importAttributes).parse(result.code, {
+    acorn.parse(result.code, {
       ecmaVersion: 'latest',
       sourceType: 'module'
     }),
@@ -246,7 +245,7 @@ class StripCssModulesResource extends ResourceInterface {
     let contents = await response.text();
 
     acornWalk.simple(
-      acorn.Parser.extend(importAttributes).parse(contents, {
+      acorn.parse(contents, {
         ecmaVersion: 'latest',
         sourceType: 'module'
       }),

--- a/packages/plugin-css-modules/src/index.js
+++ b/packages/plugin-css-modules/src/index.js
@@ -11,6 +11,7 @@ import * as acornWalk from 'acorn-walk';
 import * as acorn from 'acorn';
 import { hashString } from '@greenwood/cli/src/lib/hashing-utils.js';
 import { transform } from 'sucrase';
+import { acornOptions } from '@greenwood/cli/src/lib/parsing-utils.js';
 
 const MODULES_MAP_FILENAME = '__css-modules-map.json';
 /*
@@ -39,11 +40,7 @@ function walkAllImportsForCssModules(scriptUrl, sheets, compilation) {
   });
 
   acornWalk.simple(
-    acorn.parse(result.code, {
-      ecmaVersion: 'latest',
-      sourceType: 'module'
-    }),
-    {
+    acorn.parse(result.code, acornOptions), {
       ImportDeclaration(node) {
         const { specifiers = [], source = {} } = node;
         const { value = '' } = source;
@@ -245,11 +242,7 @@ class StripCssModulesResource extends ResourceInterface {
     let contents = await response.text();
 
     acornWalk.simple(
-      acorn.parse(contents, {
-        ecmaVersion: 'latest',
-        sourceType: 'module'
-      }),
-      {
+      acorn.parse(contents, acornOptions), {
         ImportDeclaration(node) {
           const { specifiers = [], source = {}, start, end } = node;
           const { value = '' } = source;

--- a/packages/plugin-import-commonjs/package.json
+++ b/packages/plugin-import-commonjs/package.json
@@ -27,7 +27,7 @@
     "@greenwood/cli": "^0.30.0"
   },
   "dependencies": {
-    "@rollup/plugin-commonjs": "^25.0.0",
+    "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/stream": "^3.0.1",
     "cjs-module-lexer": "^1.0.0"
   },

--- a/packages/plugin-import-commonjs/test/cases/default/default.spec.js
+++ b/packages/plugin-import-commonjs/test/cases/default/default.spec.js
@@ -96,8 +96,7 @@ describe('Build Greenwood With: ', function() {
       it('should have the expected CommonJS contents from main.js (lodash) in the output', async function() {
         const contents = fs.readFileSync(scripts[0], 'utf-8');
 
-        expect(contents).to.contain('r=u,e=u.exports,function()');
-        expect(contents).to.contain('document.getElementsByTagName("span")[0].innerHTML=`import from lodash ${o}`');
+        expect(contents).to.contain('document.getElementsByTagName("span")[0].innerHTML=`import from lodash ${a}`');
       });
     });
   });

--- a/packages/plugin-import-jsx/package.json
+++ b/packages/plugin-import-jsx/package.json
@@ -28,7 +28,7 @@
     "@greenwood/cli": "^0.30.0"
   },
   "dependencies": {
-    "wc-compiler": "~0.15.0"
+    "wc-compiler": "~0.15.1"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.30.2"

--- a/packages/plugin-renderer-lit/test/cases/serve.default/src/components/card.js
+++ b/packages/plugin-renderer-lit/test/cases/serve.default/src/components/card.js
@@ -1,55 +1,25 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, css } from 'lit';
 
 export default class Card extends LitElement {
-  // TODO we have a clash on acorn version?
-  // or this issue - https://github.com/ProjectEvergreen/greenwood/issues/1183
-  // static properties = {
-  //   title: '',
-  //   thumbnail: ''
-  // };
-  // static styles = css`
-  //   div {
-  //     display: flex;
-  //     flex-direction: column;
-  //     align-items: center;
-  //     gap: 0.5rem;
-  //     border: 1px solid #818181;
-  //     width: fit-content;
-  //     border-radius: 10px;
-  //     padding: 2rem 1rem;
-  //     height: 680px;
-  //     justify-content: space-between;
-  //     background-color: #fff;
-  //     overflow-x: hidden;
-  //   }
-  //   button {
-  //     background: var(--color-accent);
-  //     color: var(--color-white);
-  //     padding: 1rem 2rem;
-  //     border: 0;
-  //     font-size: 1rem;
-  //     border-radius: 5px;
-  //     cursor: pointer;
-  //   }
-  //   img {
-  //     max-width: 500px;
-  //     min-width: 500px;
-  //     width: 100%;
-  //   }
-  //   h3 {
-  //     font-size: 1.85rem;
-  //   }
-
-  //   @media(max-width: 768px) {
-  //     img {
-  //       max-width: 300px;
-  //       min-width: 300px;
-  //     }
-  //     div {
-  //       height: 500px;
-  //     }
-  //   }
-  // `;
+  static styles = css`
+    h3 {
+      font-size: 1.85rem;
+    }
+    button {
+      background: var(--color-accent);
+      color: var(--color-white);
+      padding: 1rem 2rem;
+      border: 0;
+      font-size: 1rem;
+      border-radius: 5px;
+      cursor: pointer;
+    }
+    img {
+      max-width: 500px;
+      min-width: 500px;
+      width: 100%;
+    }
+  `;
 
   constructor() {
     super();

--- a/packages/plugin-renderer-puppeteer/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-renderer-puppeteer/test/cases/build.default/build.default.spec.js
@@ -297,7 +297,7 @@ describe('Build Greenwood With: ', function() {
 
         expect(inlineScriptTag.textContent.replace('\n', '')).to
           // eslint-disable-next-line max-len
-          .contain('import"/lit-element.6eb76f27.js";document.getElementsByClassName("output-script-inline")[0].innerHTML="script tag module inline";//# sourceMappingURL=1635690801.4bc08000.js.map');
+          .contain('import"/lit-element.5o_Y6C1Q.js";document.getElementsByClassName("output-script-inline")[0].innerHTML="script tag module inline";//# sourceMappingURL=1635690801.CKFVi45M.js.map');
       });
 
       it('should have prerendered content from <app-header> component', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3925,17 +3925,6 @@
   resolved "https://registry.yarnpkg.com/@projectevergreen/acorn-jsx-esm/-/acorn-jsx-esm-0.1.0.tgz#9870be988907048b5b432425d6157b84f8e4fdef"
   integrity sha512-ZBSkr0e2M4ylq74dTGHSkWI2dF3Mz8zwBLyzIXZMftecKDADcsCTj7bWltVgtdl8Rh4+bmY1jNWUw7AlSV/r7A==
 
-"@projectevergreen/escodegen-esm@~0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@projectevergreen/escodegen-esm/-/escodegen-esm-0.1.0.tgz#c9259d51178d4be948dd19e561ce5e2a16948a0f"
-  integrity sha512-LM9FFffsXPHiOFt78K3bgF8kO8Fx+qluAPy9jP3H4lvCFE+2nbwQM4cWdOpVik++rHf4pkDA7FxDPWWATyBABg==
-  dependencies:
-    esprima "^4.0.1"
-    estraverse "^5.2.0"
-    esutils "^2.0.2"
-  optionalDependencies:
-    source-map "~0.6.1"
-
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -4804,11 +4793,6 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-import-attributes@^1.9.5:
-  version "1.9.5"
-  resolved "https://registry.yarnpkg.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz#7eb1557b1ba05ef18b5ed0ec67591bfab04688ef"
-  integrity sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==
-
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -4819,7 +4803,7 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.1.1, acorn-walk@^8.2.0:
+acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
@@ -4836,7 +4820,7 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.0.5, acorn@^8.4.1, acorn@^8.6.0, acorn@^8.7.0, acorn@^8.9.0:
+acorn@^8.0.5, acorn@^8.4.1, acorn@^8.6.0, acorn@^8.9.0:
   version "8.11.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
@@ -5437,6 +5421,11 @@ astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
+astring@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/astring/-/astring-1.9.0.tgz#cc73e6062a7eb03e7d19c22d8b0b3451fd9bfeef"
+  integrity sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==
 
 async-limiter@~1.0.0:
   version "1.0.1"
@@ -17307,16 +17296,15 @@ wait-port@1.0.4:
     commander "^9.3.0"
     debug "^4.3.4"
 
-wc-compiler@~0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.15.0.tgz#f8c0a2b074d39490725718ddf0824ca0ee33ae67"
-  integrity sha512-bzRjWEal5QGKrryZAsD3V9abuQ4blu2LP23GdrIM1UFybDRor6hcRhYJwdBLPriw017x/J69yPuRXLgAm2xUPQ==
+wc-compiler@~0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.15.1.tgz#fe7698d81c24cea1290ee6f1e3b32783148b5bcc"
+  integrity sha512-pSDhO7r2jBf4x+t1mqLt/GGNw8KfF0g0TQuK8euP7TsNhcMslyP3wOjIai0xzEYkVr9wbJyIRt7LJSLtD776wg==
   dependencies:
     "@projectevergreen/acorn-jsx-esm" "~0.1.0"
-    "@projectevergreen/escodegen-esm" "~0.1.0"
-    acorn "^8.7.0"
-    acorn-import-attributes "^1.9.5"
-    acorn-walk "^8.2.0"
+    acorn "^8.14.0"
+    acorn-walk "^8.3.4"
+    astring "^1.9.0"
     parse5 "^6.0.1"
     sucrase "^3.35.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3997,17 +3997,18 @@
     "@babel/helper-module-imports" "^7.18.6"
     "@rollup/pluginutils" "^5.0.1"
 
-"@rollup/plugin-commonjs@^25.0.0":
-  version "25.0.7"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz#145cec7589ad952171aeb6a585bbeabd0fd3b4cf"
-  integrity sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==
+"@rollup/plugin-commonjs@^28.0.0":
+  version "28.0.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.1.tgz#e2138e31cc0637676dc3d5cae7739131f7cd565e"
+  integrity sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==
   dependencies:
     "@rollup/pluginutils" "^5.0.1"
     commondir "^1.0.1"
     estree-walker "^2.0.2"
-    glob "^8.0.3"
+    fdir "^6.2.0"
     is-reference "1.2.1"
     magic-string "^0.30.3"
+    picomatch "^4.0.2"
 
 "@rollup/plugin-node-resolve@^15.0.0":
   version "15.2.3"
@@ -4054,6 +4055,96 @@
     "@types/estree" "^1.0.0"
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
+
+"@rollup/rollup-android-arm-eabi@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.26.0.tgz#f221c519a6efb5d3652bff32351522e0fb98e392"
+  integrity sha512-gJNwtPDGEaOEgejbaseY6xMFu+CPltsc8/T+diUTTbOQLqD+bnrJq9ulH6WD69TqwqWmrfRAtUv30cCFZlbGTQ==
+
+"@rollup/rollup-android-arm64@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.26.0.tgz#196a2379d81011422fe1128e512a8811605ede16"
+  integrity sha512-YJa5Gy8mEZgz5JquFruhJODMq3lTHWLm1fOy+HIANquLzfIOzE9RA5ie3JjCdVb9r46qfAQY/l947V0zfGJ0OQ==
+
+"@rollup/rollup-darwin-arm64@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.26.0.tgz#0c83e5f25adae7f0543ac29a0ebd485a0e7cd3e4"
+  integrity sha512-ErTASs8YKbqTBoPLp/kA1B1Um5YSom8QAc4rKhg7b9tyyVqDBlQxy7Bf2wW7yIlPGPg2UODDQcbkTlruPzDosw==
+
+"@rollup/rollup-darwin-x64@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.26.0.tgz#8131b174ca8cec04e2041e42eb8382afe31095c8"
+  integrity sha512-wbgkYDHcdWW+NqP2mnf2NOuEbOLzDblalrOWcPyY6+BRbVhliavon15UploG7PpBRQ2bZJnbmh8o3yLoBvDIHA==
+
+"@rollup/rollup-freebsd-arm64@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.26.0.tgz#550a0ebf5bea6ceee79dc2f75a0bcef7d660de2c"
+  integrity sha512-Y9vpjfp9CDkAG4q/uwuhZk96LP11fBz/bYdyg9oaHYhtGZp7NrbkQrj/66DYMMP2Yo/QPAsVHkV891KyO52fhg==
+
+"@rollup/rollup-freebsd-x64@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.26.0.tgz#51ca2e6d9ce72e63d5201607651732e5300a6f81"
+  integrity sha512-A/jvfCZ55EYPsqeaAt/yDAG4q5tt1ZboWMHEvKAH9Zl92DWvMIbnZe/f/eOXze65aJaaKbL+YeM0Hz4kLQvdwg==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.26.0.tgz#ae71d6aa81e702c4efb72c1a67a6a4e790267a1b"
+  integrity sha512-paHF1bMXKDuizaMODm2bBTjRiHxESWiIyIdMugKeLnjuS1TCS54MF5+Y5Dx8Ui/1RBPVRE09i5OUlaLnv8OGnA==
+
+"@rollup/rollup-linux-arm-musleabihf@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.26.0.tgz#6aa7baa5c39c095fa5f9804e283e126697e0342a"
+  integrity sha512-cwxiHZU1GAs+TMxvgPfUDtVZjdBdTsQwVnNlzRXC5QzIJ6nhfB4I1ahKoe9yPmoaA/Vhf7m9dB1chGPpDRdGXg==
+
+"@rollup/rollup-linux-arm64-gnu@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.26.0.tgz#2b06e147ca68c7729ca38e5c7a514d1b00f4d151"
+  integrity sha512-4daeEUQutGRCW/9zEo8JtdAgtJ1q2g5oHaoQaZbMSKaIWKDQwQ3Yx0/3jJNmpzrsScIPtx/V+1AfibLisb3AMQ==
+
+"@rollup/rollup-linux-arm64-musl@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.26.0.tgz#70f8cacb255800e4cad41bdbe447432354288909"
+  integrity sha512-eGkX7zzkNxvvS05ROzJ/cO/AKqNvR/7t1jA3VZDi2vRniLKwAWxUr85fH3NsvtxU5vnUUKFHKh8flIBdlo2b3Q==
+
+"@rollup/rollup-linux-powerpc64le-gnu@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.26.0.tgz#21aed3ef42518b7fe33f4037a14b0939a071cf75"
+  integrity sha512-Odp/lgHbW/mAqw/pU21goo5ruWsytP7/HCC/liOt0zcGG0llYWKrd10k9Fj0pdj3prQ63N5yQLCLiE7HTX+MYw==
+
+"@rollup/rollup-linux-riscv64-gnu@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.26.0.tgz#fe27eb8cbd3a6e0706459781c2463b624f785696"
+  integrity sha512-MBR2ZhCTzUgVD0OJdTzNeF4+zsVogIR1U/FsyuFerwcqjZGvg2nYe24SAHp8O5sN8ZkRVbHwlYeHqcSQ8tcYew==
+
+"@rollup/rollup-linux-s390x-gnu@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.26.0.tgz#80289a528dd333b0e277efd93bfa8e2cdd27e5eb"
+  integrity sha512-YYcg8MkbN17fMbRMZuxwmxWqsmQufh3ZJFxFGoHjrE7bv0X+T6l3glcdzd7IKLiwhT+PZOJCblpnNlz1/C3kGQ==
+
+"@rollup/rollup-linux-x64-gnu@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.26.0.tgz#9909570be5cb738c23858c94308d37dde363eb7e"
+  integrity sha512-ZuwpfjCwjPkAOxpjAEjabg6LRSfL7cAJb6gSQGZYjGhadlzKKywDkCUnJ+KEfrNY1jH5EEoSIKLCb572jSiglA==
+
+"@rollup/rollup-linux-x64-musl@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.26.0.tgz#371315e032497f7a46f64b4ebcd207313b7f6669"
+  integrity sha512-+HJD2lFS86qkeF8kNu0kALtifMpPCZU80HvwztIKnYwym3KnA1os6nsX4BGSTLtS2QVAGG1P3guRgsYyMA0Yhg==
+
+"@rollup/rollup-win32-arm64-msvc@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.26.0.tgz#f4b4e0747710ba287eb2e2a011538ee2ed7f74d3"
+  integrity sha512-WUQzVFWPSw2uJzX4j6YEbMAiLbs0BUysgysh8s817doAYhR5ybqTI1wtKARQKo6cGop3pHnrUJPFCsXdoFaimQ==
+
+"@rollup/rollup-win32-ia32-msvc@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.26.0.tgz#2eeabbc99342dafe04613a76c441be4ebcca49c3"
+  integrity sha512-D4CxkazFKBfN1akAIY6ieyOqzoOoBV1OICxgUblWxff/pSjCA2khXlASUx7mK6W1oP4McqhgcCsu6QaLj3WMWg==
+
+"@rollup/rollup-win32-x64-msvc@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.26.0.tgz#a3ae3da434a4ba0785312e963ae4c1239470403a"
+  integrity sha512-2x8MO1rm4PGEP0xWbubJW5RtbNLk3puzAMaLQd3B3JHVw4KcHlmXcO+Wewx9zCoo7EUFiMlu/aZbCJ7VjMzAag==
 
 "@rollup/stream@^3.0.1":
   version "3.0.1"
@@ -4193,6 +4284,11 @@
   version "0.0.46"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.46.tgz#0fb6bfbbeabd7a30880504993369c4bf1deab1fe"
   integrity sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
+
+"@types/estree@1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
+  integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
 "@types/estree@^1.0.0":
   version "1.0.5"
@@ -4723,25 +4819,32 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn-walk@^8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.0.0.tgz#56ae4c0f434a45fff4a125e7ea95fa9c98f67a16"
-  integrity sha512-oZRad/3SMOI/pxbbmqyurIx7jHw1wZDcR9G44L8pUVFEomX/0dH89SrM1KaDXuv1NpzAXz6Op/Xu/Qd5XXzdEA==
-
 acorn-walk@^8.1.1, acorn-walk@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn-walk@^8.3.4:
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
+  integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
+  dependencies:
+    acorn "^8.11.0"
 
 acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.0.1, acorn@^8.0.5, acorn@^8.4.1, acorn@^8.6.0, acorn@^8.7.0, acorn@^8.9.0:
+acorn@^8.0.5, acorn@^8.4.1, acorn@^8.6.0, acorn@^8.7.0, acorn@^8.9.0:
   version "8.11.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
+
+acorn@^8.11.0, acorn@^8.14.0:
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
+  integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
 
 acorn@^8.8.2:
   version "8.11.2"
@@ -8311,6 +8414,11 @@ fdir@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.0.2.tgz#077480393c4b20583e389b1bd72b9e964a1e310c"
   integrity sha512-XJVxBciDoEpRipMYyrTCqVQA4jMTfHNiYNy8OvIGTaQzEFPuMJEvmps+Rouo6rsnivkQax9s5m5gy1lHmY2Hmg==
+
+fdir@^6.2.0:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.2.tgz#ddaa7ce1831b161bc3657bb99cb36e1622702689"
+  integrity sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==
 
 fecha@^4.2.0:
   version "4.2.3"
@@ -13462,6 +13570,11 @@ picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
+
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -15030,11 +15143,31 @@ rollup-plugin-analyzer@^4.0.0:
   resolved "https://registry.yarnpkg.com/rollup-plugin-analyzer/-/rollup-plugin-analyzer-4.0.0.tgz#96b757ed64a098b59d72f085319e68cdd86d5798"
   integrity sha512-LL9GEt3bkXp6Wa19SNR5MWcvHNMvuTFYg+eYBZN2OIFhSWN+pEJUQXEKu5BsOeABob3x9PDaLKW7w5iOJnsESQ==
 
-rollup@^3.29.4:
-  version "3.29.4"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.4.tgz#4d70c0f9834146df8705bfb69a9a19c9e1109981"
-  integrity sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==
+rollup@^4.26.0:
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.26.0.tgz#a3e5fb29d50953633a2fd4506da6448d93268944"
+  integrity sha512-ilcl12hnWonG8f+NxU6BlgysVA0gvY2l8N0R84S1HcINbW20bvwuCngJkkInV6LXhwRpucsW5k1ovDwEdBVrNg==
+  dependencies:
+    "@types/estree" "1.0.6"
   optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.26.0"
+    "@rollup/rollup-android-arm64" "4.26.0"
+    "@rollup/rollup-darwin-arm64" "4.26.0"
+    "@rollup/rollup-darwin-x64" "4.26.0"
+    "@rollup/rollup-freebsd-arm64" "4.26.0"
+    "@rollup/rollup-freebsd-x64" "4.26.0"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.26.0"
+    "@rollup/rollup-linux-arm-musleabihf" "4.26.0"
+    "@rollup/rollup-linux-arm64-gnu" "4.26.0"
+    "@rollup/rollup-linux-arm64-musl" "4.26.0"
+    "@rollup/rollup-linux-powerpc64le-gnu" "4.26.0"
+    "@rollup/rollup-linux-riscv64-gnu" "4.26.0"
+    "@rollup/rollup-linux-s390x-gnu" "4.26.0"
+    "@rollup/rollup-linux-x64-gnu" "4.26.0"
+    "@rollup/rollup-linux-x64-musl" "4.26.0"
+    "@rollup/rollup-win32-arm64-msvc" "4.26.0"
+    "@rollup/rollup-win32-ia32-msvc" "4.26.0"
+    "@rollup/rollup-win32-x64-msvc" "4.26.0"
     fsevents "~2.3.2"
 
 run-async@^2.2.0, run-async@^2.4.0:


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1218 

## Documentation 

N / A

## Summary of Changes

1. Upgrade to latest version of Acorn that now natively supports Import Attributes syntax
1. Upgrade to Rollup v4 and bump all relevant Rollup plugins (which now also supports import attributes in some plugin hooks!)
1. Add test cases to validate support for things like static and private `class` fields
1. Had originally tried fixing https://github.com/ProjectEvergreen/greenwood/issues/1183 but to support all this across browser, API routes, and SSR page bundling, needed to make all these above upgrades anyway
1. Upgrade to [v0.15.1](https://github.com/ProjectEvergreen/wcc/releases/tag/0.15.1) of WCC

## TODO
1. [x] Upstream this change to WCC and bump here - https://github.com/ProjectEvergreen/wcc/issues/173
1. [x] WCC also needs some help for processing new syntax - https://github.com/ProjectEvergreen/wcc/issues/174
1. [x] archive / deprecate our custom fork - https://github.com/ProjectEvergreen/escodegen-esm