### PR TITLE
bug/issue 1350 make sure to clone responses when running resource plugin serve block in dev server

### DIFF
--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -69,7 +69,7 @@ async function getDevServer(compilation) {
           const current = await plugin.serve(url, request);
           const merged = mergeResponse(response.clone(), current.clone());
 
-          response = merged;
+          response = merged.clone();
         }
       }
 
@@ -167,7 +167,7 @@ async function getDevServer(compilation) {
     // don't interfere with external requests or API calls, only files
     // and only run in development
     if (process.env.__GWD_COMMAND__ === 'develop' && url.protocol === 'file:') { // eslint-disable-line no-underscore-dangle
-      // TODO there's probably a better way to do this with tee-ing streams but this works for now
+      // there's probably a better way to do this with tee-ing streams but this works for now
       const { header, status, message } = ctx.response;
       const response = new Response(ctx.body, {
         statusText: message,


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1350

## Documentation 

N / A

## Summary of Changes

1. `clone` merged response in the serve block for resource plugins in the dev server