### PR TITLE
bug/issue 1329 pass custom runtime to API routes for Vercel adapter

### DIFF
--- a/packages/plugin-adapter-vercel/src/index.js
+++ b/packages/plugin-adapter-vercel/src/index.js
@@ -117,7 +117,7 @@ async function vercelAdapter(compilation, options) {
     const outputRoot = new URL(`.${basePath}/api/${id}.func/`, adapterOutputUrl);
     const { assets = [] } = value;
 
-    await setupFunctionBuildFolder(id, outputType, outputRoot);
+    await setupFunctionBuildFolder(id, outputType, outputRoot, runtime);
 
     await fs.cp(
       new URL(outputHref),

--- a/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/build.default.options-runtime.spec.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/build.default.options-runtime.spec.js
@@ -26,7 +26,7 @@
  *     index.js
  */
 import chai from 'chai';
-import fs from 'fs/promises';
+import fs from 'fs';
 import glob from 'glob-promise';
 import { JSDOM } from 'jsdom';
 import path from 'path';
@@ -65,12 +65,12 @@ describe('Build Greenwood With: ', function() {
       let functionFolders;
 
       before(async function() {
-        configFile = await fs.readFile(new URL('./config.json', vercelOutputFolder), 'utf-8');
+        configFile = await fs.promises.readFile(new URL('./config.json', vercelOutputFolder), 'utf-8');
         functionFolders = await glob.promise(path.join(normalizePathnameForWindows(vercelFunctionsOutputUrl), '**/*.func'));
       });
 
       it('should output the expected number of serverless function output folders', function() {
-        expect(functionFolders.length).to.be.equal(1);
+        expect(functionFolders.length).to.be.equal(2);
       });
 
       it('should output the expected configuration file for the build output', function() {
@@ -78,18 +78,22 @@ describe('Build Greenwood With: ', function() {
       });
 
       it('should output the expected package.json for each serverless function', function() {
-        functionFolders.forEach(async (folder) => {
-          const packageJson = await fs.readFile(new URL('./package.json', `file://${folder}/`), 'utf-8');
-
-          expect(packageJson).to.be.equal('{"type":"module"}');
+        functionFolders.forEach((folder) => {
+          fs.readFile(path.join(folder, 'package.json'), 'utf-8', (err, contents) => {
+            if (!err) {
+              expect(contents).to.equal('{"type":"module"}');
+            }
+          });
         });
       });
 
       it('should output the expected .vc-config.json for each serverless function with runtime option honored', function() {
-        functionFolders.forEach(async (folder) => {
-          const packageJson = await fs.readFile(new URL('./vc-config.json', `file://${folder}/`), 'utf-8');
-
-          expect(packageJson).to.be.equal('{"runtime":"nodejs22.x","handler":"index.js","launcherType":"Nodejs","shouldAddHelpers":true}');
+        functionFolders.forEach((folder) => {
+          fs.readFile(path.join(folder, '.vc-config.json'), 'utf-8', (err, contents) => {
+            if (!err) {
+              expect(contents).to.equal('{"runtime":"nodejs22.x","handler":"index.js","launcherType":"Nodejs","shouldAddHelpers":true}');
+            }
+          });
         });
       });
     });

--- a/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/src/pages/api/greeting.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/src/pages/api/greeting.js
@@ -1,0 +1,11 @@
+export async function handler(request) {
+  const params = new URLSearchParams(request.url.slice(request.url.indexOf('?')));
+  const name = params.has('name') ? params.get('name') : 'World';
+  const body = { message: `Hello ${name}!` };
+
+  return new Response(JSON.stringify(body), {
+    headers: new Headers({
+      'Content-Type': 'application/json'
+    })
+  });
+}


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #1329 

runtime key was missing from API routes
https://vercel.com/the-green-lodge/greenwood-demo-adapter-vercel/88d9gYKvtc8dCqETNtmbMA9ESmts
![Screenshot 2025-01-12 at 7 51 46 PM](https://github.com/user-attachments/assets/519acfee-45e7-46c9-b4ec-58b66b8ba655)

![Screenshot 2025-01-12 at 7 21 51 PM](https://github.com/user-attachments/assets/d297c2c6-41eb-4362-baed-468ee3f2bd14)


## Documentation 

N / A 

## Summary of Changes

1. Make sure to pass `runtime` setting to _vc-config.json_ for API routes