### PR TITLE
enhancement/avoid extension checking in Babel resource plugin intercept lifecycle

### DIFF
--- a/packages/plugin-babel/src/index.js
+++ b/packages/plugin-babel/src/index.js
@@ -37,8 +37,12 @@ class BabelResource extends ResourceInterface {
     this.contentType = ['text/javascript'];
   }
 
-  async shouldPreIntercept(url) {
-    return url.pathname.split('.').pop() === this.extensions[0] && !url.pathname.startsWith('/node_modules/');
+  async shouldPreIntercept(url, request, response) {
+    const { protocol, pathname } = url;
+
+    return protocol === 'file:'
+      && !pathname.startsWith('/node_modules/')
+      && response.headers.get('Content-Type').indexOf(this.contentType) >= 0;
   }
 
   async preIntercept(url, request, response) {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/153/files#diff-745fdda9fef5a58b2eebf6f4a4ccfffa2506fcfb7c2722295528c375bfe71681R432

## Documentation 

<!-- if this issue has been labeled with documentation, please make sure submit a PR to our website repo and link it -->
<!-- https://github.com/ProjectEvergreen/www.greenwoodjs.dev -->

## Summary of Changes

1. Refactor Babel plugin to not do extension check in intercept lifecycle