### PR TITLE
chore/restore intermittent failing Window Loaders GIHub Actions for latest Node LTS upgrade

### DIFF
--- a/.github/workflows/ci-win-loaders.yml
+++ b/.github/workflows/ci-win-loaders.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [20]
+        node: [22]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

https://github.com/ProjectEvergreen/greenwood/pull/1373#issuecomment-2585391696

## Documentation 

N / A

## Summary of Changes

1. Doing anything to get these test cases running again

## TODO
1. [x] Try Node 22
1. [ ] Try windows-2022