### PR TITLE
bug/issue 1346 bundle transitive CSS `url(...)` references

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,6 +63,7 @@
     "@spectrum-web-components/action-menu": "^1.0.1",
     "@spectrum-web-components/styles": "^1.0.1",
     "@uswds/web-components": "^0.0.1-alpha",
+    "font-awesome": "^4.6.3",
     "geist": "^1.2.0",
     "lit": "^3.1.0",
     "lit-redux-router": "~0.20.0",

--- a/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
@@ -14,6 +14,8 @@
  * src/
  *   components/
  *     header.js
+ *   foo/
+ *     bar.baz
  *   images/
  *     webcomponents.jpg
  *   pages/
@@ -194,6 +196,14 @@ describe('Build Greenwood With: ', function() {
             const styleTag = Array.from(dom.window.document.querySelectorAll('head style'));
 
             expect(styleTag[0].textContent).to.contain(`html{background-image:url('/${imagePath}')}`);
+          });
+        });
+
+        describe('absolute user workspace reference', () => {
+          const resourcePath = 'foo/bar.642520792.baz';
+
+          it('should have the expected resource reference from the user\'s workspace in the output directory', async function() {
+            expect(await glob.promise(path.join(this.context.publicDir, resourcePath))).to.have.lengthOf(1);
           });
         });
       });

--- a/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
@@ -52,16 +52,21 @@ describe('Build Greenwood With: ', function() {
   describe(LABEL, function() {
 
     before(async function() {
-      const geistFont = await getDependencyFiles(
+      // this package has a known issue with import.meta.resolve
+      // if this gets fixed, we can remove the need for this setup
+      // https://github.com/vercel/geist-font/issues/150
+      const geistPackageJson = await getDependencyFiles(
+        `${process.cwd()}/node_modules/geist/package.json`,
+        `${outputPath}/node_modules/geist/`
+      );
+      const geistFonts = await getDependencyFiles(
         `${process.cwd()}/node_modules/geist/dist/fonts/geist-sans/*`,
         `${outputPath}/node_modules/geist/dist/fonts/geist-sans/`
       );
 
       runner.setup(outputPath, [
-        // this package has a known issue with import.meta.resolve
-        // if this gets fixed, we can remove the need for this setup
-        // https://github.com/vercel/geist-font/issues/150
-        ...geistFont
+        ...geistPackageJson,
+        ...geistFonts
       ]);
       runner.runCommand(cliPath, 'build');
     });

--- a/packages/cli/test/cases/build.config.optimization-default/fixtures/expected.css
+++ b/packages/cli/test/cases/build.config.optimization-default/fixtures/expected.css
@@ -62,7 +62,7 @@ h1:has(+h2){margin:0 0 0.25rem 0}
 
 .snippet{margin:var(--size-4) 0;padding:0 var(--size-4);}
 
-h1{background-image:url('/foo/bar.baz')}
+h1{background-image:url('/foo/bar.642520792.baz')}
 
 .has-success{background-image:url('data:image/svg+xml;...')}
 

--- a/packages/cli/test/cases/build.config.optimization-default/src/foo/bar.baz
+++ b/packages/cli/test/cases/build.config.optimization-default/src/foo/bar.baz
@@ -1,0 +1,1 @@
+some file

--- a/packages/cli/test/cases/build.config.optimization-default/src/pages/index.html
+++ b/packages/cli/test/cases/build.config.optimization-default/src/pages/index.html
@@ -9,7 +9,7 @@
 
       @font-face {
         font-family: "Geist-Sans";
-        src: url('../../node_modules/geist/dist/fonts/geist-sans/Geist-Regular.woff2') format("truetype");
+        src: url('/node_modules/geist/dist/fonts/geist-sans/Geist-Regular.woff2') format("truetype");
       }
 
       html {

--- a/packages/cli/test/cases/build.default.import-node-modules/src/styles/theme.css
+++ b/packages/cli/test/cases/build.default.import-node-modules/src/styles/theme.css
@@ -1,1 +1,2 @@
 @import url('/node_modules/@spectrum-web-components/styles/all-large-dark.css');
+@import url('/node_modules/font-awesome/css/font-awesome.css');

--- a/www/assets/fonts/source-sans-pro.css
+++ b/www/assets/fonts/source-sans-pro.css
@@ -5,7 +5,7 @@
   font-weight: 400;
   font-display: swap;
   src: local('Source Sans Pro Regular'), local('SourceSansPro-Regular'),
-    url('/assets/fonts/source-sans-pro-v13-latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
-    url('/assets/fonts/source-sans-pro-v13-latin-regular.woff') format('woff'), /* Modern Browsers */
-    url('/assets/fonts/source-sans-pro-v13-latin-regular.ttf') format('truetype'); /* Safari, Android, iOS */
+    url('./source-sans-pro-v13-latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
+    url('./source-sans-pro-v13-latin-regular.woff') format('woff'), /* Modern Browsers */
+    url('./source-sans-pro-v13-latin-regular.ttf') format('truetype'); /* Safari, Android, iOS */
 }

--- a/www/assets/fonts/source-sans-pro.css
+++ b/www/assets/fonts/source-sans-pro.css
@@ -1,11 +1,11 @@
-/* source-sans-pro-regular - latin */
+/* intentionally mixing paths for CSS bundling testing */
 @font-face {
   font-family: 'Source Sans Pro';
   font-style: normal;
   font-weight: 400;
   font-display: swap;
   src: local('Source Sans Pro Regular'), local('SourceSansPro-Regular'),
-    url('./source-sans-pro-v13-latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
+    url('/assets/fonts/source-sans-pro-v13-latin-regular.woff2') format('woff2'), /* Super Modern Browsers */
     url('./source-sans-pro-v13-latin-regular.woff') format('woff'), /* Modern Browsers */
     url('./source-sans-pro-v13-latin-regular.ttf') format('truetype'); /* Safari, Android, iOS */
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8976,6 +8976,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.15.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+font-awesome@^4.6.3:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
+  integrity sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -16022,7 +16027,7 @@ sort-keys@^2.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-"source-map-js@>=0.6.2 <2.0.0":
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -16031,11 +16036,6 @@ source-map-js@^1.0.1, source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
-
-source-map-js@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
-  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 source-map-resolve@^0.5.0:
   version "0.5.3"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1346 

> Should now see a lot less _Unable to resolve ..._ messages, as per https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/101

## Documentation 

1. [x] Will want to make sure any of these _node_modules_ resolutions carry over to the CSS side as well - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/issues/144

## Summary of Changes

1. Leverage `workingUrl` to better handling bundling of relative `url(...)` references in CSS files
1. Add test cases

## TODO
1. [x] Are we properly handling all explicit case of `./`. `../`, and `/` (where `/` is not a reference to _node_modules_)