### PR TITLE
bug/issue 1349 handle false positive package.json files in packages when running walker package ranger

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,6 +68,7 @@
     "lit": "^3.1.0",
     "lit-redux-router": "~0.20.0",
     "lodash-es": "^4.17.20",
+    "luxon": "^3.5.0",
     "postcss-nested": "^4.1.2",
     "pwa-helpers": "^0.9.1",
     "redux": "^5.0.1",

--- a/packages/cli/src/lib/walker-package-ranger.js
+++ b/packages/cli/src/lib/walker-package-ranger.js
@@ -35,7 +35,7 @@ function resolveBareSpecifier(specifier) {
  * {
  *   dependencyName: 'lit-html',
  *   resolved: 'file:///path/to/project/greenwood-lit-ssr/node_modules/.pnpm/lit-html@3.2.1/node_modules/lit-html/node/lit-html.js',
- *   root: 'file:///path/to/project/greenwood-lit-ssr/node_modules/.pnpm/lit-html@3.2.1/node_modules/lit-html/package.json'
+ *   root: 'file:///path/to/project/greenwood-lit-ssr/node_modules/.pnpm/lit-html@3.2.1/node_modules/lit-html/
  *  }
  */
 function derivePackageRoot(resolved) {
@@ -52,7 +52,15 @@ function derivePackageRoot(resolved) {
 
   for (const segment of segments.slice(1)) {
     if (fs.existsSync(new URL('./package.json', root))) {
-      break;
+      // we have to check that this package.json actually has as a name AND version
+      // https://github.com/moment/luxon/issues/1543#issuecomment-2546858540
+      // https://github.com/ProjectEvergreen/greenwood/issues/1349
+      const resolvedPackageJson = JSON.parse(fs.readFileSync(new URL('./package.json', root), 'utf-8'));
+      const { name, version } = resolvedPackageJson;
+
+      if (name && version) {
+        break;
+      }
     }
 
     root = root.replace(`${segment}/`, '');

--- a/packages/cli/test/cases/develop.default/import-map.snapshot.json
+++ b/packages/cli/test/cases/develop.default/import-map.snapshot.json
@@ -4149,5 +4149,7 @@
   "binary-extensions": "/~/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/binary-extensions/index.js",
   "readdirp": "/~/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/readdirp/index.js",
   "immutable": "/~/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/immutable/dist/immutable.es.js",
-  "source-map-js": "/~/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/source-map-js/source-map.js"
+  "source-map-js": "/~/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/source-map-js/source-map.js",
+  "luxon": "/~/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/luxon/src/luxon.js",
+  "luxon/package.json": "/~/Users/owenbuckley/Workspace/project-evergreen/greenwood/node_modules/luxon/package.json"
 }

--- a/packages/cli/test/cases/develop.default/package.json
+++ b/packages/cli/test/cases/develop.default/package.json
@@ -6,6 +6,7 @@
     "@spectrum-css/card": "^9.3.0",
     "@spectrum-web-components/action-menu": "^1.0.1",
     "@uswds/web-components": "^0.0.1-alpha",
-    "lit": "^3.1.0"
+    "lit": "^3.1.0",
+    "luxon": "^3.5.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11918,6 +11918,11 @@ luxon@^3.2.1:
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.3.0.tgz#d73ab5b5d2b49a461c47cedbc7e73309b4805b48"
   integrity sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==
 
+luxon@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.5.0.tgz#6b6f65c5cd1d61d1fd19dbf07ee87a50bf4b8e20"
+  integrity sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==
+
 macos-release@^2.2.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.4.1.tgz#64033d0ec6a5e6375155a74b1a1eba8e509820ac"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1349 

## Documentation 

N / A

## Summary of Changes

1. Check for minimal valid _package.json_ files when running walker package ranger
1. Add a test case
1. Smoke tested against [all demos](https://github.com/thescientist13/greenwood-lit-ssr/pulls?q=is%3Apr+is%3Aopen+label%3Ademo)