### PR TITLE
bug/issue 1250 forgot to `Extract` type for copy plugin definition

### DIFF
--- a/packages/cli/src/types/plugins.d.ts
+++ b/packages/cli/src/types/plugins.d.ts
@@ -43,7 +43,7 @@ export interface ContextPlugin extends Plugin {
 
 // https://greenwoodjs.dev/docs/reference/plugins-api/#copy
 export interface CopyPlugin extends Plugin {
-  type: Pick<PLUGIN_TYPES, "copy">;
+  type: Extract<PLUGIN_TYPES, "copy">;
   provider: (compilation: Compilation) => Promise<{ from: URL; to: URL }[]>;
 }
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1250 and left over from #1440 

## Documentation 

N / A

## Summary of Changes

1. One plugin type wasn't using `Extract` 🤦‍♂️ 