### PR TITLE
bug/issue 1368 handle bundling of relative node_modules paths for CSS `url` paths

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -91,6 +91,9 @@ function bundleCss(body, sourceUrl, compilation, workingUrl) {
           } else if (value.startsWith('/node_modules/')) {
             // if it's a node modules shortcut alias, just use that
             finalValue = value;
+          } else if (value.indexOf('../node_modules/') >= 0) {
+            // if it's a relative node_modules path, convert it to a shortcut alias
+            finalValue = `/${value.replace(/\.\.\//g, '')}`;
           } else if (resolvedUrl.href.indexOf('/node_modules/') >= 0) {
             // if we are deep in node_modules land, use resolution logic to figure out the specifier
             const resolvedRoot = derivePackageRoot(resolvedUrl.href);

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -51,7 +51,7 @@ describe('Build Greenwood With: ', function() {
     before(async function() {
       // this package has a known issue with import.meta.resolve
       // in that it has no main, module, or exports so it has to be hoisted
-      // at least for this current version
+      // at least for this current version, as well as for testing relative ../node_modules references
       // https://unpkg.com/browse/font-awesome@4.7.0/package.json
       // https://github.com/FortAwesome/Font-Awesome/pull/19041
       const fontAwesomePackageJson = await getDependencyFiles(

--- a/packages/cli/test/cases/build.default.import-node-modules/src/styles/theme.css
+++ b/packages/cli/test/cases/build.default.import-node-modules/src/styles/theme.css
@@ -1,2 +1,2 @@
 @import url('/node_modules/@spectrum-web-components/styles/all-large-dark.css');
-@import url('/node_modules/font-awesome/css/font-awesome.css');
+@import url('../../node_modules/font-awesome/css/font-awesome.css');


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1368 

## Documentation 

N / A

## Summary of Changes

1. Handle relative _../node_modules/_ paths in CSS `url` references
1. Update test case