### PR TITLE
bug/issue 1431 obfuscate names of bundled node_modules static assets

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -112,6 +112,9 @@ function bundleCss(body, sourceUrl, compilation, workingUrl) {
             const ext = resolvedUrl.pathname.split(".").pop();
 
             finalValue = finalValue.replace(`.${ext}`, `.${hash}.${ext}`);
+            // "obfuscate" these file names since some hosting platforms may ignore node_modules within the build folder
+            // https://github.com/ProjectEvergreen/greenwood/issues/1431
+            finalValue = finalValue.replace("/node_modules/", "/node-modules/");
 
             fs.mkdirSync(new URL(`.${path.dirname(finalValue)}/`, outputDir), {
               recursive: true,

--- a/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
@@ -156,7 +156,7 @@ describe("Build Greenwood With: ", function () {
 
       describe("bundled URL references in CSS files", function () {
         describe("node modules reference", () => {
-          const fontPath = "node_modules/geist/dist/fonts/geist-sans";
+          const fontPath = "node-modules/geist/dist/fonts/geist-sans";
           let dom;
 
           before(async function () {

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -187,7 +187,7 @@ describe("Build Greenwood With: ", function () {
       it("should have the expected number of font files referenced in vendor CSS file in the output directory", async function () {
         expect(
           await glob.promise(
-            path.join(this.context.publicDir, "node_modules/font-awesome/fonts/*"),
+            path.join(this.context.publicDir, "node-modules/font-awesome/fonts/*"),
           ),
         ).to.have.lengthOf(5);
       });
@@ -200,7 +200,7 @@ describe("Build Greenwood With: ", function () {
 
         expect(
           contents.indexOf(
-            "@font-face {font-family:'FontAwesome';src:url('/node_modules/font-awesome/fonts/fontawesome-webfont.139345087.eot?v=4.7.0');",
+            "@font-face {font-family:'FontAwesome';src:url('/node-modules/font-awesome/fonts/fontawesome-webfont.139345087.eot?v=4.7.0');",
           ) > 0,
         ).to.equal(true);
       });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1431 

## Documentation 

N / A

## Summary of Changes

1. Rename _node_modules_ -> _node-modules_ for bundled static assets