### PR TITLE
docs/better document and clarify Lit SSR plugin usage caveats

### DIFF
--- a/packages/plugin-renderer-lit/README.md
+++ b/packages/plugin-renderer-lit/README.md
@@ -41,6 +41,7 @@ $ pnpm add -D @greenwood/plugin-renderer-lit
 1. Please familiarize yourself with some of the [caveats](https://lit.dev/docs/ssr/overview/#library-status) called out in the Lit docs, like:
     - Lit SSR [**only** renders into declarative shadow roots](https://github.com/lit/lit/issues/3080#issuecomment-1165158794), so you will have to keep browser support and polyfill usage in mind.
     - At this time, `LitElement` does not support `async` work.  You can follow along with this issue [in the Lit repo](https://github.com/lit/lit/issues/2469).
+1. Lit SSR does [not support native `HTMLElement`](https://github.com/lit/lit/discussions/2092) so you will need to use `LitElement` as your base class in all instances.
 1. Lit only supports templates on the server side for HTML generated content, thus Greenwood's `getBody` API must be used.  We would love for [server only components](https://github.com/lit/lit/issues/2469#issuecomment-1759583861) to be a thing though!
 1. Lit does not support [`CSSStyleSheet` (aka CSS Modules) in their SSR DOM shim](https://github.com/lit/lit/issues/2631#issuecomment-1065400805).
 1. Full hydration support is not available yet.  See [this Greenwood issue](https://github.com/ProjectEvergreen/greenwood/issues/880) to follow along with when it will land.

--- a/packages/plugin-renderer-lit/README.md
+++ b/packages/plugin-renderer-lit/README.md
@@ -36,14 +36,19 @@ $ yarn add @greenwood/plugin-renderer-lit --dev
 $ pnpm add -D @greenwood/plugin-renderer-lit
 ```
 
+For **pnpm**, you will also want to add this to your _.npmrc_ file
+```sh
+public-hoist-pattern[]=@lit-labs/*
+```
+
 ## Caveats
 
-1. Please familiarize yourself with some of the [caveats](https://lit.dev/docs/ssr/overview/#library-status) called out in the Lit docs, like:
+1. Lit SSR [does not support native `HTMLElement`](https://github.com/lit/lit/discussions/2092) which means **_you will need to use `LitElement` as your base class in all instances where you are pre-rendering or using SSR_**.
+1. Be aware of the known documented [caveats](https://lit.dev/docs/ssr/overview/#library-status) as called out in the Lit SSR docs, such as:
     - Lit SSR [**only** renders into declarative shadow roots](https://github.com/lit/lit/issues/3080#issuecomment-1165158794), so you will have to keep browser support and polyfill usage in mind.
-    - At this time, `LitElement` does not support `async` work.  You can follow along with this issue [in the Lit repo](https://github.com/lit/lit/issues/2469).
-1. Lit SSR does [not support native `HTMLElement`](https://github.com/lit/lit/discussions/2092) so you will need to use `LitElement` as your base class in all instances.
+    - At this time, `LitElement` does not support `async` work (e.g. for `connectedCallback`).  You can follow along with this issue [in the Lit repo](https://github.com/lit/lit/issues/2469).
 1. Lit only supports templates on the server side for HTML generated content, thus Greenwood's `getBody` API must be used.  We would love for [server only components](https://github.com/lit/lit/issues/2469#issuecomment-1759583861) to be a thing though!
-1. Lit does not support [`CSSStyleSheet` (aka CSS Modules) in their SSR DOM shim](https://github.com/lit/lit/issues/2631#issuecomment-1065400805).
+1. Lit does not support [`CSSStyleSheet` (aka CSS Modules) in their SSR DOM shim](https://github.com/lit/lit/issues/4862).  As an alternative, you may consider using Greenwood's [**Raw adapter**](https://greenwoodjs.dev/docs/plugins/raw/) to inline CSS in `<style>` tags into your custom elements.
 1. Full hydration support is not available yet.  See [this Greenwood issue](https://github.com/ProjectEvergreen/greenwood/issues/880) to follow along with when it will land.
 
 > See [this repo](https://github.com/thescientist13/greenwood-lit-ssr) for a full demo of isomorphic Lit SSR with SSR pages and API routes deployed to Vercel serverless functions.


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

Was called out in https://github.com/ProjectEvergreen/greenwood/issues/1336 that this caveat was missing.  Could have sworn it was there 🤦 

## Documentation 

N / A

## Summary of Changes

1. Properly callout native `HTMLElement` caveat in Lit SSR
1. Share tip on Lit SSR styles work around using Raw plugin + `<style>` tag
1. Document pnpm hoisting strategy for **lit-labs** dependencies

## TODO
1. [x] Incorporate additional caveats feedback around rendering strategies
1. [x] Lit SSR styles work around (raw plugin + style tag)
1. [x] pnpm hoisting strategy
1. [x] make `HTMLElement` limitation more up-front on the website - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/147