### PR TITLE
enhancement/issue 684 improve import map generation diagnostics

### DIFF
--- a/packages/cli/src/lib/walker-package-ranger.js
+++ b/packages/cli/src/lib/walker-package-ranger.js
@@ -24,7 +24,7 @@ function resolveBareSpecifier(specifier) {
   try {
     resolvedPath = import.meta.resolve(specifier);
   } catch (e) {
-    diagnostics.set(specifier, `ERROR (${e.code}): unable to resolve specifier => \`${specifier}\`\n${e.message}\n`);
+    diagnostics.set(specifier, `ERROR (${e.code}): unable to resolve specifier => \`${specifier}\`\n${e.message}`);
   }
 
   return resolvedPath;

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -84,7 +84,7 @@ class NodeModulesResource extends ResourceInterface {
         console.log('****************************************************************************');
 
         diagnostics.forEach((value) => {
-          console.warn(`- ${value}`);
+          console.warn(`- ${value}\n`);
         });
 
         console.log('\n>>> Some issue were detected, learn more about these warnings at https://greenwoodjs.dev/docs/introduction/web-standards/#import-maps');

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -84,10 +84,10 @@ class NodeModulesResource extends ResourceInterface {
         console.log('****************************************************************************');
 
         Object.keys(diagnostics).forEach((diagnostic) => {
-          console.warn(diagnostics[diagnostic]);
+          console.warn(`- ${diagnostics[diagnostic]}\n`);
         });
 
-        console.log('Learn more about these warnings at => https://greenwoodjs.dev/docs/introduction/web-standards/#import-maps');
+        console.log('>>> Learn more about these warnings at https://greenwoodjs.dev/docs/introduction/web-standards/#import-maps <<<');
         console.log('****************************************************************************');
       }
 

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -80,14 +80,14 @@ class NodeModulesResource extends ResourceInterface {
       console.log('Generating import map from project dependencies...');
       const { importMap, diagnostics } = await walkPackageJson(userPackageJson);
 
-      if (Object.keys(diagnostics).length > 0) {
+      if (diagnostics.size > 0) {
         console.log('****************************************************************************');
 
-        Object.keys(diagnostics).forEach((diagnostic) => {
-          console.warn(`- ${diagnostics[diagnostic]}\n`);
+        diagnostics.forEach((value) => {
+          console.warn(`- ${value}`);
         });
 
-        console.log('>>> Learn more about these warnings at https://greenwoodjs.dev/docs/introduction/web-standards/#import-maps <<<');
+        console.log('\n>>> Some issue were detected, learn more about these warnings at https://greenwoodjs.dev/docs/introduction/web-standards/#import-maps');
         console.log('****************************************************************************');
       }
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

https://github.com/ProjectEvergreen/greenwood/issues/684

## Documentation 

1. [x] https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/153

## Summary of Changes
1. Made diagnostics output a bit more readable
    <details>
      <pre>
      ****************************************************************************
      - ERROR (ERR_PACKAGE_PATH_NOT_EXPORTED): unable to resolve specifier => `@libsql/core` 
      No "exports" main defined in /Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/@libsql/core/package.json imported from /Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/@greenwood/cli/src/lib/walker-package-ranger.js
      
      - ERROR (ERR_PACKAGE_PATH_NOT_EXPORTED): unable to resolve specifier => `@types/ws` 
      No "exports" main defined in /Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/@types/ws/package.json imported from /Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/@greenwood/cli/src/lib/walker-package-ranger.js
      
      - ERROR (ERR_PACKAGE_PATH_NOT_EXPORTED): unable to resolve specifier => `dunder-proto` 
      No "exports" main defined in /Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/dunder-proto/package.json imported from /Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/@greenwood/cli/src/lib/walker-package-ranger.js
      
      - ERROR (ERR_PACKAGE_PATH_NOT_EXPORTED): unable to resolve specifier => `math-intrinsics` 
      No "exports" main defined in /Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/math-intrinsics/package.json imported from /Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/@greenwood/cli/src/lib/walker-package-ranger.js
      
      - ERROR (ERR_MODULE_NOT_FOUND): unable to resolve specifier => `type-fest` 
      Cannot find package 'type-fest' imported from /Users/owenbuckley/Workspace/analogstudiosri/api/node_modules/@greenwood/cli/src/lib/walker-package-ranger.js
      
      >>> Learn more about these warnings at https://greenwoodjs.dev/docs/introduction/web-standards/#import-maps <<<
      ****************************************************************************
      </pre>
    </details>
1. Handle NodeJS resolving to built-ins - https://github.com/thescientist13/import-meta-resolve-demo?tab=readme-ov-file#node-built-ins-hijacking-dependencies

## TODO
1. [x] Node built ins (expected behavior) - https://github.com/thescientist13/import-meta-resolve-demo?tab=readme-ov-file#node-built-ins-hijacking-dependencies
1. [x] See if we can better handle `ERR_PACKAGE_PATH_NOT_EXPORTED` - just going to document best we can for now - https://github.com/ProjectEvergreen/greenwood/discussions/1396
    - https://github.com/thescientist13/import-meta-resolve-demo?tab=readme-ov-file#no-main-exports-map-entry-point-err_package_path_not_exported
    - https://github.com/es-shims/dunder-proto/issues/3
    - https://github.com/nodejs/node/issues/49445#issuecomment-2607924371
1. [x] Make diagnostics a Map
1. [x] final website documentation / takeaways / best practices - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/153
1. [x] absorb https://github.com/ProjectEvergreen/greenwood/issues/1394? - Not right now