### PR TITLE
feature/issue 1328 customize Vercel adapter serverless runtime nodejs version

### DIFF
--- a/packages/plugin-adapter-vercel/README.md
+++ b/packages/plugin-adapter-vercel/README.md
@@ -61,7 +61,26 @@ export default {
 }
 ```
 
+## Options
+
+### Runtime
+
+Vercel supports [multiple semver major NodeJS versions](https://vercel.com/docs/functions/runtimes/node-js/node-js-versions#default-and-available-versions) for the serverless runtime as part of the [build output API](https://vercel.com/docs/build-output-api/v3/primitives#serverless-functions).  With the **runtime** option, you can configure your functions for any supported NodeJS version.  Current default version is `nodejs20.x`. 
+
+```javascript
+import { greenwoodPluginAdapterVercel } from '@greenwood/plugin-adapter-vercel';
+
+export default {
+  plugins: [
+    greenwoodPluginAdapterVercel({
+      runtime: 'nodejs22.x'
+    })
+  ]
+}
+```
+
 ## Caveats
+
 1. [Edge runtime](https://vercel.com/docs/concepts/functions/edge-functions) is not supported ([yet](https://github.com/ProjectEvergreen/greenwood/issues/1141)).
 1. The Vercel CLI (`vercel dev`) is not compatible with Build Output v3.
     ```sh

