### PR TITLE
bug/issue 1250 add missing types for content as data module imports

### DIFF
--- a/greenwood.config.test-types.ts
+++ b/greenwood.config.test-types.ts
@@ -15,6 +15,20 @@ import { greenwoodPluginPostCss } from "@greenwood/plugin-postcss";
 import { greenwoodPluginRendererLit } from "@greenwood/plugin-renderer-lit";
 import { greenwoodPluginRendererPuppeteer } from "@greenwood/plugin-renderer-puppeteer";
 
+import { getContentByRoute } from "@greenwood/cli/src/data/client.js";
+
+const foo = await getContentByRoute("foo");
+console.log(foo);
+
+import ChildrenQuery from "@greenwood/plugin-graphql/src/queries/children.gql";
+import CollectionQuery from "@greenwood/plugin-graphql/src/queries/collection.gql";
+import GraphQuery from "@greenwood/plugin-graphql/src/queries/graph.gql";
+
+console.log({ ChildrenQuery, CollectionQuery, GraphQuery });
+
+import client from "@greenwood/plugin-graphql/src/core/client.js";
+console.log({ client });
+
 const port: number = 8080;
 
 const config: Config = {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
       "import": "./src/index.js"
     },
     "./register": "./src/register.js",
+    "./src/data/client": "./src/data/client.js",
     "./src/*": "./src/*"
   },
   "bin": {

--- a/packages/cli/src/data/client.d.ts
+++ b/packages/cli/src/data/client.d.ts
@@ -1,0 +1,7 @@
+import type { GetContentByRoute, GetContentByCollection, GetContent } from "../types/content.d.ts";
+
+declare module "@greenwood/cli/src/data/client.js" {
+  export const getContentByRoute: GetContentByRoute;
+  export const getContentByCollection: GetContentByCollection;
+  export const getContent: GetContent;
+}

--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -24,6 +24,9 @@
       "types": "./src/types/index.d.ts",
       "import": "./src/index.js"
     },
+    "./src/queries/children.gql": "./src/queries/children.gql",
+    "./src/queries/collection.gql": "./src/queries/collection.gql",
+    "./src/queries/graph.gql": "./src/queries/graph.gql",
     "./src/core/*": "./src/core/*",
     "./src/queries/*": "./src/queries/*"
   },

--- a/packages/plugin-graphql/src/core/client.d.ts
+++ b/packages/plugin-graphql/src/core/client.d.ts
@@ -1,0 +1,7 @@
+declare module "@greenwood/plugin-graphql/src/core/client.js" {
+  const Client: {
+    query: (params: string) => Promise;
+  };
+
+  export default Client;
+}

--- a/packages/plugin-graphql/src/queries/queries.d.ts
+++ b/packages/plugin-graphql/src/queries/queries.d.ts
@@ -1,0 +1,17 @@
+declare module "@greenwood/plugin-graphql/src/queries/children.gql" {
+  const ChildrenQuery: string;
+
+  export default ChildrenQuery;
+}
+
+declare module "@greenwood/plugin-graphql/src/queries/collection.gql" {
+  const CollectionQuery: string;
+
+  export default CollectionQuery;
+}
+
+declare module "@greenwood/plugin-graphql/src/queries/graph.gql" {
+  const GraphQuery: string;
+
+  export default GraphQuery;
+}

--- a/packages/plugin-graphql/src/types/index.d.ts
+++ b/packages/plugin-graphql/src/types/index.d.ts
@@ -1,4 +1,6 @@
 import type { ResourcePlugin, ServerPlugin } from "@greenwood/cli";
+import "../queries/queries.d.ts";
+import "../core/client.d.ts";
 
 export type GraphQLPlugin = () => Array<ResourcePlugin, ServerPlugin>;
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #1250 

## Documentation 

N / A

## Summary of Changes

1. Add module support for CLI related content as data utilities
1. Add module support for GraphQL related content as data utilities