### PR TITLE
feature/issue 1424 TypeScript based layouts

### DIFF
--- a/packages/cli/src/lib/layout-utils.js
+++ b/packages/cli/src/lib/layout-utils.js
@@ -52,6 +52,9 @@ async function getPageLayout(pageHref = "", compilation, layout) {
   const hasCustomDynamicLayout = await checkResourceExists(
     new URL(`./${layout}.js`, userLayoutsDir),
   );
+  const hasCustomDynamicTypeScriptLayout = await checkResourceExists(
+    new URL(`./${layout}.ts`, userLayoutsDir),
+  );
   const hasPageLayout = await checkResourceExists(new URL("./page.html", userLayoutsDir));
   const hasCustom404Page = await checkResourceExists(new URL("./404.html", pagesDir));
   const isHtmlPage = extension === "html" && (await checkResourceExists(new URL(pageHref)));
@@ -77,8 +80,10 @@ async function getPageLayout(pageHref = "", compilation, layout) {
       customPluginDefaultPageLayouts.length > 0
         ? await fs.readFile(new URL("./page.html", customPluginDefaultPageLayouts[0]), "utf-8")
         : await fs.readFile(new URL("./page.html", userLayoutsDir), "utf-8");
-  } else if (hasCustomDynamicLayout && !is404Page) {
-    const routeModuleLocationUrl = new URL(`./${layout}.js`, userLayoutsDir);
+  } else if ((hasCustomDynamicLayout || hasCustomDynamicTypeScriptLayout) && !is404Page) {
+    const routeModuleLocationUrl = hasCustomDynamicLayout
+      ? new URL(`./${layout}.js`, userLayoutsDir)
+      : new URL(`./${layout}.ts`, userLayoutsDir);
     const routeWorkerUrl = compilation.config.plugins
       .find((plugin) => plugin.type === "renderer")
       .provider().executeModuleUrl;

--- a/packages/cli/test/cases/build.typescript.default/build.typescript.default.spec.js
+++ b/packages/cli/test/cases/build.typescript.default/build.typescript.default.spec.js
@@ -1,9 +1,9 @@
 /*
  * Use Case
- * Run Greenwood with TypeScript processing.
+ * Run Greenwood with TypeScript processing for pages, layouts and scripts.
  *
  * User Result
- * Should generate a bare bones Greenwood build with the user's JavaScript files processed based on the pluygins default config.
+ * Should generate a Greenwood build using Greenwood's built-in TypeScript support.
  *
  * User Command
  * greenwood build
@@ -13,25 +13,20 @@
  *
  * User Workspace
  *  src/
+ *   layouts/
+ *     app.ts
  *   pages/
  *     index.html
  *   scripts/
  *     main.ts
  *
  * Default Config
- * {
- *   "compilerOptions": {
- *      "target": "es2020",
- *      "module": "es2020",
- *      "moduleResolution": "node",
- *      "sourceMap": true
- *   }
- * }
  *
  */
 import chai from "chai";
 import fs from "fs";
 import glob from "glob-promise";
+import { JSDOM } from "jsdom";
 import path from "path";
 import { runSmokeTest } from "../../../../../test/smoke-test.js";
 import { getOutputTeardownFiles } from "../../../../../test/utils.js";
@@ -59,9 +54,38 @@ describe("Build Greenwood With: ", function () {
       runner.runCommand(cliPath, "build");
     });
 
-    runSmokeTest(["public", "index"], LABEL);
+    runSmokeTest(["public"], LABEL);
 
-    describe("TypeScript should process JavaScript that uses an interface", function () {
+    describe("TypeScript based App Layout should be processed JavaScript and output HTML", function () {
+      const text = "TypeScript App Layout";
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./index.html"));
+      });
+
+      it("should the correct app.ts layout <title> tag contents", function () {
+        const title = dom.window.document.querySelector("head title").textContent;
+
+        expect(title).to.be.equal(text);
+      });
+
+      it("should the correct app.ts layout <h1> tag contents", function () {
+        const heading = dom.window.document.querySelector("h1").textContent;
+
+        expect(heading).to.be.equal(text);
+      });
+
+      it("should the correct index.html page <h2> tag contents", function () {
+        const heading = dom.window.document.querySelector("h2").textContent;
+
+        expect(heading).to.be.equal("Hello World!");
+      });
+    });
+
+    xdescribe("TypeScript based Page Layout leveraging custom format support", function () {});
+
+    describe("TypeScript in a <script> tag should get correctly processed as JavaScript", function () {
       it("should output correctly processed JavaScript without the interface", function () {
         const jsFiles = glob.sync(path.join(this.context.publicDir, "*.js"));
         const javascript = fs.readFileSync(jsFiles[0], "utf-8");

--- a/packages/cli/test/cases/build.typescript.default/build.typescript.default.spec.js
+++ b/packages/cli/test/cases/build.typescript.default/build.typescript.default.spec.js
@@ -56,34 +56,107 @@ describe("Build Greenwood With: ", function () {
 
     runSmokeTest(["public"], LABEL);
 
-    describe("TypeScript based App Layout should be processed JavaScript and output HTML", function () {
-      const text = "TypeScript App Layout";
+    describe("TypeScript based App Layout should should generate the expected HTML for the home page", function () {
       let dom;
 
       before(async function () {
         dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./index.html"));
       });
 
-      it("should the correct app.ts layout <title> tag contents", function () {
+      it("should have the correct app.ts layout <title> tag contents", function () {
         const title = dom.window.document.querySelector("head title").textContent;
 
-        expect(title).to.be.equal(text);
+        expect(title).to.be.equal("TypeScript App Layout");
       });
 
-      it("should the correct app.ts layout <h1> tag contents", function () {
+      it("should have the correct app.ts layout <h1> tag contents", function () {
         const heading = dom.window.document.querySelector("h1").textContent;
 
-        expect(heading).to.be.equal(text);
+        expect(heading).to.be.equal("TypeScript App Layout");
       });
 
-      it("should the correct index.html page <h2> tag contents", function () {
+      it("should have the correct index.html page <h2> tag contents", function () {
         const heading = dom.window.document.querySelector("h2").textContent;
 
         expect(heading).to.be.equal("Hello World!");
       });
     });
 
-    xdescribe("TypeScript based Page Layout leveraging custom format support", function () {});
+    describe("TypeScript based Custom Page Layout should generate the expected HTML for the Contact Page", function () {
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./contact/index.html"));
+      });
+
+      it("should have the correct blog.ts layout <title> tag contents", function () {
+        const title = dom.window.document.querySelector("head title").textContent;
+
+        expect(title).to.be.equal("Default Page Layout");
+      });
+
+      it("should have the correct blog.ts layout <h1> tag contents", function () {
+        const heading = dom.window.document.querySelector("h1").textContent;
+
+        expect(heading).to.be.equal("TypeScript App Layout");
+      });
+
+      it("should have the correct blog.ts layout <h1> tag contents", function () {
+        const heading = dom.window.document.querySelector("h2").textContent;
+
+        expect(heading).to.be.equal("Default Page Layout");
+      });
+
+      it("should have the correct index.html page <h3> tag contents", function () {
+        const heading = dom.window.document.querySelector("h3").textContent;
+
+        expect(heading).to.be.equal("Contact Page");
+      });
+
+      it("should have the correct index.html page <p> tag contents", function () {
+        const heading = dom.window.document.querySelector("p").textContent;
+
+        expect(heading).to.be.equal("Please reach out!");
+      });
+    });
+
+    describe("TypeScript based Custom Page Layout should generate the expected HTML for the Blog Page", function () {
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./blog/index.html"));
+      });
+
+      it("should have the correct page.ts layout <title> tag contents", function () {
+        const title = dom.window.document.querySelector("head title").textContent;
+
+        expect(title).to.be.equal("TypeScript Blog Page Layout");
+      });
+
+      it("should have the correct app.ts layout <h1> tag contents", function () {
+        const heading = dom.window.document.querySelector("h1").textContent;
+
+        expect(heading).to.be.equal("TypeScript App Layout");
+      });
+
+      it("should have the correct index.html page <h2> tag contents", function () {
+        const heading = dom.window.document.querySelector("h2").textContent;
+
+        expect(heading).to.be.equal("TypeScript Blog Page Layout");
+      });
+
+      it("should have the correct index.html page <h3> tag contents", function () {
+        const heading = dom.window.document.querySelector("h3").textContent;
+
+        expect(heading).to.be.equal("My Blog Posts");
+      });
+
+      it("should have the correct index.html page <p> tag contents", function () {
+        const heading = dom.window.document.querySelector("p").textContent;
+
+        expect(heading).to.be.equal("Lorum Ipsum");
+      });
+    });
 
     describe("TypeScript in a <script> tag should get correctly processed as JavaScript", function () {
       it("should output correctly processed JavaScript without the interface", function () {

--- a/packages/cli/test/cases/build.typescript.default/src/layouts/app.ts
+++ b/packages/cli/test/cases/build.typescript.default/src/layouts/app.ts
@@ -1,0 +1,16 @@
+export default class AppLayout extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = `
+      <!doctype html>
+      <html lang="en" prefix="og:http://ogp.me/ns#">
+        <head>
+          <title>TypeScript App Layout</title>
+        </head>
+        <body>
+          <h1>TypeScript App Layout</h1>
+          <page-outlet></page-outlet>
+        </body>
+      </html>
+    `;
+  }
+}

--- a/packages/cli/test/cases/build.typescript.default/src/layouts/blog.ts
+++ b/packages/cli/test/cases/build.typescript.default/src/layouts/blog.ts
@@ -1,0 +1,18 @@
+const html: string = `
+<!doctype html>
+<html lang="en" prefix="og:http://ogp.me/ns#">
+  <head>
+    <title>TypeScript Blog Page Layout</title>
+  </head>
+  <body>
+    <h2>TypeScript Blog Page Layout</h2>
+    <content-outlet></content-outlet>
+  </body>
+</html>
+`;
+
+export default class BlogLayout extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = html;
+  }
+}

--- a/packages/cli/test/cases/build.typescript.default/src/layouts/page.ts
+++ b/packages/cli/test/cases/build.typescript.default/src/layouts/page.ts
@@ -1,0 +1,18 @@
+const html: string = `
+<!doctype html>
+<html lang="en" prefix="og:http://ogp.me/ns#">
+  <head>
+    <title>Default Page Layout</title>
+  </head>
+  <body>
+    <h2>Default Page Layout</h2>
+    <content-outlet></content-outlet>
+  </body>
+</html>
+`;
+
+export default class BlogLayout extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = html;
+  }
+}

--- a/packages/cli/test/cases/build.typescript.default/src/pages/blog/index.md
+++ b/packages/cli/test/cases/build.typescript.default/src/pages/blog/index.md
@@ -1,0 +1,7 @@
+---
+layout: "blog"
+---
+
+### My Blog Posts
+
+Lorum Ipsum

--- a/packages/cli/test/cases/build.typescript.default/src/pages/contact.md
+++ b/packages/cli/test/cases/build.typescript.default/src/pages/contact.md
@@ -1,0 +1,3 @@
+### Contact Page
+
+Please reach out!

--- a/packages/cli/test/cases/build.typescript.default/src/pages/index.html
+++ b/packages/cli/test/cases/build.typescript.default/src/pages/index.html
@@ -1,10 +1,9 @@
-<!doctype html>
-<html lang="en" prefix="og:http://ogp.me/ns#">
+<html>
   <head>
     <script type="module" src="/scripts/main.ts"></script>
   </head>
 
   <body>
-    <h1>Hello World!</h1>
+    <h2>Hello World!</h2>
   </body>
 </html>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

fills in a gap from #1424 (somewhat overlaps with #1395)

## Documentation 

1. [x] ~~Document minimally supported TypeScript layout formats (_.html_, _.js_, _.ts_) and that custom layouts only apply to markdown?~~ - I think this is fine for now, and #1475 can handle final docs on this

## Summary of Changes

1. Add support for TS based layouts

## TODO
1. [x] Add support for default and custom layouts
1. [x] Need to reconcile the fact that "top level pages" opt-out of page layouts with some sort of docs / issue tracking - https://github.com/ProjectEvergreen/greenwood/issues/1475
    - https://github.com/ProjectEvergreen/greenwood/blob/v0.32.0-alpha.7/packages/cli/src/lib/layout-utils.js#L66
    - it seems only markdown files would honor a custom layout, so should reconcile against - #1247 
1. [x] Not sure if related specifically to TypeScript, but getting these warnings from WCC, due to our "placeholders" for `<page-outlet>` / `<content-outlet>` - https://github.com/ProjectEvergreen/greenwood/issues/1476
    ```sh
    WARNING: customElement <page-outlet> is not defined.  You may not have imported it.
    WARNING: customElement <page-outlet> is not defined.  You may not have imported it.
    WARNING: customElement <content-outlet> is not defined.  You may not have imported it.
    ``` 
1. [ ] Need to reconcile against #1473 