### PR TITLE
bug/issue 1409 do not force encoding when bundling / emitting static asset contents

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -334,7 +334,7 @@ function greenwoodImportMetaUrl(compilation) {
         const { relativeAssetPath } = assetUrl;
         const assetName = path.basename(pathname);
         const assetExtension = assetName.split(".").pop();
-        const assetContents = await fs.promises.readFile(url, "utf-8");
+        const assetContents = await fs.promises.readFile(url);
         const name = assetName.replace(`.${assetExtension}`, "");
         const request = new Request(url, { headers: { Accept: "text/javascript" } });
         let bundleExtensions = ["js"];

--- a/packages/cli/test/cases/build.default.static-asset-bundling/build.default.static-asset-bundling.spec.js
+++ b/packages/cli/test/cases/build.default.static-asset-bundling/build.default.static-asset-bundling.spec.js
@@ -63,7 +63,7 @@ describe("Build Greenwood With: ", function () {
       });
 
       it("should have the expected bundle path for the first static asset", function () {
-        const bundleName = "greenwood-logo.BBDNkm3l.png";
+        const bundleName = "greenwood-logo.DiicYFep.png";
 
         expect(headerContents).to.contain(bundleName);
       });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1409 

## Documentation 

N / A

## Summary of Changes

1. Don't force encoding when reading static assets off of disk during bundling

![Screenshot 2025-02-08 at 3 13 06 PM](https://github.com/user-attachments/assets/f57b4522-57dd-4914-97d2-39e993615d98)