### PR TITLE
feature/issue 1247 standalone markdown plugin

### DIFF
--- a/greenwood.config.js
+++ b/greenwood.config.js
@@ -4,6 +4,7 @@ import { greenwoodPluginPolyfills } from "@greenwood/plugin-polyfills";
 import { greenwoodPluginPostCss } from "@greenwood/plugin-postcss";
 import { greenwoodPluginImportRaw } from "@greenwood/plugin-import-raw";
 import { greenwoodPluginRendererPuppeteer } from "@greenwood/plugin-renderer-puppeteer";
+import { greenwoodPluginMarkdown } from "@greenwood/plugin-markdown";
 import rollupPluginAnalyzer from "rollup-plugin-analyzer";
 
 /** @type {import('@greenwood/cli').Config} */
@@ -14,6 +15,9 @@ export default {
   activeContent: true,
   prerender: true,
   plugins: [
+    greenwoodPluginMarkdown({
+      plugins: ["@mapbox/rehype-prism", "rehype-slug", "rehype-autolink-headings", "remark-github"],
+    }),
     greenwoodPluginGraphQL(),
     greenwoodPluginPolyfills({
       lit: true,
@@ -39,7 +43,4 @@ export default {
       },
     },
   ],
-  markdown: {
-    plugins: ["@mapbox/rehype-prism", "rehype-slug", "rehype-autolink-headings", "remark-github"],
-  },
 };

--- a/greenwood.config.test-types.ts
+++ b/greenwood.config.test-types.ts
@@ -10,6 +10,7 @@ import { greenwoodPluginImportCommonJs } from "@greenwood/plugin-import-commonjs
 import { greenwoodPluginImportJsx } from "@greenwood/plugin-import-jsx";
 import { greenwoodPluginImportRaw } from "@greenwood/plugin-import-raw";
 import { greenwoodPluginIncludeHTML } from "@greenwood/plugin-include-html";
+import { greenwoodPluginMarkdown } from "@greenwood/plugin-markdown";
 import { greenwoodPluginPolyfills } from "@greenwood/plugin-polyfills";
 import { greenwoodPluginPostCss } from "@greenwood/plugin-postcss";
 import { greenwoodPluginRendererLit } from "@greenwood/plugin-renderer-lit";
@@ -31,9 +32,6 @@ const config: Config = {
   isolation: true,
   layoutsDirectory: "/my-layouts",
   optimization: "default",
-  markdown: {
-    plugins: ["@mapbox/rehype-prism"],
-  },
   pagesDirectory: "/my-pages",
   plugins: [
     greenwoodPluginAdapterAws(),
@@ -47,6 +45,9 @@ const config: Config = {
     greenwoodPluginImportJsx(),
     greenwoodPluginImportRaw,
     greenwoodPluginIncludeHTML(),
+    greenwoodPluginMarkdown({
+      plugins: ["@mapbox/rehype-prism", "rehype-slug", "rehype-autolink-headings", "remark-github"],
+    }),
     greenwoodPluginPolyfills(),
     greenwoodPluginPostCss(),
     greenwoodPluginRendererLit(),

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,6 @@
     "koa": "^2.13.0",
     "koa-body": "^6.0.1",
     "livereload": "^0.9.1",
-    "markdown-toc": "^1.2.0",
     "node-html-parser": "^1.2.21",
     "rollup": "^4.26.0",
     "sucrase": "^3.35.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,14 +56,8 @@
     "livereload": "^0.9.1",
     "markdown-toc": "^1.2.0",
     "node-html-parser": "^1.2.21",
-    "rehype-raw": "^7.0.0",
-    "rehype-stringify": "^10.0.1",
-    "remark-frontmatter": "^5.0.0",
-    "remark-parse": "^11.0.0",
-    "remark-rehype": "^11.1.1",
     "rollup": "^4.26.0",
     "sucrase": "^3.35.0",
-    "unified": "^11.0.5",
     "wc-compiler": "~0.16.0"
   },
   "devDependencies": {

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -66,7 +66,6 @@ const defaultConfig = {
   },
   isolation: false,
   layoutsDirectory: "layouts",
-  markdown: { plugins: [] },
   optimization: optimizations[0],
   pagesDirectory: "pages",
   plugins: greenwoodPlugins,

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -3,7 +3,6 @@ import fs from "fs/promises";
 import fm from "front-matter";
 import { checkResourceExists, requestAsObject } from "../lib/resource-utils.js";
 import { activeFrontmatterKeys } from "../lib/content-utils.js";
-import toc from "markdown-toc";
 import { Worker } from "worker_threads";
 
 function getLabelFromRoute(_route) {
@@ -210,35 +209,10 @@ const generateGraph = async (compilation) => {
                 }
               }
 
-              /*
-               * Custom front matter - Variable Definitions
-               * --------------------------------------------------
-               * collection: the name of the collection for the page (as a string or array)
-               * order: the order of this item within the collection
-               * tocHeading: heading size to use a Table of Contents for a page
-               * tableOfContents: json object containing page's table of contents (list of headings)
-               */
-
-              // prune "reserved" attributes that are supported by Greenwood
+              // prune "reserved" frontmatter that are supported by Greenwood
               [...activeFrontmatterKeys, "layout"].forEach((key) => {
                 delete customData[key];
               });
-
-              // set flag whether to gather a list of headings on a page as menu items
-              customData.tocHeading = customData.tocHeading || 0;
-              customData.tableOfContents = [];
-
-              if (fileContents && customData.tocHeading > 0 && customData.tocHeading <= 6) {
-                // parse markdown for table of contents and output to json
-                customData.tableOfContents = toc(fileContents).json;
-
-                // parse table of contents for only the pages user wants linked
-                if (customData.tableOfContents.length > 0 && customData.tocHeading > 0) {
-                  customData.tableOfContents = customData.tableOfContents.filter(
-                    (item) => item.lvl === customData.tocHeading,
-                  );
-                }
-              }
 
               /*
                * Page Properties

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -77,19 +77,16 @@ const generateGraph = async (compilation) => {
             const extension = `.${filenameUrl.pathname.split(".").pop()}`;
             const relativePagePath = filenameUrl.pathname.replace(pagesDir.pathname, "./");
             const isApiRoute = relativePagePath.startsWith("./api");
-            const req = isApiRoute
-              ? new Request(filenameUrl, { headers: { Accept: "text/javascript" } })
-              : new Request(filenameUrl, { headers: { Accept: "text/html" } });
             let isCustom = null;
 
             for (const plugin of customPageFormatPlugins) {
-              if (plugin.shouldServe && (await plugin.shouldServe(filenameUrl, req))) {
+              if (plugin.servePage) {
                 isCustom = plugin.servePage;
                 break;
               }
             }
 
-            const isStatic = isCustom === "static" || extension === ".md" || extension === ".html";
+            const isStatic = isCustom === "static" || extension === ".html";
             const isDynamic = isCustom === "dynamic" || extension === ".js" || extension === ".ts";
             const isPage = isStatic || isDynamic;
             let route = `${relativePagePath.replace(".", "").replace(`${extension}`, "")}`;

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -68,7 +68,7 @@ async function getDevServer(compilation) {
         statusText: message,
         status,
         headers: new Headers(header),
-      });
+      }).clone();
       const response = await resourcePlugins.reduce(async (responsePromise, plugin) => {
         const intermediateResponse = await responsePromise;
         if (

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -6,21 +6,15 @@
  *
  */
 import fs from "fs/promises";
-import rehypeStringify from "rehype-stringify";
-import rehypeRaw from "rehype-raw";
-import remarkFrontmatter from "remark-frontmatter";
-import remarkParse from "remark-parse";
-import remarkRehype from "remark-rehype";
 import { getUserScripts, getPageLayout, getAppLayout } from "../../lib/layout-utils.js";
 import { requestAsObject } from "../../lib/resource-utils.js";
-import { unified } from "unified";
 import { Worker } from "worker_threads";
 import { parse as htmlparser } from "node-html-parser";
 
 class StandardHtmlResource {
   constructor(compilation) {
     this.compilation = compilation;
-    this.extensions = [".html", ".md"];
+    this.extensions = [".html"];
     this.contentType = "text/html";
   }
 
@@ -35,53 +29,20 @@ class StandardHtmlResource {
     );
   }
 
-  async serve(url, request) {
-    const { config, context } = this.compilation;
-    const { userWorkspace } = context;
+  async serve(url, request, response) {
     const { pathname } = url;
     const isSpaRoute = this.compilation.graph.find((node) => node.isSPA);
     const matchingRoute = this.compilation.graph.find((node) => node.route === pathname) || {};
     const { pageHref } = matchingRoute;
-    const filePath =
-      !matchingRoute.external && pageHref
-        ? new URL(pageHref).pathname.replace(userWorkspace.pathname, "./")
-        : "";
-    const isMarkdownContent = (filePath || "").split(".").pop() === "md";
+    const initContents = (await response.text()) ?? "";
     let body = "";
     let layout = matchingRoute.layout || null;
     let customImports = matchingRoute.imports || [];
     let ssrBody;
     let ssrLayout;
-    let processedMarkdown = null;
 
     if (matchingRoute.external) {
       layout = matchingRoute.layout || layout;
-    }
-
-    if (isMarkdownContent) {
-      const markdownContents = await fs.readFile(new URL(pageHref), "utf-8");
-      const rehypePlugins = [];
-      const remarkPlugins = [];
-
-      for (const plugin of config.markdown.plugins) {
-        if (plugin.indexOf("rehype-") >= 0) {
-          rehypePlugins.push((await import(plugin)).default);
-        }
-
-        if (plugin.indexOf("remark-") >= 0) {
-          remarkPlugins.push((await import(plugin)).default);
-        }
-      }
-
-      processedMarkdown = await unified()
-        .use(remarkParse) // parse markdown into AST
-        .use(remarkFrontmatter) // extract frontmatter from AST
-        .use(remarkPlugins) // apply userland remark plugins
-        .use(remarkRehype, { allowDangerousHtml: true }) // convert from markdown to HTML AST
-        .use(rehypeRaw) // support mixed HTML in markdown
-        .use(rehypePlugins) // apply userland rehype plugins
-        .use(rehypeStringify) // convert AST to HTML string
-        .process(markdownContents);
     }
 
     if (matchingRoute.isSSR) {
@@ -130,27 +91,28 @@ class StandardHtmlResource {
     body = await getAppLayout(body, this.compilation, customImports, matchingRoute);
     body = await getUserScripts(body, this.compilation);
 
-    if (processedMarkdown) {
-      const wrappedCustomElementRegex =
-        /<p><[a-zA-Z]*-[a-zA-Z](.*)>(.*)<\/[a-zA-Z]*-[a-zA-Z](.*)><\/p>/g;
-      const ceTest = wrappedCustomElementRegex.test(processedMarkdown.value);
+    // TODO
+    // if (processedMarkdown) {
+    //   const wrappedCustomElementRegex =
+    //     /<p><[a-zA-Z]*-[a-zA-Z](.*)>(.*)<\/[a-zA-Z]*-[a-zA-Z](.*)><\/p>/g;
+    //   const ceTest = wrappedCustomElementRegex.test(processedMarkdown.value);
 
-      if (ceTest) {
-        const ceMatches = processedMarkdown.value.match(wrappedCustomElementRegex);
+    //   if (ceTest) {
+    //     const ceMatches = processedMarkdown.value.match(wrappedCustomElementRegex);
 
-        ceMatches.forEach((match) => {
-          const stripWrappingTags = match.replace("<p>", "").replace("</p>", "");
+    //     ceMatches.forEach((match) => {
+    //       const stripWrappingTags = match.replace("<p>", "").replace("</p>", "");
 
-          processedMarkdown.value = processedMarkdown.value.replace(match, stripWrappingTags);
-        });
-      }
+    //       processedMarkdown.value = processedMarkdown.value.replace(match, stripWrappingTags);
+    //     });
+    //   }
 
-      // https://github.com/ProjectEvergreen/greenwood/issues/1126
-      body = body.replace(
-        /<content-outlet>(.*)<\/content-outlet>/s,
-        processedMarkdown.value.replace(/\$/g, "$$$"),
-      );
-    } else if (matchingRoute.external) {
+    //   // https://github.com/ProjectEvergreen/greenwood/issues/1126
+    //   body = body.replace(
+    //     /<content-outlet>(.*)<\/content-outlet>/s,
+    //     processedMarkdown.value.replace(/\$/g, "$$$"),
+    //   );
+    if (matchingRoute.external) {
       body = body.replace(/<content-outlet>(.*)<\/content-outlet>/s, matchingRoute.body);
     } else if (ssrBody) {
       body = body.replace(
@@ -159,9 +121,8 @@ class StandardHtmlResource {
       );
     }
 
-    // clean up any empty placeholder content-outlet
     if (body.indexOf("<content-outlet></content-outlet>") > 0) {
-      body = body.replace("<content-outlet></content-outlet>", "");
+      body = body.replace("<content-outlet></content-outlet>", initContents);
     }
 
     return new Response(body, {

--- a/packages/cli/src/types/config.d.ts
+++ b/packages/cli/src/types/config.d.ts
@@ -15,9 +15,6 @@ export type Config = {
   isolation?: boolean;
   layoutsDirectory?: string;
   optimization?: "default" | "inline" | "none" | "static";
-  markdown?: {
-    plugins?: string[];
-  };
   pagesDirectory?: string;
   plugins?: Array<PLUGINS | Array<PLUGINS>>;
   polyfills?: {

--- a/packages/plugin-markdown/README.md
+++ b/packages/plugin-markdown/README.md
@@ -1,0 +1,63 @@
+# @greenwood/plugin-markdown
+
+## Overview
+
+A Greenwood plugin for processing markdown files for pages using the [Unified](https://unifiedjs.com/) ecosystem, which includes [**remark**](https://github.com/remarkjs/remark) and [**rehype**](https://github.com/rehypejs/rehype) based plugins.  For more information and complete docs on Greenwood, please visit [our website](https://www.greenwoodjs.dev).
+
+> This package assumes you already have `@greenwood/cli` installed.
+
+## Installation
+
+You can use your favorite JavaScript package manager to install this package.
+
+```bash
+# npm
+$ npm i -D @greenwood/plugin-markdown
+
+# yarn
+$ yarn add @greenwood/plugin-markdown --dev
+
+# pnpm
+$ pnpm add -D @greenwood/plugin-markdown
+```
+
+## Usage
+
+Use this plugin in your _greenwood.config.js_:
+
+```javascript
+import { greenwoodPluginMarkdown } from '@greenwood/plugin-markdown';
+
+export default {
+  // ...
+
+  plugins: [
+    greenwoodPluginMarkdown()
+  ]
+}
+```
+
+Now you can start authoring content in markdown!
+
+```sh
+src/
+  pages/
+    index.html
+    about.md
+```
+
+## Types
+
+Types should automatically be inferred through this package's exports map, but can be referenced explicitly in both JavaScript (JSDoc) and TypeScript files if needed.
+
+```js
+/** @type {import('@greenwood/plugin-markdown').MarkdownPlugin} */
+```
+
+```ts
+import type { MarkdownPlugin } from '@greenwood/plugin-markdown';
+```
+
+## Options
+
+TODO

--- a/packages/plugin-markdown/package.json
+++ b/packages/plugin-markdown/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@greenwood/plugin-markdown",
+  "version": "0.32.0-alpha.5",
+  "description": "A Greenwood plugin for processing markdown files for pages using the Unified ecosystem.",
+  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-markdown",
+  "author": "Owen Buckley <owen@thegreenhouse.io>",
+  "license": "MIT",
+  "keywords": [
+    "Greenwood",
+    "Static Site Generator",
+    "Server Side Rendering",
+    "Full Stack Web Development",
+    "Markdown",
+    "Unified",
+    "Rehpye",
+    "Remark"
+  ],
+  "type": "module",
+  "main": "src/index.js",
+  "types": "./src/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/types/index.d.ts",
+      "import": "./src/index.js"
+    }
+  },
+  "files": [
+    "src/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@greenwood/cli": "^0.31.0"
+  },
+  "dependencies": {
+    "rehype-raw": "^7.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-frontmatter": "^5.0.0",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.1",
+    "unified": "^11.0.5"
+  },
+  "devDependencies": {
+    "@greenwood/cli": "^0.32.0-alpha.5"
+  }
+}

--- a/packages/plugin-markdown/package.json
+++ b/packages/plugin-markdown/package.json
@@ -35,6 +35,7 @@
     "@greenwood/cli": "^0.31.0"
   },
   "dependencies": {
+    "markdown-toc": "^1.2.0",
     "rehype-raw": "^7.0.0",
     "rehype-stringify": "^10.0.1",
     "remark-frontmatter": "^5.0.0",

--- a/packages/plugin-markdown/src/index.js
+++ b/packages/plugin-markdown/src/index.js
@@ -1,0 +1,98 @@
+import fs from "fs/promises";
+import rehypeStringify from "rehype-stringify";
+import rehypeRaw from "rehype-raw";
+import remarkFrontmatter from "remark-frontmatter";
+import remarkParse from "remark-parse";
+import remarkRehype from "remark-rehype";
+import { unified } from "unified";
+
+class MarkdownResource {
+  constructor(compilation, options = {}) {
+    this.compilation = compilation;
+    this.extensions = [".md"];
+    this.contentType = "text/html";
+    this.servePage = "static";
+    this.options = options;
+  }
+
+  async shouldPreServe(url) {
+    const { protocol, pathname } = url;
+    const hasMatchingPageRoute = this.compilation.graph.find((node) => node.route === pathname);
+
+    // console.log('shouldServe', { hasMatchingPageRoute, protocol, pathname });
+    return (
+      protocol.startsWith("http") &&
+      hasMatchingPageRoute &&
+      hasMatchingPageRoute.pageHref.endsWith(this.extensions[0])
+    );
+  }
+
+  async preServe(url) {
+    const { pathname } = url;
+    const matchingPageRoute = this.compilation.graph.find((node) => node.route === pathname);
+    const markdownContents = await fs.readFile(new URL(matchingPageRoute.pageHref), "utf-8");
+    const rehypePlugins = [];
+    const remarkPlugins = [];
+    let processedMarkdown = "";
+
+    for (const plugin of this.options?.plugins || []) {
+      if (plugin.indexOf("rehype-") >= 0) {
+        rehypePlugins.push((await import(plugin)).default);
+      }
+
+      if (plugin.indexOf("remark-") >= 0) {
+        remarkPlugins.push((await import(plugin)).default);
+      }
+    }
+
+    processedMarkdown = await unified()
+      .use(remarkParse) // parse markdown into AST
+      .use(remarkFrontmatter) // extract frontmatter from AST
+      .use(remarkPlugins) // apply userland remark plugins
+      .use(remarkRehype, { allowDangerousHtml: true }) // convert from markdown to HTML AST
+      .use(rehypeRaw) // support mixed HTML in markdown
+      .use(rehypePlugins) // apply userland rehype plugins
+      .use(rehypeStringify) // convert AST to HTML string
+      .process(markdownContents);
+
+    // TODO
+    // if (processedMarkdown) {
+    //   const wrappedCustomElementRegex =
+    //     /<p><[a-zA-Z]*-[a-zA-Z](.*)>(.*)<\/[a-zA-Z]*-[a-zA-Z](.*)><\/p>/g;
+    //   const ceTest = wrappedCustomElementRegex.test(processedMarkdown.value);
+
+    //   if (ceTest) {
+    //     const ceMatches = processedMarkdown.value.match(wrappedCustomElementRegex);
+
+    //     ceMatches.forEach((match) => {
+    //       const stripWrappingTags = match.replace("<p>", "").replace("</p>", "");
+
+    //       processedMarkdown.value = processedMarkdown.value.replace(match, stripWrappingTags);
+    //     });
+    //   }
+
+    //   // https://github.com/ProjectEvergreen/greenwood/issues/1126
+    //   body = body.replace(
+    //     /<content-outlet>(.*)<\/content-outlet>/s,
+    //     processedMarkdown.value.replace(/\$/g, "$$$"),
+    //   );
+    // }
+
+    return new Response(processedMarkdown, {
+      headers: new Headers({
+        "Content-Type": this.contentType,
+      }),
+    });
+  }
+}
+
+/** @type {import('./types/index.d.ts').MarkdownPlugin} */
+const greenwoodPluginMarkdown = (options = {}) => [
+  {
+    type: "resource",
+    name: "plugin-markdown",
+    provider: (compilation) => new MarkdownResource(compilation, options),
+  },
+];
+
+export { greenwoodPluginMarkdown };

--- a/packages/plugin-markdown/src/types/index.d.ts
+++ b/packages/plugin-markdown/src/types/index.d.ts
@@ -1,0 +1,11 @@
+import type { ResourcePlugin } from "@greenwood/cli";
+
+type MarkdownPluginOptions = {
+  plugins?: string[];
+};
+
+export type MarkdownPlugin = (options?: MarkdownPluginOptions) => Array<ResourcePlugin>;
+
+declare module "@greenwood/plugin-markdown" {
+  export const greenwoodPluginMarkdown: MarkdownPlugin;
+}


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1247 

## Documentation 

1. [ ] Needs documentation for the following
    - move to plugins page (w/ netlify redirect)
    - `preServe` lifecycle
    - tocHeadings - https://greenwoodjs.dev/docs/content-as-data/pages-data/#table-of-contents

## Summary of Changes

1. Created standalone **unified** based markdown plugin
1. Moved over all deps from the CLI

## TODO
1. [ ] how to support GraphQL and ToC data?
    - can it just resolve to the content server instead?
1. [ ] Confirm live reload 
1. [ ] Port Greenwood test cases
1. [ ] custom elements wrapper logic
1. [ ] integrate `shouldPreServe` / `preServe` in all places (e.g. _loader.js_)
1. [ ] Custom plugin options - https://github.com/ProjectEvergreen/greenwood/issues/1247#issuecomment-2721881358
    - types (plugins config, exports, etc)
    - tests
1. [ ] with pre lifecycles, do we even need the distinction of greenwood vs non-greenwood plugins at the top of _serve.js_?
1. [ ] Documentation
    - ~~README~~
    - options (plugins, table of content headings)
1. [ ] (nice to have) - standalone usage - https://github.com/ProjectEvergreen/greenwood/issues/1247

## Thoughts / Questions
1. [ ] does this help with some hot reloading of content as data?  https://github.com/ProjectEvergreen/greenwood/issues/1278
1. [ ] Refine plugins API discussion
    - pre option like in Vite
    - early return instead of `shouldServe` _and_ `serve`