### PR TITLE
bug/issue 1352 align none optimization option with output filename and contents

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -120,8 +120,7 @@ function greenwoodSyncPageResourceBundlesPlugin(compilation) {
 
           if (resourceKey === facadeModuleId) {
             const { fileName } = bundles[bundle];
-            const { rawAttributes, contents } = resource;
-            const noop = rawAttributes && rawAttributes.indexOf('data-gwd-opt="none"') >= 0 || compilation.config.optimization === 'none';
+            const { contents } = resource;
             const outputPath = new URL(`./${fileName}`, outputDir);
 
             compilation.resources.set(resource.sourcePathURL.pathname, {
@@ -130,10 +129,6 @@ function greenwoodSyncPageResourceBundlesPlugin(compilation) {
               optimizedFileContents: await fs.promises.readFile(outputPath, 'utf-8'),
               contents
             });
-
-            if (noop) {
-              await fs.promises.writeFile(outputPath, contents);
-            }
           }
         }
       }

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -377,7 +377,9 @@ class StandardCssResource extends ResourceInterface {
   }
 
   async intercept(url, request, response) {
-    let body = bundleCss(await response.text(), url, this.compilation);
+    let body = this.compilation.config.optimization !== 'none'
+      ? bundleCss(await response.text(), url, this.compilation)
+      : await response.text();
     let headers = {};
 
     if ((request.headers.get('Accept')?.indexOf('text/javascript') >= 0 || url.searchParams?.get('polyfill') === 'type-css') && !url.searchParams.has('type')) {

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -184,7 +184,7 @@ class StandardHtmlResource extends ResourceInterface {
         if (type === 'script') {
           const tag = root.querySelectorAll('script').find(script => script.getAttribute('src') === src);
 
-          if (!optimizationAttr && optimization === 'default') {
+          if (!optimizationAttr && (optimization === 'default' || optimization === 'none')) {
             const optimizedFilePath = `${basePath}/${optimizedFileName}`;
 
             body = body.replace(src, optimizedFilePath);

--- a/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
@@ -77,14 +77,14 @@ describe('Build Greenwood With: ', function() {
         });
 
         it('should have the expected <script> tag in the <head>', function() {
-          const src = jsFiles[0].replace(this.context.publicDir, '');
+          const src = jsFiles[0].replace(this.context.publicDir.replace(/\\/g, '/'), '');
           const scriptTags = Array.from(dom.window.document.querySelectorAll('head script[type="module"]')).filter(tag => tag.getAttribute('src') === src);
 
           expect(scriptTags.length).to.be.equal(1);
         });
 
         it('should have the expected preload <script> tag in the <head>', function() {
-          const src = jsFiles[0].replace(this.context.publicDir, '');
+          const src = jsFiles[0].replace(this.context.publicDir.replace(/\\/g, '/'), '');
           const scriptPreloadTags = Array.from(dom.window.document.querySelectorAll('head link[as="script"]'));
 
           expect(scriptPreloadTags.length).to.be.equal(1);
@@ -110,7 +110,7 @@ describe('Build Greenwood With: ', function() {
         });
 
         it('should have the expected preload <link> tag in the <head>', function() {
-          const href = cssFiles[0].replace(this.context.publicDir, '');
+          const href = cssFiles[0].replace(this.context.publicDir.replace(/\\/g, '/'), '');
           const linkPreloadTags = Array.from(dom.window.document.querySelectorAll('head link[as="style"]'));
 
           expect(linkPreloadTags.length).to.be.equal(1);
@@ -118,7 +118,7 @@ describe('Build Greenwood With: ', function() {
         });
 
         it('should have the expected <link> tag href  for theme.css', function() {
-          const href = cssFiles[0].replace(this.context.publicDir, '');
+          const href = cssFiles[0].replace(this.context.publicDir.replace(/\\/g, '/'), '');
           const linkTags = Array.from(dom.window.document.querySelectorAll('head link[rel="stylesheet"]')).filter(tag => tag.getAttribute('href') === href);
 
           expect(linkTags.length).to.be.equal(1);

--- a/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
@@ -77,9 +77,18 @@ describe('Build Greenwood With: ', function() {
         });
 
         it('should have the expected <script> tag in the <head>', function() {
-          const scriptTags = Array.from(dom.window.document.querySelectorAll('head script[type="module"]')).filter(tag => !tag.getAttribute('data-gwd'));
+          const src = jsFiles[0].replace(this.context.publicDir, '');
+          const scriptTags = Array.from(dom.window.document.querySelectorAll('head script[type="module"]')).filter(tag => tag.getAttribute('src') === src);
 
           expect(scriptTags.length).to.be.equal(1);
+        });
+
+        it('should have the expected preload <script> tag in the <head>', function() {
+          const src = jsFiles[0].replace(this.context.publicDir, '');
+          const scriptPreloadTags = Array.from(dom.window.document.querySelectorAll('head link[as="script"]'));
+
+          expect(scriptPreloadTags.length).to.be.equal(1);
+          expect(scriptPreloadTags[0].getAttribute('href')).to.be.equal(src);
         });
 
         it('should contain the expected <app-header> in the <body>', function() {
@@ -100,10 +109,19 @@ describe('Build Greenwood With: ', function() {
           expect(css).to.contain('{\n  margin: 0;\n  padding: 0;\n  font-family: \'Comic Sans\', sans-serif;\n}');
         });
 
-        it('should have two <link> tag in the <head>', function() {
-          const linkTags = dom.window.document.querySelectorAll('head link');
+        it('should have the expected preload <link> tag in the <head>', function() {
+          const href = cssFiles[0].replace(this.context.publicDir, '');
+          const linkPreloadTags = Array.from(dom.window.document.querySelectorAll('head link[as="style"]'));
 
-          expect(linkTags.length).to.be.equal(2);
+          expect(linkPreloadTags.length).to.be.equal(1);
+          expect(linkPreloadTags[0].getAttribute('href')).to.be.equal(href);
+        });
+
+        it('should have the expected <link> tag href  for theme.css', function() {
+          const href = cssFiles[0].replace(this.context.publicDir, '');
+          const linkTags = Array.from(dom.window.document.querySelectorAll('head link[rel="stylesheet"]')).filter(tag => tag.getAttribute('href') === href);
+
+          expect(linkTags.length).to.be.equal(1);
         });
       });
     });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1352 

## Documentation 

N / A

## Summary of Changes

1. Have standard CSS plugin honor `none` optimization setting
1. For CSS bundling, we still need to honor the contents of any plugin process
1. For JavaScript / Rollup we don't want to emit the original source contents either
1. In the standard HTML resource plugin, make sure `"none"` still pulls in the right final optimized contents
1. Update test cases

## TODO
1. [x] fix Windows build (probably a pathing issue in the test files)
1. [x] We should probably create a ticket for a completely _unbundled_ output, that doesn't even transform filename.  Basically whatever your _src/_ contents are, that is literally what will be moved over and better clarify difference / distinction between none and unbundled - https://github.com/ProjectEvergreen/greenwood/issues/1367