### PR TITLE
Allow source plugins to access existing graph

### DIFF
--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -360,6 +360,9 @@ const generateGraph = async (compilation) => {
 
       const sourcePlugins = compilation.config.plugins.filter((plugin) => plugin.type === "source");
 
+      compilation.graph = graph;
+      compilation.manifest = { apis };
+
       if (sourcePlugins.length > 0) {
         console.debug("building from external sources...");
         for (const plugin of sourcePlugins) {
@@ -385,9 +388,6 @@ const generateGraph = async (compilation) => {
           }
         }
       }
-
-      compilation.graph = graph;
-      compilation.manifest = { apis };
 
       resolve(compilation);
     } catch (err) {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1470 

## Documentation 

<!-- if this issue has been labeled with documentation, please make sure submit a PR to our website repo and link it -->
<!-- https://github.com/ProjectEvergreen/www.greenwoodjs.dev -->

## Summary of Changes

- Moved assignment of graph into compilation *before* source plugins run, meaning plugins can access existing graph.