### PR TITLE
bug/issue 1338 better detection for external CSS import statements

### DIFF
--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -170,7 +170,7 @@ async function trackResourcesForRoute(html, compilation, route) {
 }
 
 function isLocalLink(url = '') {
-  return url !== '' && (url.indexOf('http') !== 0 && url.indexOf('//') !== 0);
+  return url !== '' && !url.startsWith('http') && !url.startsWith('//');
 }
 
 // TODO handle full request
@@ -269,5 +269,6 @@ export {
   requestAsObject,
   resolveForRelativeUrl,
   trackResourcesForRoute,
-  transformKoaRequestIntoStandardRequest
+  transformKoaRequestIntoStandardRequest,
+  isLocalLink
 };

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -10,6 +10,7 @@ import { parse, walk } from 'css-tree';
 import { ResourceInterface } from '../../lib/resource-interface.js';
 import { hashString } from '../../lib/hashing-utils.js';
 import { getResolvedHrefFromPathnameShortcut } from '../../lib/node-modules-utils.js';
+import { isLocalLink } from '../../lib/resource-utils.js';
 
 function bundleCss(body, sourceUrl, compilation, workingUrl) {
   const { projectDirectory, outputDir, userWorkspace } = compilation.context;
@@ -27,7 +28,7 @@ function bundleCss(body, sourceUrl, compilation, workingUrl) {
       if ((type === 'String' || type === 'Url') && this.atrulePrelude && this.atrule.name === 'import') {
         const { value } = node;
 
-        if (!value.startsWith('http')) {
+        if (isLocalLink(value)) {
           if (value.indexOf('.') === 0 || value.indexOf('/node_modules') === 0) {
             const resolvedUrl = value.startsWith('/node_modules')
               ? new URL(getResolvedHrefFromPathnameShortcut(value, projectDirectory))
@@ -48,7 +49,7 @@ function bundleCss(body, sourceUrl, compilation, workingUrl) {
           optimizedCss += `@import url('${value}');`;
         }
       } else if (type === 'Url' && this.atrule?.name !== 'import') {
-        if (value.startsWith('http') || value.startsWith('//') || value.startsWith('data:')) {
+        if (!isLocalLink(value) || value.startsWith('data:')) {
           optimizedCss += `url('${value}')`;
           return;
         }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #1338 

Noticed that CSS `@import` statements starting with `//`, eg: `@import url('//fonts.googleapis.com/css?family=Raleway&display=swap');` was production a not found warning based on [this change](https://github.com/ProjectEvergreen/greenwood/pull/1342/files#diff-e20a60e7b88e17250746babe9a6f80b88def96d34e3901541b6ced7dd668b378R30)

```sh
//fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap from file => file:///Users/owenbuckley/Workspace/project-evergreen/greenwood/packages/plugin-renderer-lit/test/cases/build.prerender.getting-started/src/styles/theme.css
```  

## Documentation 

N / A

## Summary of Changes

1. Better detection for remote URLs in CSS `@import`