### PR TITLE
enhancement/issue 1327 refresh typescript plugin compiler defaults and recommendations

### DIFF
--- a/packages/plugin-typescript/README.md
+++ b/packages/plugin-typescript/README.md
@@ -4,7 +4,7 @@
 
 A Greenwood plugin for writing [**TypeScript**](https://www.typescriptlang.org/). For more information and complete docs on Greenwood, please visit [our website](https://www.greenwoodjs.dev).
 
-> This package assumes you already have `@greenwood/cli` installed.
+> This package assumes you already have `@greenwood/cli` and `typescript` >= 5.3.x installed.
 
 ## Installation
 
@@ -70,8 +70,10 @@ This plugin provides the following default `compilerOptions`.
   "compilerOptions": {
     "target": "es2020",
     "module": "es2020",
-    "moduleResolution": "node",
-    "sourceMap": true
+    "moduleResolution": "NodeNext",
+    "lib": ["es2022", "DOM", "DOM.Iterable", "esnext"],
+    "allowImportingTsExtensions": true,
+    "allowSyntheticDefaultImports": true
   }
 }
 ```

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -24,12 +24,11 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.31.0"
-  },
-  "dependencies": {
-    "typescript": "^5.1.6"
+    "@greenwood/cli": "^0.31.0",
+    "typescript": "^5.3.0"
   },
   "devDependencies": {
-    "@greenwood/cli": "^0.31.1"
+    "@greenwood/cli": "^0.31.1",
+    "typescript": "^5.3.0"
   }
 }

--- a/packages/plugin-typescript/src/index.js
+++ b/packages/plugin-typescript/src/index.js
@@ -8,10 +8,12 @@ import { ResourceInterface } from "@greenwood/cli/src/lib/resource-interface.js"
 import tsc from "typescript";
 
 const defaultCompilerOptions = {
-  target: "es2020",
-  module: "es2020",
-  moduleResolution: "node",
-  sourceMap: true,
+  target: "es2022",
+  module: "es2022",
+  moduleResolution: "NodeNext",
+  lib: ["es2022", "DOM", "DOM.Iterable", "esnext"],
+  allowImportingTsExtensions: true,
+  allowSyntheticDefaultImports: true,
 };
 
 async function getCompilerOptions(projectDirectory, extendConfig) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17937,10 +17937,10 @@ typescript@^5.0.0, typescript@^5.0.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
-typescript@^5.1.6:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
-  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+typescript@^5.3.0:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
+  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
 
 uglify-js@^3.1.4:
   version "3.13.5"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1327 / #658

## Documentation 

1. [ ] TODO - website issue tracking (combine with #1250 )
    - recommendations on how to use `tsc` for CI (e.g. `noEmit`)
    - typescript as a peer dependency
    - https://github.com/ProjectEvergreen/greenwood/issues/658
    - erasable syntax - https://bsky.app/profile/robpalmer.bsky.social/post/3lgvwb44um22r
    - a guide to _tsconfig.json_ - https://2ality.com/2025/01/tsconfig-json.html ?

## Summary of Changes

1. Made **typescript** a peer dependency, with a minimum version of `5.3.0` (for Import Attributes support)
1. Refresh default compiler options
1. Update README

## TODO
1. [ ] This may become invalid in light of discussions around first party TS support - https://github.com/ProjectEvergreen/greenwood/discussions/1422#discussioncomment-12231079