### PR TITLE
bug/issue 1456 better handling and display for special characters in pages metadata

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -20,3 +20,4 @@ ignore:
   - packages/plugin-babel/node_modules
   - packages/init/node_modules
   - packages/plugin-typescript/node_modules
+  - packages/cli/test/cases/build.default.workspace-special-characters/src/pages

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -62,7 +62,6 @@ const generateGraph = async (compilation) => {
         const files = (await fs.readdir(directory)).filter((file) => !file.startsWith("."));
 
         for (const filename of files) {
-          console.log({ filename });
           const filenameUrl = new URL(`./${filename}`, directory);
           const filenameUrlAsDir = new URL(`./${filename}/`, directory);
           const isDirectory =
@@ -370,8 +369,10 @@ const generateGraph = async (compilation) => {
           const data = await instance();
 
           for (const node of data) {
-            if (!node.body || !node.route) {
-              const missingKey = !node.body ? "body" : "route";
+            const { body, route } = node;
+
+            if (!body || !route) {
+              const missingKey = !body ? "body" : "route";
 
               reject(`ERROR: provided node does not provide a ${missingKey} property.`);
             }
@@ -381,8 +382,9 @@ const generateGraph = async (compilation) => {
               data: {},
               imports: [],
               resources: [],
-              outputHref: new URL(`.${node.route}index.html`, outputDir).href,
+              outputHref: new URL(`.${route}index.html`, outputDir).href,
               ...node,
+              route: encodeURIComponent(route).replace(/%2F/g, "/"),
               external: true,
             });
           }

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -62,6 +62,7 @@ const generateGraph = async (compilation) => {
         const files = (await fs.readdir(directory)).filter((file) => !file.startsWith("."));
 
         for (const filename of files) {
+          console.log({ filename });
           const filenameUrl = new URL(`./${filename}`, directory);
           const filenameUrlAsDir = new URL(`./${filename}/`, directory);
           const isDirectory =
@@ -115,7 +116,9 @@ const generateGraph = async (compilation) => {
                * isolation: if this should be run in isolated mode
                */
               apiRoutes.set(`${basePath}${route}`, {
-                id: getIdFromRelativePathPath(relativePagePath, extension).replace("api-", ""),
+                id: decodeURIComponent(
+                  getIdFromRelativePathPath(relativePagePath, extension).replace("api-", ""),
+                ),
                 pageHref: new URL(relativePagePath, pagesDir).href,
                 outputHref: new URL(relativePagePath, outputDir).href.replace(extension, ".js"),
                 route: `${basePath}${route}`,
@@ -263,9 +266,9 @@ const generateGraph = async (compilation) => {
                * servePage: signal that this is a custom page file type (static | dynamic)
                */
               const page = {
-                id: getIdFromRelativePathPath(relativePagePath, extension),
-                label,
-                title,
+                id: decodeURIComponent(getIdFromRelativePathPath(relativePagePath, extension)),
+                label: decodeURIComponent(label),
+                title: title ? decodeURIComponent(title) : title,
                 route: `${basePath}${route}`,
                 layout,
                 data: customData || {},

--- a/packages/cli/test/cases/build.default.workspace-special-characters/build.default.workspace-special-characters.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-special-characters/build.default.workspace-special-characters.spec.js
@@ -1,0 +1,97 @@
+/*
+ * Use Case
+ * Run Greenwood build command with no config and special characters in workspace files.
+ *
+ * User Result
+ * Should successfully generate a Greenwood build.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * None (Greenwood Default)
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     index.html
+ */
+import chai from "chai";
+import { JSDOM } from "jsdom";
+import path from "path";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath, URL } from "url";
+
+const expect = chai.expect;
+
+describe("Build Greenwood With: ", function () {
+  const LABEL =
+    "Default Greenwood Configuration and Workspace with special characters in page names";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(function () {
+      runner.setup(outputPath);
+      runner.runCommand(cliPath, "build");
+    });
+
+    runSmokeTest(["public", "index"], LABEL);
+
+    describe("Default output for index.html", function () {
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./index.html"));
+      });
+
+      it("should have a the expected heading text", function () {
+        const heading = dom.window.document.querySelector("body h1").textContent;
+
+        expect(heading).to.be.equal("Home Page");
+      });
+    });
+
+    describe("Default output for Lügner2.html", function () {
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./Lügner2/index.html"));
+      });
+
+      it("should have a the expected heading text", function () {
+        const heading = dom.window.document.querySelector("body h1").textContent;
+
+        expect(heading).to.be.equal("Lügner2 Page");
+      });
+    });
+
+    describe("Default output for First Post.html", function () {
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./First Post/index.html"));
+      });
+
+      it("should have a the expected heading text", function () {
+        const heading = dom.window.document.querySelector("body h1").textContent;
+
+        expect(heading).to.be.equal("First Post Page");
+      });
+    });
+  });
+
+  after(function () {
+    runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/cli/test/cases/build.default.workspace-special-characters/build.default.workspace-special-characters.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-special-characters/build.default.workspace-special-characters.spec.js
@@ -14,7 +14,9 @@
  * User Workspace
  * src/
  *   pages/
+ *     First Post.html
  *     index.html
+ *     Lügner2.html
  */
 import chai from "chai";
 import { JSDOM } from "jsdom";

--- a/packages/cli/test/cases/build.default.workspace-special-characters/src/pages/First Post.html
+++ b/packages/cli/test/cases/build.default.workspace-special-characters/src/pages/First Post.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    <h1>First Post Page</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/build.default.workspace-special-characters/src/pages/Lügner2.html
+++ b/packages/cli/test/cases/build.default.workspace-special-characters/src/pages/Lügner2.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    <h1>Lügner2 Page</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/build.default.workspace-special-characters/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.workspace-special-characters/src/pages/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    <h1>Home Page</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
+++ b/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
@@ -141,6 +141,34 @@ describe("Build Greenwood With: ", function () {
         });
       });
     });
+
+    describe("Default output for Lügner2.html", function () {
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./Lügner2/index.html"));
+      });
+
+      it("should have a the expected heading text", function () {
+        const heading = dom.window.document.querySelector("body h1").textContent;
+
+        expect(heading).to.be.equal("Lügner2 Page");
+      });
+    });
+
+    describe("Default output for First Post.html", function () {
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./First Post/index.html"));
+      });
+
+      it("should have a the expected heading text", function () {
+        const heading = dom.window.document.querySelector("body h1").textContent;
+
+        expect(heading).to.be.equal("First Post Page");
+      });
+    });
   });
 
   after(function () {

--- a/packages/cli/test/cases/build.plugins.source/greenwood.config.js
+++ b/packages/cli/test/cases/build.plugins.source/greenwood.config.js
@@ -31,15 +31,14 @@ const customExternalSourcesPlugin = {
           title: "Lügner2",
           id: "Lügner2",
           label: "Lügner2",
-          // route: "/Lügner2/",
-          route: "/L%C3%BCgner2/",
+          route: "/Lügner2/",
           body: `<h1>Lügner2 Page</h1>`,
         },
         {
           title: "First Post",
           id: "first-post",
           label: "First Post",
-          route: "/First%20Post/",
+          route: "/First Post/",
           body: `<h1>First Post Page</h1>`,
         },
       ];

--- a/packages/cli/test/cases/build.plugins.source/greenwood.config.js
+++ b/packages/cli/test/cases/build.plugins.source/greenwood.config.js
@@ -9,27 +9,45 @@ const customExternalSourcesPlugin = {
         await fs.readFile(new URL("./data.json", import.meta.url), "utf-8"),
       );
 
-      return artists.map((artist) => {
-        const { bio, id, imageUrl, name } = artist;
-        const route = `/artists/${name.toLowerCase().replace(/ /g, "-")}/`;
+      return [
+        ...artists.map((artist) => {
+          const { bio, id, imageUrl, name } = artist;
+          const route = `/artists/${name.toLowerCase().replace(/ /g, "-")}/`;
 
-        return {
-          title: name,
-          body: `
+          return {
+            title: name,
+            body: `
             <p>${bio}</p>
             <img src='${imageUrl}'/>
           `,
-          route,
-          layout: "artist",
-          label: name,
-          imageUrl,
-          id,
-        };
-      });
+            route,
+            layout: "artist",
+            label: name,
+            imageUrl,
+            id,
+          };
+        }),
+        {
+          title: "Lügner2",
+          id: "Lügner2",
+          label: "Lügner2",
+          // route: "/Lügner2/",
+          route: "/L%C3%BCgner2/",
+          body: `<h1>Lügner2 Page</h1>`,
+        },
+        {
+          title: "First Post",
+          id: "first-post",
+          label: "First Post",
+          route: "/First%20Post/",
+          body: `<h1>First Post Page</h1>`,
+        },
+      ];
     };
   },
 };
 
 export default {
+  activeContent: true,
   plugins: [customExternalSourcesPlugin],
 };


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1456 

## Documentation 

1. [x] ~~Need to callout on the sources plugin docs that `route` should already be URI encoded~~ - N / A

## Summary of Changes

1. Handle display for special characters in `title`, `label`, and `id`
1. Add test cases

## TODO
1. [ ] Should probably add test cases for `title` / `label`
1. [x] Strategy around [Greenwood auto-encoding `route`](https://github.com/ProjectEvergreen/greenwood/issues/1456#issuecomment-2745347569)?