### PR TITLE
bug/issue 1351 better handling of frontmatter syntax for `JSON.stringify` in SSR page bundles

### DIFF
--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -6,6 +6,7 @@ import { hashString } from '../lib/hashing-utils.js';
 import { checkResourceExists, mergeResponse, normalizePathnameForWindows, trackResourcesForRoute } from '../lib/resource-utils.js';
 import path from 'path';
 import { rollup } from 'rollup';
+import { pruneGraph } from '../lib/content-utils.js';
 
 async function interceptPage(url, request, plugins, body) {
   let response = new Response(body, {
@@ -304,8 +305,8 @@ async function bundleSsrPages(compilation, optimizePlugins) {
         const moduleUrl = new URL('${relativeDepth}${pagesPathDiff}${pagePath.replace('./', '')}', import.meta.url);
 
         export async function handler(request) {
-          const compilation = JSON.parse('${JSON.stringify(compilation)}');
-          const page = JSON.parse('${JSON.stringify(page)}');
+          const compilation = JSON.parse(\`${JSON.stringify({ ...compilation, graph: pruneGraph(compilation.graph) }).replace(/\\"/g, '&quote').replace(/\\n/g, '')}\`);
+          const page = JSON.parse(\`${JSON.stringify(pruneGraph([page])[0]).replace(/\\"/g, '&quote').replace(/\\n/g, '')}\`);
           const data = await executeRouteModule({ moduleUrl, compilation, page, request });
           let staticHtml = \`${staticHtml}\`;
 

--- a/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
@@ -100,6 +100,25 @@ describe('Serve Greenwood With: ', function() {
       });
     });
 
+    // https://github.com/ProjectEvergreen/greenwood/issues/1351
+    describe('Serve command with HTML route response for the about page using various frontmatter syntaxes', function() {
+      let response;
+      let dom;
+
+      before(async function() {
+        response = await fetch(`${hostname}/about/`);
+        const body = await response.clone().text();
+        dom = new JSDOM(body);
+      });
+
+      it('should have the expected output for the page', function() {
+        const headings = dom.window.document.querySelectorAll('body > h1');
+
+        expect(headings.length).to.equal(1);
+        expect(headings[0].textContent).to.equal('Welcome to the about page!');
+      });
+    });
+
     describe('Serve command with HTML route response for artists page using "get" functions', function() {
       let response;
       let dom;

--- a/packages/cli/test/cases/serve.default.ssr/src/pages/about.md
+++ b/packages/cli/test/cases/serve.default.ssr/src/pages/about.md
@@ -1,3 +1,10 @@
-## About Page
+---
+title: |
+  Greenwood's Super Cool About Page
+imports:
+  - ../components/counter.js type="module"
+sidebar:
+  order: 1
+---
 
-Lorum Ipsum.
+# Welcome to the about page!


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1351 

## Documentation 

<!-- if this issue has been labeled with documentation, please make sure submit a PR to our website repo and link it -->
<!-- https://github.com/ProjectEvergreen/www.greenwoodjs.dev -->

## Summary of Changes

1. Handle apostrophes / single quotes
1. Handle multi-line strings
1. Handle double quotes
1. Prune graph

> Added this as a call out in the "noisy active frontmatter" section of this discussion - https://github.com/ProjectEvergreen/greenwood/discussions/1286