### PR TITLE
enhancement/issue 684 import map generation cache and dedupe optimizations

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -82,14 +82,16 @@ class NodeModulesResource extends ResourceInterface {
 
       if (Object.keys(diagnostics).length > 0) {
         console.log('****************************************************************************');
+
         Object.keys(diagnostics).forEach((diagnostic) => {
           console.warn(diagnostics[diagnostic]);
         });
+
         console.log('Learn more about these warnings at => https://greenwoodjs.dev/docs/introduction/web-standards/#import-maps');
         console.log('****************************************************************************');
       }
 
-      generatedImportMap = importMap;
+      generatedImportMap = Object.fromEntries(importMap);
     } else {
       generatedImportMap = generatedImportMap || {};
     }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #684 

> See this repo for reference - https://github.com/AnalogStudiosRI/api/pull/44

## Documentation 

N / A

## Summary of Changes

1. Cache walked packages (helps mitigate cyclic / peer dependencies)
1. Removed need for nested `walkPackageJson` within `walkPackageJson`
1. Refactor import map to be an actual `Map`

## TODO
1. [x] Why are some GraphQL tests failing, but only when run with the entire suite, not on their own individually 🤔 
    - had to account for concurrency / worker thread pool scenaiors