### PR TITLE
bug/issue 1250 properly type Rollup plugin

### DIFF
--- a/packages/cli/src/types/plugins.d.ts
+++ b/packages/cli/src/types/plugins.d.ts
@@ -1,6 +1,6 @@
 import type { Compilation } from "./compilation.d.ts";
 import type { Page } from "./content.d.ts";
-import type { Plugin as RollupPlugin } from "rollup";
+import type { Plugin as TRollupPlugin } from "rollup";
 
 // https://greenwoodjs.dev/docs/reference/plugins-api/#overview
 export type PLUGIN_TYPES =
@@ -79,7 +79,7 @@ export interface ResourcePlugin extends Plugin {
 // https://greenwoodjs.dev/docs/reference/plugins-api/#rollup
 export interface RollupPlugin extends Plugin {
   type: Extract<PLUGIN_TYPES, "rollup">;
-  provider: (compilation: Compilation) => RollupPlugin[];
+  provider: (compilation: Compilation) => TRollupPlugin[];
 }
 
 // https://greenwoodjs.dev/docs/reference/plugins-api/#server


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1250

## Documentation 

<!-- if this issue has been labeled with documentation, please make sure submit a PR to our website repo and link it -->
<!-- https://github.com/ProjectEvergreen/www.greenwoodjs.dev -->

## Summary of Changes

1. Needed to better type actual Rollup plugin types (Why do I keep forgetting these 🤦 🤦 )