### PR TITLE
enhancement/consolidate and better document hoisted Lit renderer plugin dependencies

### DIFF
--- a/packages/plugin-renderer-lit/README.md
+++ b/packages/plugin-renderer-lit/README.md
@@ -39,6 +39,7 @@ $ pnpm add -D @greenwood/plugin-renderer-lit
 For **pnpm**, you will also want to add this to your _.npmrc_ file
 ```sh
 public-hoist-pattern[]=@lit-labs/*
+public-hoist-pattern[]=lit-html
 ```
 
 ## Usage

--- a/packages/plugin-renderer-lit/src/execute-route-module.js
+++ b/packages/plugin-renderer-lit/src/execute-route-module.js
@@ -1,7 +1,7 @@
 import { render } from "@lit-labs/ssr";
 import { collectResult } from "@lit-labs/ssr/lib/render-result.js";
 import { html } from "lit";
-import { unsafeHTML } from "lit-html/directives/unsafe-html.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 async function executeRouteModule({
   moduleUrl,


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

N / A

## Documentation 

1. [x] We should add this [call-out to the website]( https://greenwoodjs.dev/docs/plugins/lit-ssr/#installation) as well (can go out anytime) - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/194

## Summary of Changes

1. Realized we could get the `html` export from the "top" level **lit** package
1. Need to call out **lit-html** as a hoisted pnpm dependency due to its direct reference in the [hydrate-element script](https://github.com/lit/lit/blob/c9160405deaf8de68bb1e587ef9b2484cb58b353/packages/labs/ssr-client/src/lit-element-hydrate-support.ts#L14)