### PR TITLE
bug/issue 1424 exclude CSS Modules plugin from custom transforming itself

### DIFF
--- a/packages/plugin-css-modules/src/index.js
+++ b/packages/plugin-css-modules/src/index.js
@@ -33,7 +33,12 @@ function getCssModulesMap(compilation) {
 async function getTransformedScriptContents(scriptUrl, compilation) {
   const resourcePlugins = compilation.config.plugins
     .filter((plugin) => {
-      return plugin.type === "resource";
+      // exclude the CSS Module related plugins, which would strip imports before scanning happens
+      return (
+        plugin.type === "resource" &&
+        plugin.name !== "plugin-css-modules-strip-modules" &&
+        plugin.name !== "plugin-css-modules:scan"
+      );
     })
     .map((plugin) => {
       return plugin.provider(compilation);


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

#1424 

Realized in https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/191#issuecomment-2741894155 that the CSS Modules plugin was not updating

![Screenshot 2025-03-20 at 7 36 43 PM](https://github.com/user-attachments/assets/b2d202a7-d4d9-4b6f-bb04-053889edb44e)
![Screenshot 2025-03-20 at 7 36 49 PM](https://github.com/user-attachments/assets/b2317c51-b84b-4672-8acf-f7022b9a870d)

## Documentation 

N / A

## Summary of Changes

1. Prevent plugin from self-stripping CSS module imports content

