### PR TITLE
bug/1385 better sanitize Rollup importer for when resolving user workspace resources

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -7,7 +7,7 @@ import * as walk from 'acorn-walk';
 
 // https://github.com/rollup/rollup/issues/2121
 // would be nice to get rid of this
-function cleanRollupId(id) {
+function cleanRollupId(id = '') {
   return id.replace('\x00', '').replace('?commonjs-proxy', '');
 }
 
@@ -27,7 +27,7 @@ function greenwoodResourceLoader (compilation, browser = false) {
     async resolveId(id, importer, options) {
       const { userWorkspace, scratchDir } = compilation.context;
       const normalizedId = cleanRollupId(id);
-      const importerUrl = new URL(`file://${importer ?? ''}`);
+      const importerUrl = new URL(`file://${cleanRollupId(importer) ?? ''}`);
       const isUserWorkspaceImporter = importerUrl?.pathname?.startsWith(userWorkspace.pathname);
       const isScratchDirImporter = importerUrl?.pathname?.startsWith(scratchDir.pathname);
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

https://github.com/ProjectEvergreen/greenwood/issues/1385

```sh
TypeError: Invalid URL
    at new URL (node:internal/url:775:36)
    at Object.resolveId (file:///Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/@greenwood/cli/src/config/rollup.config.js:30:27)
    at file:///Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/rollup/dist/es/shared/node-entry.js:20812:40
    at async PluginDriver.hookFirstAndGetPlugin (file:///Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/rollup/dist/es/shared/node-entry.js:20712:28)
    at async resolveId (file:///Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/rollup/dist/es/shared/node-entry.js:19316:26)
    at async ModuleLoader.resolveId (file:///Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/rollup/dist/es/shared/node-entry.js:19745:15)
    at async Object.resolveId (file:///Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/@rollup/plugin-commonjs/dist/es/index.js:580:15) {
  code: 'PLUGIN_ERROR',
  input: 'file://\x00stream?commonjs-external',
  pluginCode: 'ERR_INVALID_URL',
  plugin: 'commonjs--resolver',
  hook: 'resolveId'
}
```

## Documentation 

N / A

## Summary of Changes

1. Regression from #1384 , so better "sanitizing" Rollup `importer` when handling user workspace resolution (was getting values like `\x00stream?commonjs-external` which was breaking `URL`)