--- a/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/build.default.options-runtime.spec.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/build.default.options-runtime.spec.js
@@ -1,0 +1,155 @@
+/*
+ * Use Case
+ * Run Greenwood with the Vercel adapter plugin and setting the runtime option.
+ *
+ * User Result
+ * Should generate a static Greenwood build with serverless and edge functions output.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * import { greenwoodPluginAdapterVercel } from '@greenwood/plugin-adapter-vercel';
+ *
+ * {
+ *   plugins: [{
+ *     greenwoodPluginAdapterVercel({
+ *       runtime: 'nodejs22.x
+ *     })
+ *   }]
+ * }
+ *
+ * User Workspace
+ * package.json
+ * src/
+ *   pages/
+ *     index.js
+ */
+import chai from 'chai';
+import fs from 'fs/promises';
+import glob from 'glob-promise';
+import { JSDOM } from 'jsdom';
+import path from 'path';
+import { checkResourceExists } from '@greenwood/cli/src/lib/resource-utils.js';
+import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { normalizePathnameForWindows } from '@greenwood/cli/src/lib/resource-utils.js';
+import { Runner } from 'gallinago';
+import { fileURLToPath } from 'url';
+
+const expect = chai.expect;
+
+describe('Build Greenwood With: ', function() {
+  const LABEL = 'Vercel Adapter plugin output with runtime option set';
+  const cliPath = path.join(process.cwd(), 'packages/cli/src/index.js');
+  const outputPath = fileURLToPath(new URL('.', import.meta.url));
+  const vercelOutputFolder = new URL('./.vercel/output/', import.meta.url);
+  const vercelFunctionsOutputUrl = new URL('./functions/', vercelOutputFolder);
+  const hostname = 'http://www.example.com';
+  let runner;
+
+  before(function() {
+    this.context = {
+      publicDir: path.join(outputPath, 'public')
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function() {
+    before(function() {
+      runner.setup(outputPath, getSetupFiles(outputPath));
+      runner.runCommand(cliPath, 'build');
+    });
+
+    describe('Default Output', function() {
+      let configFile;
+      let functionFolders;
+
+      before(async function() {
+        configFile = await fs.readFile(new URL('./config.json', vercelOutputFolder), 'utf-8');
+        functionFolders = await glob.promise(path.join(normalizePathnameForWindows(vercelFunctionsOutputUrl), '**/*.func'));
+      });
+
+      it('should output the expected number of serverless function output folders', function() {
+        expect(functionFolders.length).to.be.equal(1);
+      });
+
+      it('should output the expected configuration file for the build output', function() {
+        expect(configFile).to.be.equal('{"version":3}');
+      });
+
+      it('should output the expected package.json for each serverless function', function() {
+        functionFolders.forEach(async (folder) => {
+          const packageJson = await fs.readFile(new URL('./package.json', `file://${folder}/`), 'utf-8');
+
+          expect(packageJson).to.be.equal('{"type":"module"}');
+        });
+      });
+
+      it('should output the expected .vc-config.json for each serverless function with runtime option honored', function() {
+        functionFolders.forEach(async (folder) => {
+          const packageJson = await fs.readFile(new URL('./vc-config.json', `file://${folder}/`), 'utf-8');
+
+          expect(packageJson).to.be.equal('{"runtime":"nodejs22.x","handler":"index.js","launcherType":"Nodejs","shouldAddHelpers":true}');
+        });
+      });
+    });
+
+    describe('Static directory output', function() {
+      it('should return the expected response when the serverless adapter entry point handler is invoked', async function() {
+        const publicFiles = await glob.promise(path.join(outputPath, 'public/**/**'));
+
+        for (const file of publicFiles) {
+          const buildOutputDestination = file.replace(path.join(outputPath, 'public'), path.join(vercelOutputFolder.pathname, 'static'));
+          const itExists = await checkResourceExists(new URL(`file://${buildOutputDestination}`));
+
+          expect(itExists).to.be.equal(true);
+        }
+      });
+    });
+
+    describe('Index SSR Page adapter', function() {
+      it('should return the expected response when the serverless adapter entry point handler is invoked', async function() {
+        const handler = (await import(new URL('./index.func/index.js', vercelFunctionsOutputUrl))).default;
+        const response = {
+          headers: new Headers()
+        };
+
+        await handler({
+          url: `${hostname}/`,
+          headers: {
+            host: hostname
+          },
+          method: 'GET'
+        }, {
+          status: function(code) {
+            response.status = code;
+          },
+          send: function(body) {
+            response.body = body;
+          },
+          setHeader: function(key, value) {
+            response.headers.set(key, value);
+          }
+        });
+
+        const { status, body, headers } = response;
+        const dom = new JSDOM(body);
+        const headings = dom.window.document.querySelectorAll('body > h1');
+
+        expect(status).to.be.equal(200);
+        expect(headers.get('content-type')).to.be.equal('text/html');
+
+        expect(headings.length).to.be.equal(1);
+        expect(headings[0].textContent).to.be.equal('Just here causing trouble! :D');
+      });
+    });
+  });
+
+  after(function() {
+    runner.teardown([
+      path.join(outputPath, '.vercel'),
+      ...getOutputTeardownFiles(outputPath)
+    ]);
+  });
+
+});

--- a/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/build.default.options-runtime.spec.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/build.default.options-runtime.spec.js
@@ -31,7 +31,7 @@ import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
 import { checkResourceExists } from '@greenwood/cli/src/lib/resource-utils.js';
-import { getSetupFiles, getOutputTeardownFiles } from '../../../../../test/utils.js';
+import { getOutputTeardownFiles } from '../../../../../test/utils.js';
 import { normalizePathnameForWindows } from '@greenwood/cli/src/lib/resource-utils.js';
 import { Runner } from 'gallinago';
 import { fileURLToPath } from 'url';
@@ -56,7 +56,7 @@ describe('Build Greenwood With: ', function() {
 
   describe(LABEL, function() {
     before(function() {
-      runner.setup(outputPath, getSetupFiles(outputPath));
+      runner.setup(outputPath);
       runner.runCommand(cliPath, 'build');
     });
 

--- a/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/greenwood.config.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/greenwood.config.js
@@ -1,0 +1,9 @@
+import { greenwoodPluginAdapterVercel } from '../../../src/index.js';
+
+export default {
+  plugins: [
+    greenwoodPluginAdapterVercel({
+      runtime: 'nodejs22.x'
+    })
+  ]
+};

--- a/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/src/pages/index.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/src/pages/index.js
@@ -1,0 +1,5 @@
+export default class IndexPage extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = '<h1>Just here causing trouble! :D</h1>';
+  }
+}

--- a/packages/plugin-adapter-vercel/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.default/build.default.spec.js
@@ -106,7 +106,7 @@ describe('Build Greenwood With: ', function() {
         functionFolders.forEach(async (folder) => {
           const packageJson = await fs.readFile(new URL('./vc-config.json', `file://${folder}/`), 'utf-8');
 
-          expect(packageJson).to.be.equal('{"runtime":"nodejs18.x","handler":"index.js","launcherType":"Nodejs","shouldAddHelpers":true}');
+          expect(packageJson).to.be.equal('{"runtime":"nodejs20.x","handler":"index.js","launcherType":"Nodejs","shouldAddHelpers":true}');
         });
       });
     });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1329 

## Documentation 

N / A

## Summary of Changes

1. Add for a **runtime** option for the Vercel adapter
1. Set new default version to `nodejs20.x`
1. Document **runtime** option in the plugin's README

## TODO

1. [x] Should align with final minimum version coming out of #1202 / #1326
   - let's stick with Node 18 for the default - going to stick with `20.x` for now, actually - https://github.com/ProjectEvergreen/greenwood/pull/1330#pullrequestreview-2526726633