### PR TITLE
bug/issue 1250 `devServer.proxy` config type should be optional

### DIFF
--- a/packages/cli/src/types/config.d.ts
+++ b/packages/cli/src/types/config.d.ts
@@ -8,7 +8,7 @@ export type Config = {
     extensions?: string[];
     hud?: boolean;
     port?: number;
-    proxy: {
+    proxy?: {
       [key: string]: string;
     };
   };


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1250 and left over from #1440 

## Documentation 

N / A

## Summary of Changes

1. `devServer.proxy` should have been optional 🤦‍♂️ 