### PR TITLE
enhancement/issue 1491 refactor out usages of async Promise executors

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -10,83 +10,68 @@ import {
 } from "../lifecycles/prerender.js";
 
 const runProductionBuild = async (compilation) => {
-  // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async (resolve, reject) => {
-    try {
-      const { prerender, activeContent, plugins } = compilation.config;
-      const outputDir = compilation.context.outputDir;
-      const prerenderPlugin = compilation.config.plugins.find(
-        (plugin) => plugin.type === "renderer",
-      )
-        ? compilation.config.plugins
-            .find((plugin) => plugin.type === "renderer")
-            .provider(compilation)
-        : {};
-      const adapterPlugin = compilation.config.plugins.find((plugin) => plugin.type === "adapter")
-        ? compilation.config.plugins
-            .find((plugin) => plugin.type === "adapter")
-            .provider(compilation)
-        : null;
+  const { prerender, activeContent, plugins } = compilation.config;
+  const outputDir = compilation.context.outputDir;
+  const prerenderPlugin = compilation.config.plugins.find((plugin) => plugin.type === "renderer")
+    ? compilation.config.plugins.find((plugin) => plugin.type === "renderer").provider(compilation)
+    : {};
+  const adapterPlugin = compilation.config.plugins.find((plugin) => plugin.type === "adapter")
+    ? compilation.config.plugins.find((plugin) => plugin.type === "adapter").provider(compilation)
+    : null;
 
-      if (!(await checkResourceExists(outputDir))) {
-        await fs.mkdir(outputDir, {
-          recursive: true,
-        });
-      }
+  if (!(await checkResourceExists(outputDir))) {
+    await fs.mkdir(outputDir, {
+      recursive: true,
+    });
+  }
 
-      if (prerender) {
-        // start any of the user's server plugins if needed
-        const servers = [
-          ...compilation.config.plugins
-            .filter((plugin) => {
-              return plugin.type === "server" && !plugin.isGreenwoodDefaultPlugin;
-            })
-            .map((plugin) => plugin.provider(compilation)),
-        ];
+  if (prerender) {
+    // start any of the user's server plugins if needed
+    const servers = [
+      ...compilation.config.plugins
+        .filter((plugin) => {
+          return plugin.type === "server" && !plugin.isGreenwoodDefaultPlugin;
+        })
+        .map((plugin) => plugin.provider(compilation)),
+    ];
 
-        if (activeContent) {
-          (
-            await getDevServer({
-              ...compilation,
-              // prune for the content as data plugin and start the dev server with only that plugin enabled
-              plugins: [plugins.find((plugin) => plugin.name === "plugin-active-content")],
-            })
-          ).listen(compilation.config.devServer.port, () => {
-            console.info("Initializing active content...");
-          });
-        }
-
-        await Promise.all(
-          servers.map(async (server) => {
-            await server.start();
-
-            return Promise.resolve(server);
-          }),
-        );
-
-        if (prerenderPlugin.executeModuleUrl) {
-          await preRenderCompilationWorker(compilation, prerenderPlugin);
-        } else {
-          await preRenderCompilationCustom(compilation, prerenderPlugin);
-        }
-      } else {
-        await staticRenderCompilation(compilation);
-      }
-
-      console.info("success, done generating all pages!");
-
-      await bundleCompilation(compilation);
-      await copyAssets(compilation);
-
-      if (adapterPlugin) {
-        await adapterPlugin();
-      }
-
-      resolve();
-    } catch (err) {
-      reject(err);
+    if (activeContent) {
+      (
+        await getDevServer({
+          ...compilation,
+          // prune for the content as data plugin and start the dev server with only that plugin enabled
+          plugins: [plugins.find((plugin) => plugin.name === "plugin-active-content")],
+        })
+      ).listen(compilation.config.devServer.port, () => {
+        console.info("Initializing active content...");
+      });
     }
-  });
+
+    await Promise.all(
+      servers.map(async (server) => {
+        await server.start();
+
+        return Promise.resolve(server);
+      }),
+    );
+
+    if (prerenderPlugin.executeModuleUrl) {
+      await preRenderCompilationWorker(compilation, prerenderPlugin);
+    } else {
+      await preRenderCompilationCustom(compilation, prerenderPlugin);
+    }
+  } else {
+    await staticRenderCompilation(compilation);
+  }
+
+  console.info("success, done generating all pages!");
+
+  await bundleCompilation(compilation);
+  await copyAssets(compilation);
+
+  if (adapterPlugin) {
+    await adapterPlugin();
+  }
 };
 
 export { runProductionBuild };

--- a/packages/cli/src/commands/develop.js
+++ b/packages/cli/src/commands/develop.js
@@ -5,31 +5,26 @@ const runDevServer = async (compilation) => {
   const { port } = devServer;
   const postfixSlash = basePath === "" ? "" : "/";
 
-  // we intentionally _don't_ want this promise to resolve to keep the servers "hanging" for development
-  // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async (resolve, reject) => {
-    try {
-      (await getDevServer(compilation)).listen(port, async () => {
-        console.info(
-          `Started local development server at http://localhost:${port}${basePath}${postfixSlash}`,
-        );
+  (await getDevServer(compilation)).listen(port, async () => {
+    console.info(
+      `Started local development server at http://localhost:${port}${basePath}${postfixSlash}`,
+    );
 
-        const servers = [
-          ...compilation.config.plugins
-            .filter((plugin) => {
-              return plugin.type === "server";
-            })
-            .map((plugin) => plugin.provider(compilation)),
-        ];
+    const servers = [
+      ...compilation.config.plugins
+        .filter((plugin) => {
+          return plugin.type === "server";
+        })
+        .map((plugin) => plugin.provider(compilation)),
+    ];
 
-        for (const server of servers) {
-          server.start();
-        }
-      });
-    } catch (err) {
-      reject(err);
+    for (const server of servers) {
+      server.start();
     }
   });
+
+  // we intentionally _don't_ want this promise to resolve to keep the servers "hanging" for development
+  return new Promise(() => {});
 };
 
 export { runDevServer };

--- a/packages/cli/src/commands/eject.js
+++ b/packages/cli/src/commands/eject.js
@@ -1,28 +1,19 @@
 import fs from "fs/promises";
 
 const ejectConfiguration = async (compilation) => {
-  // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async (resolve, reject) => {
-    try {
-      const configFileDirUrl = new URL("../config/", import.meta.url);
-      const configFiles = await fs.readdir(configFileDirUrl);
+  const configFileDirUrl = new URL("../config/", import.meta.url);
+  const configFiles = await fs.readdir(configFileDirUrl);
 
-      for (const file of configFiles) {
-        const from = new URL(`./${file}`, configFileDirUrl);
-        const to = new URL(`./${file}`, compilation.context.projectDirectory);
+  for (const file of configFiles) {
+    const from = new URL(`./${file}`, configFileDirUrl);
+    const to = new URL(`./${file}`, compilation.context.projectDirectory);
 
-        await fs.copyFile(from, to);
+    await fs.copyFile(from, to);
 
-        console.log(`Ejected ${file} successfully.`);
-      }
+    console.log(`Ejected ${file} successfully.`);
+  }
 
-      console.debug("all configuration files ejected.");
-
-      resolve();
-    } catch (err) {
-      reject(err);
-    }
-  });
+  console.debug("all configuration files ejected.");
 };
 
 export { ejectConfiguration };

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -11,16 +11,12 @@ const runProdServer = async (compilation) => {
       ? getHybridServer
       : getStaticServer;
 
-  // we intentionally _don't_ want this promise to resolve to keep the server "hanging" for production
-  // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async (resolve, reject) => {
-    try {
-      (await server(compilation)).listen(port, () => {
-        console.info(`Started server at http://localhost:${port}${basePath}${postfixSlash}`);
-      });
-    } catch (err) {
-      reject(err);
-    }
+  (await server(compilation)).listen(port, () => {
+    console.info(`Started server at http://localhost:${port}${basePath}${postfixSlash}`);
   });
+
+  // we intentionally _don't_ want this promise to resolve to keep the server "hanging" for production
+  return new Promise(() => {});
 };
+
 export { runProdServer };

--- a/packages/cli/src/commands/serve.js
+++ b/packages/cli/src/commands/serve.js
@@ -2,18 +2,19 @@ import { getStaticServer, getHybridServer } from "../lifecycles/serve.js";
 import { checkResourceExists } from "../lib/resource-utils.js";
 
 const runProdServer = async (compilation) => {
+  const { basePath, port } = compilation.config;
+  const postfixSlash = basePath === "" ? "" : "/";
+  const hasApisDir = await checkResourceExists(compilation.context.apisDir);
+  const hasDynamicRoutes = compilation.graph.find((page) => page.isSSR && !page.prerender);
+  const server =
+    (hasDynamicRoutes && !compilation.config.prerender) || hasApisDir
+      ? getHybridServer
+      : getStaticServer;
+
+  // we intentionally _don't_ want this promise to resolve to keep the server "hanging" for production
   // eslint-disable-next-line no-async-promise-executor
   return new Promise(async (resolve, reject) => {
     try {
-      const { basePath, port } = compilation.config;
-      const postfixSlash = basePath === "" ? "" : "/";
-      const hasApisDir = await checkResourceExists(compilation.context.apisDir);
-      const hasDynamicRoutes = compilation.graph.find((page) => page.isSSR && !page.prerender);
-      const server =
-        (hasDynamicRoutes && !compilation.config.prerender) || hasApisDir
-          ? getHybridServer
-          : getStaticServer;
-
       (await server(compilation)).listen(port, () => {
         console.info(`Started server at http://localhost:${port}${basePath}${postfixSlash}`);
       });
@@ -22,5 +23,4 @@ const runProdServer = async (compilation) => {
     }
   });
 };
-
 export { runProdServer };

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -57,10 +57,10 @@ if (program.parse.length === 0) {
 
 const run = async () => {
   process.env.__GWD_COMMAND__ = command;
-  const compilation = await generateCompilation();
 
   try {
     console.info(`Running Greenwood with the ${command} command.`);
+    const compilation = await generateCompilation();
 
     switch (command) {
       case "build":

--- a/packages/cli/src/lib/layout-utils.js
+++ b/packages/cli/src/lib/layout-utils.js
@@ -88,8 +88,7 @@ async function getPageLayout(pageHref = "", compilation, layout) {
       .find((plugin) => plugin.type === "renderer")
       .provider().executeModuleUrl;
 
-    // eslint-disable-next-line no-async-promise-executor
-    await new Promise(async (resolve, reject) => {
+    await new Promise((resolve, reject) => {
       const worker = new Worker(new URL("./ssr-route-worker.js", import.meta.url));
 
       worker.on("message", (result) => {
@@ -141,8 +140,7 @@ async function getAppLayout(pageLayoutContents, compilation, customImports = [],
       .find((plugin) => plugin.type === "renderer")
       .provider().executeModuleUrl;
 
-    // eslint-disable-next-line no-async-promise-executor
-    await new Promise(async (resolve, reject) => {
+    await new Promise((resolve, reject) => {
       const worker = new Worker(new URL("./ssr-route-worker.js", import.meta.url));
 
       worker.on("message", (result) => {

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -457,40 +457,28 @@ async function bundleScriptResources(compilation) {
 }
 
 const bundleCompilation = async (compilation) => {
-  // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async (resolve, reject) => {
-    try {
-      const optimizeResourcePlugins = compilation.config.plugins
-        .filter((plugin) => {
-          return plugin.type === "resource";
-        })
-        .map((plugin) => {
-          return plugin.provider(compilation);
-        });
+  const optimizeResourcePlugins = compilation.config.plugins
+    .filter((plugin) => {
+      return plugin.type === "resource";
+    })
+    .map((plugin) => {
+      return plugin.provider(compilation);
+    });
 
-      console.info("bundling static assets...");
+  console.info("bundling static assets...");
 
-      // need styles bundled first for usage with import attributes syncing in Rollup
-      await bundleStyleResources(compilation, optimizeResourcePlugins);
+  // need styles bundled first for usage with import attributes syncing in Rollup
+  await bundleStyleResources(compilation, optimizeResourcePlugins);
 
-      await Promise.all([
-        await bundleApiRoutes(compilation),
-        await bundleScriptResources(compilation),
-      ]);
+  await Promise.all([await bundleApiRoutes(compilation), await bundleScriptResources(compilation)]);
 
-      // bundleSsrPages depends on bundleScriptResources having run first
-      await bundleSsrPages(compilation, optimizeResourcePlugins);
+  // bundleSsrPages depends on bundleScriptResources having run first
+  await bundleSsrPages(compilation, optimizeResourcePlugins);
 
-      console.info("optimizing static pages....");
-      await optimizeStaticPages(compilation, optimizeResourcePlugins);
-      await cleanUpResources(compilation);
-      await emitResources(compilation);
-
-      resolve();
-    } catch (err) {
-      reject(err);
-    }
-  });
+  console.info("optimizing static pages....");
+  await optimizeStaticPages(compilation, optimizeResourcePlugins);
+  await cleanUpResources(compilation);
+  await emitResources(compilation);
 };
 
 export { bundleCompilation };

--- a/packages/cli/src/lifecycles/compile.js
+++ b/packages/cli/src/lifecycles/compile.js
@@ -4,117 +4,110 @@ import { initContext } from "./context.js";
 import { readAndMergeConfig } from "./config.js";
 import fs from "fs/promises";
 
-const generateCompilation = () => {
-  // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async (resolve, reject) => {
-    try {
-      let compilation = {
-        graph: [],
-        context: {},
-        config: {},
-        // TODO put resources into manifest
-        resources: new Map(),
-        manifest: {
-          apis: new Map(),
-        },
-        collections: {},
-      };
+const generateCompilation = async () => {
+  let compilation = {
+    graph: [],
+    context: {},
+    config: {},
+    // TODO put resources into manifest
+    resources: new Map(),
+    manifest: {
+      apis: new Map(),
+    },
+    collections: {},
+  };
 
-      console.info("Initializing project config");
-      compilation.config = await readAndMergeConfig();
+  console.info("Initializing project config");
+  compilation.config = await readAndMergeConfig();
 
-      // determine whether to use default layout or user detected workspace
-      console.info("Initializing project workspace contexts");
-      compilation.context = await initContext(compilation);
+  // determine whether to use default layout or user detected workspace
+  console.info("Initializing project workspace contexts");
+  compilation.context = await initContext(compilation);
 
-      const { scratchDir, outputDir } = compilation.context;
+  const { scratchDir, outputDir } = compilation.context;
 
-      if (!(await checkResourceExists(scratchDir))) {
-        await fs.mkdir(scratchDir);
-      }
+  if (!(await checkResourceExists(scratchDir))) {
+    await fs.mkdir(scratchDir);
+  }
 
-      if (process.env.__GWD_COMMAND__ === "serve") {
-        console.info("Loading graph from build output...");
+  if (process.env.__GWD_COMMAND__ === "serve") {
+    console.info("Loading graph from build output...");
 
-        if (!(await checkResourceExists(new URL("./graph.json", outputDir)))) {
-          reject(new Error("No build output detected.  Make sure you have run greenwood build"));
-        }
-
-        compilation.graph = JSON.parse(
-          await fs.readFile(new URL("./graph.json", outputDir), "utf-8"),
-        );
-
-        if (await checkResourceExists(new URL("./manifest.json", outputDir))) {
-          console.info("Loading manifest from build output...");
-          // TODO put reviver into a utility?
-          const manifest = JSON.parse(
-            // @ts-expect-error see https://github.com/microsoft/TypeScript/issues/42866
-            await fs.readFile(new URL("./manifest.json", outputDir)),
-            function reviver(key, value) {
-              if (typeof value === "object" && value !== null) {
-                if (value.dataType === "Map") {
-                  return new Map(value.value);
-                }
-              }
-              return value;
-            },
-          );
-
-          compilation.manifest = manifest;
-        }
-
-        if (await checkResourceExists(new URL("./resources.json", outputDir))) {
-          console.info("Loading resources from build output...");
-          // TODO put reviver into a utility?
-          const resources = JSON.parse(
-            // @ts-expect-error see https://github.com/microsoft/TypeScript/issues/42866
-            await fs.readFile(new URL("./resources.json", outputDir)),
-            function reviver(key, value) {
-              if (typeof value === "object" && value !== null) {
-                if (value.dataType === "Map") {
-                  // revive URLs
-                  if (value.value.sourcePathURL) {
-                    value.value.sourcePathURL = new URL(value.value.sourcePathURL);
-                  }
-
-                  return new Map(value.value);
-                }
-              }
-              return value;
-            },
-          );
-
-          compilation.resources = resources;
-        }
-      } else {
-        // generate a graph of all pages / components to build
-        console.info("Generating graph of workspace files...");
-        compilation = await generateGraph(compilation);
-
-        // https://stackoverflow.com/a/56150320/417806
-        // TODO put reviver into a util?
-        await fs.writeFile(
-          new URL("./manifest.json", scratchDir),
-          JSON.stringify(compilation.manifest, (key, value) => {
-            if (value instanceof Map) {
-              return {
-                dataType: "Map",
-                value: [...value],
-              };
-            } else {
-              return value;
-            }
-          }),
-        );
-
-        await fs.writeFile(new URL("./graph.json", scratchDir), JSON.stringify(compilation.graph));
-      }
-
-      resolve(compilation);
-    } catch (err) {
-      reject(err);
+    if (!(await checkResourceExists(new URL("./graph.json", outputDir)))) {
+      return Promise.reject(
+        new Error("No build output detected.  Make sure you have run greenwood build"),
+      );
     }
-  });
+
+    compilation.graph = JSON.parse(await fs.readFile(new URL("./graph.json", outputDir), "utf-8"));
+
+    if (await checkResourceExists(new URL("./manifest.json", outputDir))) {
+      console.info("Loading manifest from build output...");
+      // TODO put reviver into a utility?
+      const manifest = JSON.parse(
+        // @ts-expect-error see https://github.com/microsoft/TypeScript/issues/42866
+        await fs.readFile(new URL("./manifest.json", outputDir)),
+        function reviver(key, value) {
+          if (typeof value === "object" && value !== null) {
+            if (value.dataType === "Map") {
+              return new Map(value.value);
+            }
+          }
+          return value;
+        },
+      );
+
+      compilation.manifest = manifest;
+    }
+
+    if (await checkResourceExists(new URL("./resources.json", outputDir))) {
+      console.info("Loading resources from build output...");
+      // TODO put reviver into a utility?
+      const resources = JSON.parse(
+        // @ts-expect-error see https://github.com/microsoft/TypeScript/issues/42866
+        await fs.readFile(new URL("./resources.json", outputDir)),
+        function reviver(key, value) {
+          if (typeof value === "object" && value !== null) {
+            if (value.dataType === "Map") {
+              // revive URLs
+              if (value.value.sourcePathURL) {
+                value.value.sourcePathURL = new URL(value.value.sourcePathURL);
+              }
+
+              return new Map(value.value);
+            }
+          }
+          return value;
+        },
+      );
+
+      compilation.resources = resources;
+    }
+  } else {
+    // generate a graph of all pages / components to build
+    console.info("Generating graph of workspace files...");
+    compilation = await generateGraph(compilation);
+
+    // https://stackoverflow.com/a/56150320/417806
+    // TODO put reviver into a util?
+    await fs.writeFile(
+      new URL("./manifest.json", scratchDir),
+      JSON.stringify(compilation.manifest, (key, value) => {
+        if (value instanceof Map) {
+          return {
+            dataType: "Map",
+            value: [...value],
+          };
+        } else {
+          return value;
+        }
+      }),
+    );
+
+    await fs.writeFile(new URL("./graph.json", scratchDir), JSON.stringify(compilation.graph));
+  }
+
+  return Promise.resolve(compilation);
 };
 
 export { generateCompilation };

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -81,284 +81,279 @@ const defaultConfig = {
 };
 
 const readAndMergeConfig = async () => {
-  // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async (resolve, reject) => {
-    try {
-      // check for greenwood.config.ts or greenwood.config.js
-      const jsConfigUrl = new URL("./greenwood.config.js", cwd);
-      const tsConfigUrl = new URL("./greenwood.config.ts", cwd);
-      const configUrl = (await checkResourceExists(tsConfigUrl))
-        ? tsConfigUrl
-        : (await checkResourceExists(jsConfigUrl))
-          ? jsConfigUrl
-          : null;
-      // deep clone of default config
-      let customConfig = Object.assign({}, defaultConfig);
-      let isSPA;
+  // check for greenwood.config.ts or greenwood.config.js
+  const jsConfigUrl = new URL("./greenwood.config.js", cwd);
+  const tsConfigUrl = new URL("./greenwood.config.ts", cwd);
+  const configUrl = (await checkResourceExists(tsConfigUrl))
+    ? tsConfigUrl
+    : (await checkResourceExists(jsConfigUrl))
+      ? jsConfigUrl
+      : null;
+  // deep clone of default config
+  let customConfig = Object.assign({}, defaultConfig);
+  let isSPA;
 
-      // check for SPA
-      if (await checkResourceExists(new URL("./index.html", customConfig.workspace))) {
-        isSPA = true;
+  // check for SPA
+  if (await checkResourceExists(new URL("./index.html", customConfig.workspace))) {
+    isSPA = true;
+  }
+
+  if (configUrl) {
+    // should try and figure this out - https://github.com/ProjectEvergreen/greenwood/issues/1439
+    // console.log(`Configuration file detected... loading => ${configUrl.href}`);
+
+    // @ts-expect-error see https://github.com/microsoft/TypeScript/issues/42866
+    const userCfgFile = (await import(configUrl)).default;
+    const {
+      workspace,
+      devServer,
+      markdown,
+      optimization,
+      plugins,
+      port,
+      prerender,
+      basePath,
+      staticRouter,
+      pagesDirectory,
+      layoutsDirectory,
+      activeContent,
+      isolation,
+      polyfills,
+      useTsc,
+    } = userCfgFile;
+
+    // workspace validation
+    if (workspace) {
+      if (!(workspace instanceof URL)) {
+        return Promise.reject("Configuration error: workspace must be an instance of URL");
       }
 
-      if (configUrl) {
-        // should try and figure this out - https://github.com/ProjectEvergreen/greenwood/issues/1439
-        // console.log(`Configuration file detected... loading => ${configUrl.href}`);
-
-        // @ts-expect-error see https://github.com/microsoft/TypeScript/issues/42866
-        const userCfgFile = (await import(configUrl)).default;
-        const {
-          workspace,
-          devServer,
-          markdown,
-          optimization,
-          plugins,
-          port,
-          prerender,
-          basePath,
-          staticRouter,
-          pagesDirectory,
-          layoutsDirectory,
-          activeContent,
-          isolation,
-          polyfills,
-          useTsc,
-        } = userCfgFile;
-
-        // workspace validation
-        if (workspace) {
-          if (!(workspace instanceof URL)) {
-            reject("Configuration error: workspace must be an instance of URL");
-          }
-
-          if (await checkResourceExists(workspace)) {
-            customConfig.workspace = workspace;
-          } else {
-            reject(
-              "Configuration error: Workspace doesn't exist! Please double check your configuration.",
-            );
-          }
-        }
-
-        if (
-          typeof optimization === "string" &&
-          optimizations.indexOf(optimization.toLowerCase()) >= 0
-        ) {
-          customConfig.optimization = optimization;
-        } else if (optimization) {
-          reject(
-            `Configuration error: provided optimization "${optimization}" is not supported.  Please use one of: ${optimizations.join(", ")}.`,
-          );
-        }
-
-        if (activeContent) {
-          if (typeof activeContent !== "boolean") {
-            reject("Configuration error: activeContent must be a boolean");
-          }
-          customConfig.activeContent = activeContent;
-        }
-
-        if (plugins && plugins.length > 0) {
-          const flattened = plugins.flat(PLUGINS_FLATTENED_DEPTH);
-
-          flattened.forEach((plugin) => {
-            if (!plugin.type || pluginTypes.indexOf(plugin.type) < 0) {
-              reject(
-                `Configuration error: plugins must be one of type "${pluginTypes.join(", ")}". got "${plugin.type}" instead.`,
-              );
-            }
-
-            if (!plugin.provider || typeof plugin.provider !== "function") {
-              const providerTypeof = typeof plugin.provider;
-
-              reject(
-                `Configuration error: plugins provider must be a function. got ${providerTypeof} instead.`,
-              );
-            }
-
-            if (!plugin.name || typeof plugin.name !== "string") {
-              const nameTypeof = typeof plugin.name;
-
-              reject(`Configuration error: plugins must have a name. got ${nameTypeof} instead.`);
-            }
-          });
-
-          // if user provided a custom renderer, filter out Greenwood's default renderer
-          const customRendererPlugins = flattened.filter(
-            (plugin) => plugin.type === "renderer",
-          ).length;
-
-          if (customRendererPlugins === 1) {
-            customConfig.plugins = customConfig.plugins.filter((plugin) => {
-              return plugin.type !== "renderer";
-            });
-          } else if (customRendererPlugins > 1) {
-            console.warn(
-              "Configuration warning: more than one custom renderer plugin detected.  Please make sure you are only loading one.",
-            );
-            console.debug(plugins.filter((plugin) => plugin.type === "renderer"));
-          }
-
-          customConfig.plugins = [...customConfig.plugins, ...flattened];
-        }
-
-        if (devServer && Object.keys(devServer).length > 0) {
-          if (Object.prototype.hasOwnProperty.call(devServer, "hud")) {
-            if (typeof devServer.hud === "boolean") {
-              customConfig.devServer.hud = devServer.hud;
-            } else {
-              reject(
-                `Configuration error: devServer hud options must be a boolean.  Passed value was: ${devServer.hud}`,
-              );
-            }
-          }
-
-          if (devServer.port) {
-            if (!Number.isInteger(devServer.port)) {
-              reject(
-                `Configuration error: devServer port must be an integer.  Passed value was: ${devServer.port}`,
-              );
-            } else {
-              customConfig.devServer.port = devServer.port;
-            }
-          }
-
-          if (devServer.proxy) {
-            customConfig.devServer.proxy = devServer.proxy;
-          }
-
-          if (devServer.extensions) {
-            if (Array.isArray(devServer.extensions)) {
-              customConfig.devServer.extensions = devServer.extensions;
-            } else {
-              reject(
-                "Configuration error: provided extensions is not an array.  Please provide an array like ['txt', 'foo']",
-              );
-            }
-          }
-        }
-
-        if (markdown && Object.keys(markdown).length > 0) {
-          customConfig.markdown.plugins =
-            markdown.plugins && markdown.plugins.length > 0 ? markdown.plugins : [];
-        }
-
-        if (port) {
-          if (!Number.isInteger(port)) {
-            reject(`Configuration error: port must be an integer.  Passed value was: ${port}`);
-          } else {
-            customConfig.port = port;
-          }
-        }
-
-        if (basePath) {
-          if (typeof basePath !== "string") {
-            reject(
-              `Configuration error: basePath must be a string.  Passed value was: ${basePath}`,
-            );
-          } else {
-            customConfig.basePath = basePath;
-          }
-        }
-
-        if (pagesDirectory && typeof pagesDirectory === "string") {
-          customConfig.pagesDirectory = pagesDirectory;
-        } else if (pagesDirectory) {
-          reject(
-            `Configuration error: provided pagesDirectory "${pagesDirectory}" is not supported.  Please make sure to pass something like 'docs/'`,
-          );
-        }
-
-        if (layoutsDirectory && typeof layoutsDirectory === "string") {
-          customConfig.layoutsDirectory = layoutsDirectory;
-        } else if (layoutsDirectory) {
-          reject(
-            `Configuration error: provided layoutsDirectory "${layoutsDirectory}" is not supported.  Please make sure to pass something like 'layouts/'`,
-          );
-        }
-
-        if (prerender !== undefined) {
-          if (typeof prerender === "boolean") {
-            customConfig.prerender = prerender;
-          } else {
-            reject(
-              `Configuration error: prerender must be a boolean; true or false.  Passed value was typeof: ${typeof prerender}`,
-            );
-          }
-        }
-
-        // SPA should _not_ prerender unless if user has specified prerender should be true
-        if (prerender === undefined && isSPA) {
-          customConfig.prerender = false;
-        }
-
-        if (isolation !== undefined) {
-          if (typeof isolation === "boolean") {
-            customConfig.isolation = isolation;
-          } else {
-            reject(
-              `Configuration error: isolation must be a boolean; true or false.  Passed value was typeof: ${typeof staticRouter}`,
-            );
-          }
-        }
-
-        if (staticRouter !== undefined) {
-          if (typeof staticRouter === "boolean") {
-            customConfig.staticRouter = staticRouter;
-          } else {
-            reject(
-              `Configuration error: staticRouter must be a boolean; true or false.  Passed value was typeof: ${typeof staticRouter}`,
-            );
-          }
-        }
-
-        if (polyfills !== undefined) {
-          const { importMaps, importAttributes } = polyfills;
-
-          customConfig.polyfills = { importAttributes: null, importMaps: false };
-
-          if (importMaps) {
-            if (typeof importMaps === "boolean") {
-              customConfig.polyfills.importMaps = true;
-            } else {
-              reject(
-                `Configuration error: polyfills.importMaps must be a boolean; true or false.  Passed value was typeof: ${typeof importMaps}`,
-              );
-            }
-          }
-
-          if (importAttributes) {
-            if (Array.isArray(importAttributes)) {
-              customConfig.polyfills.importAttributes = importAttributes;
-            } else {
-              reject(
-                `Configuration error: polyfills.importAttributes must be an array of types; ['css', 'json'].  Passed value was typeof: ${typeof importAttributes}`,
-              );
-            }
-          }
-        }
-
-        if (useTsc !== undefined) {
-          if (typeof useTsc === "boolean") {
-            customConfig.useTsc = useTsc;
-          } else {
-            reject(
-              `Configuration error: useTsc must be a boolean; true or false.  Passed value was typeof: ${typeof useTsc}`,
-            );
-          }
-        }
+      if (await checkResourceExists(workspace)) {
+        customConfig.workspace = workspace;
       } else {
-        // SPA should _not_ prerender unless if user has specified prerender should be true
-        if (isSPA) {
-          customConfig.prerender = false;
+        return Promise.reject(
+          "Configuration error: Workspace doesn't exist! Please double check your configuration.",
+        );
+      }
+    }
+
+    if (
+      typeof optimization === "string" &&
+      optimizations.indexOf(optimization.toLowerCase()) >= 0
+    ) {
+      customConfig.optimization = optimization;
+    } else if (optimization) {
+      return Promise.reject(
+        `Configuration error: provided optimization "${optimization}" is not supported.  Please use one of: ${optimizations.join(", ")}.`,
+      );
+    }
+
+    if (activeContent) {
+      if (typeof activeContent !== "boolean") {
+        return Promise.reject("Configuration error: activeContent must be a boolean");
+      }
+      customConfig.activeContent = activeContent;
+    }
+
+    if (plugins && plugins.length > 0) {
+      const flattened = plugins.flat(PLUGINS_FLATTENED_DEPTH);
+
+      flattened.forEach((plugin) => {
+        if (!plugin.type || pluginTypes.indexOf(plugin.type) < 0) {
+          return Promise.reject(
+            `Configuration error: plugins must be one of type "${pluginTypes.join(", ")}". got "${plugin.type}" instead.`,
+          );
+        }
+
+        if (!plugin.provider || typeof plugin.provider !== "function") {
+          const providerTypeof = typeof plugin.provider;
+
+          return Promise.reject(
+            `Configuration error: plugins provider must be a function. got ${providerTypeof} instead.`,
+          );
+        }
+
+        if (!plugin.name || typeof plugin.name !== "string") {
+          const nameTypeof = typeof plugin.name;
+
+          return Promise.reject(
+            `Configuration error: plugins must have a name. got ${nameTypeof} instead.`,
+          );
+        }
+      });
+
+      // if user provided a custom renderer, filter out Greenwood's default renderer
+      const customRendererPlugins = flattened.filter((plugin) => plugin.type === "renderer").length;
+
+      if (customRendererPlugins === 1) {
+        customConfig.plugins = customConfig.plugins.filter((plugin) => {
+          return plugin.type !== "renderer";
+        });
+      } else if (customRendererPlugins > 1) {
+        console.warn(
+          "Configuration warning: more than one custom renderer plugin detected.  Please make sure you are only loading one.",
+        );
+        console.debug(plugins.filter((plugin) => plugin.type === "renderer"));
+      }
+
+      customConfig.plugins = [...customConfig.plugins, ...flattened];
+    }
+
+    if (devServer && Object.keys(devServer).length > 0) {
+      if (Object.prototype.hasOwnProperty.call(devServer, "hud")) {
+        if (typeof devServer.hud === "boolean") {
+          customConfig.devServer.hud = devServer.hud;
+        } else {
+          return Promise.reject(
+            `Configuration error: devServer hud options must be a boolean.  Passed value was: ${devServer.hud}`,
+          );
         }
       }
 
-      resolve({ ...defaultConfig, ...customConfig });
-    } catch (err) {
-      reject(err);
+      if (devServer.port) {
+        if (!Number.isInteger(devServer.port)) {
+          return Promise.reject(
+            `Configuration error: devServer port must be an integer.  Passed value was: ${devServer.port}`,
+          );
+        } else {
+          customConfig.devServer.port = devServer.port;
+        }
+      }
+
+      if (devServer.proxy) {
+        customConfig.devServer.proxy = devServer.proxy;
+      }
+
+      if (devServer.extensions) {
+        if (Array.isArray(devServer.extensions)) {
+          customConfig.devServer.extensions = devServer.extensions;
+        } else {
+          return Promise.reject(
+            "Configuration error: provided extensions is not an array.  Please provide an array like ['txt', 'foo']",
+          );
+        }
+      }
     }
-  });
+
+    if (markdown && Object.keys(markdown).length > 0) {
+      customConfig.markdown.plugins =
+        markdown.plugins && markdown.plugins.length > 0 ? markdown.plugins : [];
+    }
+
+    if (port) {
+      if (!Number.isInteger(port)) {
+        return Promise.reject(
+          `Configuration error: port must be an integer.  Passed value was: ${port}`,
+        );
+      } else {
+        customConfig.port = port;
+      }
+    }
+
+    if (basePath) {
+      if (typeof basePath !== "string") {
+        return Promise.reject(
+          `Configuration error: basePath must be a string.  Passed value was: ${basePath}`,
+        );
+      } else {
+        customConfig.basePath = basePath;
+      }
+    }
+
+    if (pagesDirectory && typeof pagesDirectory === "string") {
+      customConfig.pagesDirectory = pagesDirectory;
+    } else if (pagesDirectory) {
+      return Promise.reject(
+        `Configuration error: provided pagesDirectory "${pagesDirectory}" is not supported.  Please make sure to pass something like 'docs/'`,
+      );
+    }
+
+    if (layoutsDirectory && typeof layoutsDirectory === "string") {
+      customConfig.layoutsDirectory = layoutsDirectory;
+    } else if (layoutsDirectory) {
+      return Promise.reject(
+        `Configuration error: provided layoutsDirectory "${layoutsDirectory}" is not supported.  Please make sure to pass something like 'layouts/'`,
+      );
+    }
+
+    if (prerender !== undefined) {
+      if (typeof prerender === "boolean") {
+        customConfig.prerender = prerender;
+      } else {
+        return Promise.reject(
+          `Configuration error: prerender must be a boolean; true or false.  Passed value was typeof: ${typeof prerender}`,
+        );
+      }
+    }
+
+    // SPA should _not_ prerender unless if user has specified prerender should be true
+    if (prerender === undefined && isSPA) {
+      customConfig.prerender = false;
+    }
+
+    if (isolation !== undefined) {
+      if (typeof isolation === "boolean") {
+        customConfig.isolation = isolation;
+      } else {
+        return Promise.reject(
+          `Configuration error: isolation must be a boolean; true or false.  Passed value was typeof: ${typeof staticRouter}`,
+        );
+      }
+    }
+
+    if (staticRouter !== undefined) {
+      if (typeof staticRouter === "boolean") {
+        customConfig.staticRouter = staticRouter;
+      } else {
+        return Promise.reject(
+          `Configuration error: staticRouter must be a boolean; true or false.  Passed value was typeof: ${typeof staticRouter}`,
+        );
+      }
+    }
+
+    if (polyfills !== undefined) {
+      const { importMaps, importAttributes } = polyfills;
+
+      customConfig.polyfills = { importAttributes: null, importMaps: false };
+
+      if (importMaps) {
+        if (typeof importMaps === "boolean") {
+          customConfig.polyfills.importMaps = true;
+        } else {
+          return Promise.reject(
+            `Configuration error: polyfills.importMaps must be a boolean; true or false.  Passed value was typeof: ${typeof importMaps}`,
+          );
+        }
+      }
+
+      if (importAttributes) {
+        if (Array.isArray(importAttributes)) {
+          customConfig.polyfills.importAttributes = importAttributes;
+        } else {
+          Promise.reject(
+            `Configuration error: polyfills.importAttributes must be an array of types; ['css', 'json'].  Passed value was typeof: ${typeof importAttributes}`,
+          );
+        }
+      }
+    }
+
+    if (useTsc !== undefined) {
+      if (typeof useTsc === "boolean") {
+        customConfig.useTsc = useTsc;
+      } else {
+        return Promise.reject(
+          `Configuration error: useTsc must be a boolean; true or false.  Passed value was typeof: ${typeof useTsc}`,
+        );
+      }
+    }
+  } else {
+    // SPA should _not_ prerender unless if user has specified prerender should be true
+    if (isSPA) {
+      customConfig.prerender = false;
+    }
+  }
+
+  return Promise.resolve({ ...defaultConfig, ...customConfig });
 };
 
 export { readAndMergeConfig };

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -2,45 +2,36 @@ import fs from "fs/promises";
 import { checkResourceExists } from "../lib/resource-utils.js";
 
 const initContext = async ({ config }) => {
-  // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async (resolve, reject) => {
-    try {
-      const { workspace, pagesDirectory, layoutsDirectory } = config;
+  const { workspace, pagesDirectory, layoutsDirectory } = config;
+  const projectDirectory = new URL(`file://${process.cwd()}/`);
+  const scratchDir = new URL("./.greenwood/", projectDirectory);
+  const outputDir = new URL("./public/", projectDirectory);
+  const dataDir = new URL("../data/", import.meta.url);
+  const layoutsDir = new URL("../layouts/", import.meta.url);
+  const userWorkspace = workspace;
+  const pagesDir = new URL(`./${pagesDirectory}/`, userWorkspace);
+  const apisDir = new URL("./api/", pagesDir);
+  const userLayoutsDir = new URL(`./${layoutsDirectory}/`, userWorkspace);
 
-      const projectDirectory = new URL(`file://${process.cwd()}/`);
-      const scratchDir = new URL("./.greenwood/", projectDirectory);
-      const outputDir = new URL("./public/", projectDirectory);
-      const dataDir = new URL("../data/", import.meta.url);
-      const layoutsDir = new URL("../layouts/", import.meta.url);
-      const userWorkspace = workspace;
-      const pagesDir = new URL(`./${pagesDirectory}/`, userWorkspace);
-      const apisDir = new URL("./api/", pagesDir);
-      const userLayoutsDir = new URL(`./${layoutsDirectory}/`, userWorkspace);
+  const context = {
+    dataDir,
+    outputDir,
+    userWorkspace,
+    apisDir,
+    pagesDir,
+    userLayoutsDir,
+    scratchDir,
+    projectDirectory,
+    layoutsDir,
+  };
 
-      const context = {
-        dataDir,
-        outputDir,
-        userWorkspace,
-        apisDir,
-        pagesDir,
-        userLayoutsDir,
-        scratchDir,
-        projectDirectory,
-        layoutsDir,
-      };
+  if (!(await checkResourceExists(scratchDir))) {
+    await fs.mkdir(scratchDir, {
+      recursive: true,
+    });
+  }
 
-      if (!(await checkResourceExists(scratchDir))) {
-        await fs.mkdir(scratchDir, {
-          recursive: true,
-        });
-      }
-
-      resolve(context);
-    } catch (err) {
-      console.log(err);
-      reject(err);
-    }
-  });
+  return Promise.resolve(context);
 };
 
 export { initContext };

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -53,362 +53,355 @@ function trackCollectionsForPage(page, collections) {
 }
 
 const generateGraph = async (compilation) => {
-  // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async (resolve, reject) => {
-    try {
-      const { context, config } = compilation;
-      const { basePath } = config;
-      const { pagesDir, userWorkspace, outputDir } = context;
-      const customPageFormatPlugins = config.plugins
-        .filter((plugin) => plugin.type === "resource" && !plugin.isGreenwoodDefaultPlugin)
-        .map((plugin) => plugin.provider(compilation));
+  const { context, config } = compilation;
+  const { basePath } = config;
+  const { pagesDir, userWorkspace, outputDir } = context;
+  const customPageFormatPlugins = config.plugins
+    .filter((plugin) => plugin.type === "resource" && !plugin.isGreenwoodDefaultPlugin)
+    .map((plugin) => plugin.provider(compilation));
 
-      let apis = new Map();
-      let graph = [
+  let apis = new Map();
+  let graph = [
+    {
+      id: "index",
+      outputHref: new URL("./index.html", outputDir).href,
+      route: `${basePath}/`,
+      label: "Home",
+      title: null,
+      data: {},
+      imports: [],
+      resources: [],
+      prerender: true,
+      isolation: false,
+    },
+  ];
+
+  const walkDirectoryForPages = async function (directory, pages = [], apiRoutes = new Map()) {
+    const files = (await fs.readdir(directory)).filter((file) => !file.startsWith("."));
+
+    for (const filename of files) {
+      const filenameUrl = new URL(`./${filename}`, directory);
+      const filenameUrlAsDir = new URL(`./${filename}/`, directory);
+      const isDirectory =
+        (await checkResourceExists(filenameUrlAsDir)) &&
+        (await fs.stat(filenameUrlAsDir)).isDirectory();
+
+      if (isDirectory) {
+        const nextPages = await walkDirectoryForPages(filenameUrlAsDir, pages, apiRoutes);
+
+        pages = nextPages.pages;
+        apiRoutes = nextPages.apiRoutes;
+      } else {
+        const extension = `.${filenameUrl.pathname.split(".").pop()}`;
+        const relativePagePath = filenameUrl.pathname.replace(pagesDir.pathname, "./");
+        const isApiRoute = relativePagePath.startsWith("./api");
+        const req = isApiRoute
+          ? new Request(filenameUrl, { headers: { Accept: "text/javascript" } })
+          : new Request(filenameUrl, { headers: { Accept: "text/html" } });
+        let isCustom = null;
+
+        for (const plugin of customPageFormatPlugins) {
+          if (plugin.shouldServe && (await plugin.shouldServe(filenameUrl, req))) {
+            isCustom = plugin.servePage;
+            break;
+          }
+        }
+
+        const isStatic = isCustom === "static" || extension === ".md" || extension === ".html";
+        const isDynamic = isCustom === "dynamic" || extension === ".js" || extension === ".ts";
+        const isPage = isStatic || isDynamic;
+        let route = `${relativePagePath.replace(".", "").replace(`${extension}`, "")}`;
+        let fileContents;
+
+        if (isApiRoute) {
+          if (extension !== ".js" && extension !== ".ts" && !isCustom) {
+            console.warn(`${filenameUrl} is not a supported API file extension, skipping...`);
+            return;
+          }
+
+          // should this be run in isolation like SSR pages?
+          // https://github.com/ProjectEvergreen/greenwood/issues/991
+          const { isolation } = await import(filenameUrl).then((module) => module);
+
+          /*
+            * API Properties (per route)
+            *----------------------
+            * id: unique hyphen delimited string of the filename, relative to the page/api directory
+            * pageHref: href to the page's filesystem file
+            * outputHref: href of the filename to write to when generating a build
+            * route: URL route for a given page on outputFilePath
+            * isolation: if this should be run in isolated mode
+            */
+          apiRoutes.set(`${basePath}${route}`, {
+            id: decodeURIComponent(
+              getIdFromRelativePathPath(relativePagePath, extension).replace("api-", ""),
+            ),
+            pageHref: new URL(relativePagePath, pagesDir).href,
+            outputHref: new URL(relativePagePath, outputDir).href.replace(extension, ".js"),
+            route: `${basePath}${route}`,
+            isolation,
+          });
+        } else if (isPage) {
+          let root = filename.split("/")[filename.split("/").length - 1].replace(extension, "");
+          let layout = extension === ".html" ? null : "page";
+          let title = null;
+          let label = getLabelFromRoute(`${route}/`);
+          let imports = [];
+          let customData = {};
+          let prerender = true;
+          let isolation = false;
+          let hydration = false;
+
+          /*
+            * check if additional nested directories exist to correctly determine route (minus filename)
+            * examples:
+            * - pages/index.{html,md,js} -> /
+            * - pages/about.{html,md,js} -> /about/
+            * - pages/blog/index.{html,md,js} -> /blog/
+            * - pages/blog/some-post.{html,md,js} -> /blog/some-post/
+            */
+          if (relativePagePath.lastIndexOf("/index") > 0) {
+            // https://github.com/ProjectEvergreen/greenwood/issues/455
+            route =
+              root === "index" || route.replace("/index", "") === `/${root}`
+                ? route.replace("index", "")
+                : `${route}/`;
+          } else {
+            route = route === "/index" ? "/" : `${route}/`;
+          }
+
+          if (isStatic) {
+            fileContents = await fs.readFile(filenameUrl, "utf8");
+            const { attributes } = fm(fileContents);
+
+            layout = attributes.layout || layout;
+            title = attributes.title || title;
+            label = attributes.label || label;
+            imports = attributes.imports || [];
+
+            customData = attributes;
+          } else if (isDynamic) {
+            const routeWorkerUrl = compilation.config.plugins
+              .filter((plugin) => plugin.type === "renderer")[0]
+              .provider(compilation).executeModuleUrl;
+            let ssrFrontmatter;
+
+            // eslint-disable-next-line no-async-promise-executor
+            await new Promise(async (resolve, reject) => {
+              const worker = new Worker(new URL("../lib/ssr-route-worker.js", import.meta.url));
+              const request = await requestAsObject(new Request(filenameUrl));
+
+              worker.on("message", async (result) => {
+                prerender = result.prerender ?? false;
+                isolation = result.isolation ?? isolation;
+                hydration = result.hydration ?? hydration;
+
+                if (result.frontmatter) {
+                  result.frontmatter.imports = result.frontmatter.imports || [];
+                  ssrFrontmatter = result.frontmatter;
+                }
+
+                resolve();
+              });
+              worker.on("error", reject);
+              worker.on("exit", (code) => {
+                if (code !== 0) {
+                  return Promise.reject(new Error(`Worker stopped with exit code ${code}`));
+                }
+              });
+
+              worker.postMessage({
+                executeModuleUrl: routeWorkerUrl.href,
+                moduleUrl: filenameUrl.href,
+                compilation: JSON.stringify(compilation),
+                page: JSON.stringify({
+                  servePage: isCustom,
+                  route,
+                  root,
+                  label,
+                }),
+                request,
+              });
+            });
+
+            if (ssrFrontmatter) {
+              layout = ssrFrontmatter.layout || layout;
+              title = ssrFrontmatter.title || title;
+              imports = ssrFrontmatter.imports || imports;
+              label = ssrFrontmatter.label || label;
+              customData = ssrFrontmatter || customData;
+            }
+          }
+
+          /*
+            * Custom front matter - Variable Definitions
+            * --------------------------------------------------
+            * collection: the name of the collection for the page (as a string or array)
+            * order: the order of this item within the collection
+            * tocHeading: heading size to use a Table of Contents for a page
+            * tableOfContents: json object containing page's table of contents (list of headings)
+            */
+
+          // prune "reserved" attributes that are supported by Greenwood
+          [...activeFrontmatterKeys, "layout"].forEach((key) => {
+            delete customData[key];
+          });
+
+          // set flag whether to gather a list of headings on a page as menu items
+          customData.tocHeading = customData.tocHeading || 0;
+          customData.tableOfContents = [];
+
+          if (fileContents && customData.tocHeading > 0 && customData.tocHeading <= 6) {
+            // parse markdown for table of contents and output to json
+            customData.tableOfContents = toc(fileContents).json;
+
+            // parse table of contents for only the pages user wants linked
+            if (customData.tableOfContents.length > 0 && customData.tocHeading > 0) {
+              customData.tableOfContents = customData.tableOfContents.filter(
+                (item) => item.lvl === customData.tocHeading,
+              );
+            }
+          }
+
+          /*
+            * Page Properties
+            *----------------------
+            * id: unique hyphen delimited string of the filename, relative to the pages directory
+            * label: Display text for the page inferred, by default is the value of title
+            * title: used to customize the <title></title> tag of the page, inferred from the filename
+            * route: URL for accessing the page from the browser
+            * layout: the custom layout of the page
+            * data: custom page frontmatter
+            * imports: per page JS or CSS file imports specified from frontmatter
+            * resources: all script, style, etc resources for the entire page as URLs
+            * outputHref: href to the file in the output folder
+            * pageHref: href to the page's filesystem file
+            * isSSR: if this is a server side route
+            * prerender: if this page should be statically exported
+            * isolation: if this page should be run in isolated mode
+            * hydration: if this page needs hydration support
+            * servePage: signal that this is a custom page file type (static | dynamic)
+            */
+          const page = {
+            id: decodeURIComponent(getIdFromRelativePathPath(relativePagePath, extension)),
+            label: decodeURIComponent(label),
+            title: title ? decodeURIComponent(title) : title,
+            route: `${basePath}${route}`,
+            layout,
+            data: customData || {},
+            imports,
+            resources: [],
+            pageHref: new URL(relativePagePath, pagesDir).href,
+            outputHref:
+              route === "/404/"
+                ? new URL("./404.html", outputDir).href
+                : new URL(`.${route}index.html`, outputDir).href,
+            isSSR: !isStatic,
+            prerender,
+            isolation,
+            hydration,
+            servePage: isCustom,
+          };
+
+          pages.push(page);
+
+          // handle collections
+          trackCollectionsForPage(page, compilation.collections); // collections;
+        } else {
+          console.warn(`Unsupported format detected for page => ${filename}`);
+        }
+      }
+    }
+
+    return { pages, apiRoutes };
+  };
+
+  console.debug("building from local sources...");
+
+  // test for SPA
+  if (await checkResourceExists(new URL("./index.html", userWorkspace))) {
+    graph = [
+      {
+        ...graph[0],
+        pageHref: new URL("./index.html", userWorkspace).href,
+        isSPA: true,
+      },
+    ];
+  } else {
+    const oldGraph = graph[0];
+    const pages = (await checkResourceExists(pagesDir))
+      ? await walkDirectoryForPages(pagesDir)
+      : { pages: graph, apiRoutes: apis };
+
+    graph = pages.pages;
+    apis = pages.apiRoutes;
+
+    const has404Page = graph.find((page) => page.route.endsWith("/404/"));
+
+    // if the _only_ page is a 404 page, still provide a default index.html
+    if (has404Page && graph.length === 1) {
+      graph = [oldGraph, ...graph];
+    } else if (!has404Page) {
+      graph = [
+        ...graph,
         {
-          id: "index",
-          outputHref: new URL("./index.html", outputDir).href,
-          route: `${basePath}/`,
-          label: "Home",
-          title: null,
-          data: {},
-          imports: [],
-          resources: [],
-          prerender: true,
-          isolation: false,
+          ...oldGraph,
+          id: "404",
+          outputHref: new URL("./404.html", outputDir).href,
+          pageHref: new URL("./404.html", pagesDir).href,
+          route: `${basePath}/404/`,
+          path: "404.html",
+          label: "Not Found",
+          title: "Page Not Found",
         },
       ];
-
-      const walkDirectoryForPages = async function (directory, pages = [], apiRoutes = new Map()) {
-        const files = (await fs.readdir(directory)).filter((file) => !file.startsWith("."));
-
-        for (const filename of files) {
-          const filenameUrl = new URL(`./${filename}`, directory);
-          const filenameUrlAsDir = new URL(`./${filename}/`, directory);
-          const isDirectory =
-            (await checkResourceExists(filenameUrlAsDir)) &&
-            (await fs.stat(filenameUrlAsDir)).isDirectory();
-
-          if (isDirectory) {
-            const nextPages = await walkDirectoryForPages(filenameUrlAsDir, pages, apiRoutes);
-
-            pages = nextPages.pages;
-            apiRoutes = nextPages.apiRoutes;
-          } else {
-            const extension = `.${filenameUrl.pathname.split(".").pop()}`;
-            const relativePagePath = filenameUrl.pathname.replace(pagesDir.pathname, "./");
-            const isApiRoute = relativePagePath.startsWith("./api");
-            const req = isApiRoute
-              ? new Request(filenameUrl, { headers: { Accept: "text/javascript" } })
-              : new Request(filenameUrl, { headers: { Accept: "text/html" } });
-            let isCustom = null;
-
-            for (const plugin of customPageFormatPlugins) {
-              if (plugin.shouldServe && (await plugin.shouldServe(filenameUrl, req))) {
-                isCustom = plugin.servePage;
-                break;
-              }
-            }
-
-            const isStatic = isCustom === "static" || extension === ".md" || extension === ".html";
-            const isDynamic = isCustom === "dynamic" || extension === ".js" || extension === ".ts";
-            const isPage = isStatic || isDynamic;
-            let route = `${relativePagePath.replace(".", "").replace(`${extension}`, "")}`;
-            let fileContents;
-
-            if (isApiRoute) {
-              if (extension !== ".js" && extension !== ".ts" && !isCustom) {
-                console.warn(`${filenameUrl} is not a supported API file extension, skipping...`);
-                return;
-              }
-
-              // should this be run in isolation like SSR pages?
-              // https://github.com/ProjectEvergreen/greenwood/issues/991
-              const { isolation } = await import(filenameUrl).then((module) => module);
-
-              /*
-               * API Properties (per route)
-               *----------------------
-               * id: unique hyphen delimited string of the filename, relative to the page/api directory
-               * pageHref: href to the page's filesystem file
-               * outputHref: href of the filename to write to when generating a build
-               * route: URL route for a given page on outputFilePath
-               * isolation: if this should be run in isolated mode
-               */
-              apiRoutes.set(`${basePath}${route}`, {
-                id: decodeURIComponent(
-                  getIdFromRelativePathPath(relativePagePath, extension).replace("api-", ""),
-                ),
-                pageHref: new URL(relativePagePath, pagesDir).href,
-                outputHref: new URL(relativePagePath, outputDir).href.replace(extension, ".js"),
-                route: `${basePath}${route}`,
-                isolation,
-              });
-            } else if (isPage) {
-              let root = filename.split("/")[filename.split("/").length - 1].replace(extension, "");
-              let layout = extension === ".html" ? null : "page";
-              let title = null;
-              let label = getLabelFromRoute(`${route}/`);
-              let imports = [];
-              let customData = {};
-              let prerender = true;
-              let isolation = false;
-              let hydration = false;
-
-              /*
-               * check if additional nested directories exist to correctly determine route (minus filename)
-               * examples:
-               * - pages/index.{html,md,js} -> /
-               * - pages/about.{html,md,js} -> /about/
-               * - pages/blog/index.{html,md,js} -> /blog/
-               * - pages/blog/some-post.{html,md,js} -> /blog/some-post/
-               */
-              if (relativePagePath.lastIndexOf("/index") > 0) {
-                // https://github.com/ProjectEvergreen/greenwood/issues/455
-                route =
-                  root === "index" || route.replace("/index", "") === `/${root}`
-                    ? route.replace("index", "")
-                    : `${route}/`;
-              } else {
-                route = route === "/index" ? "/" : `${route}/`;
-              }
-
-              if (isStatic) {
-                fileContents = await fs.readFile(filenameUrl, "utf8");
-                const { attributes } = fm(fileContents);
-
-                layout = attributes.layout || layout;
-                title = attributes.title || title;
-                label = attributes.label || label;
-                imports = attributes.imports || [];
-
-                customData = attributes;
-              } else if (isDynamic) {
-                const routeWorkerUrl = compilation.config.plugins
-                  .filter((plugin) => plugin.type === "renderer")[0]
-                  .provider(compilation).executeModuleUrl;
-                let ssrFrontmatter;
-
-                // eslint-disable-next-line no-async-promise-executor
-                await new Promise(async (resolve, reject) => {
-                  const worker = new Worker(new URL("../lib/ssr-route-worker.js", import.meta.url));
-                  const request = await requestAsObject(new Request(filenameUrl));
-
-                  worker.on("message", async (result) => {
-                    prerender = result.prerender ?? false;
-                    isolation = result.isolation ?? isolation;
-                    hydration = result.hydration ?? hydration;
-
-                    if (result.frontmatter) {
-                      result.frontmatter.imports = result.frontmatter.imports || [];
-                      ssrFrontmatter = result.frontmatter;
-                    }
-
-                    resolve();
-                  });
-                  worker.on("error", reject);
-                  worker.on("exit", (code) => {
-                    if (code !== 0) {
-                      reject(new Error(`Worker stopped with exit code ${code}`));
-                    }
-                  });
-
-                  worker.postMessage({
-                    executeModuleUrl: routeWorkerUrl.href,
-                    moduleUrl: filenameUrl.href,
-                    compilation: JSON.stringify(compilation),
-                    page: JSON.stringify({
-                      servePage: isCustom,
-                      route,
-                      root,
-                      label,
-                    }),
-                    request,
-                  });
-                });
-
-                if (ssrFrontmatter) {
-                  layout = ssrFrontmatter.layout || layout;
-                  title = ssrFrontmatter.title || title;
-                  imports = ssrFrontmatter.imports || imports;
-                  label = ssrFrontmatter.label || label;
-                  customData = ssrFrontmatter || customData;
-                }
-              }
-
-              /*
-               * Custom front matter - Variable Definitions
-               * --------------------------------------------------
-               * collection: the name of the collection for the page (as a string or array)
-               * order: the order of this item within the collection
-               * tocHeading: heading size to use a Table of Contents for a page
-               * tableOfContents: json object containing page's table of contents (list of headings)
-               */
-
-              // prune "reserved" attributes that are supported by Greenwood
-              [...activeFrontmatterKeys, "layout"].forEach((key) => {
-                delete customData[key];
-              });
-
-              // set flag whether to gather a list of headings on a page as menu items
-              customData.tocHeading = customData.tocHeading || 0;
-              customData.tableOfContents = [];
-
-              if (fileContents && customData.tocHeading > 0 && customData.tocHeading <= 6) {
-                // parse markdown for table of contents and output to json
-                customData.tableOfContents = toc(fileContents).json;
-
-                // parse table of contents for only the pages user wants linked
-                if (customData.tableOfContents.length > 0 && customData.tocHeading > 0) {
-                  customData.tableOfContents = customData.tableOfContents.filter(
-                    (item) => item.lvl === customData.tocHeading,
-                  );
-                }
-              }
-
-              /*
-               * Page Properties
-               *----------------------
-               * id: unique hyphen delimited string of the filename, relative to the pages directory
-               * label: Display text for the page inferred, by default is the value of title
-               * title: used to customize the <title></title> tag of the page, inferred from the filename
-               * route: URL for accessing the page from the browser
-               * layout: the custom layout of the page
-               * data: custom page frontmatter
-               * imports: per page JS or CSS file imports specified from frontmatter
-               * resources: all script, style, etc resources for the entire page as URLs
-               * outputHref: href to the file in the output folder
-               * pageHref: href to the page's filesystem file
-               * isSSR: if this is a server side route
-               * prerender: if this page should be statically exported
-               * isolation: if this page should be run in isolated mode
-               * hydration: if this page needs hydration support
-               * servePage: signal that this is a custom page file type (static | dynamic)
-               */
-              const page = {
-                id: decodeURIComponent(getIdFromRelativePathPath(relativePagePath, extension)),
-                label: decodeURIComponent(label),
-                title: title ? decodeURIComponent(title) : title,
-                route: `${basePath}${route}`,
-                layout,
-                data: customData || {},
-                imports,
-                resources: [],
-                pageHref: new URL(relativePagePath, pagesDir).href,
-                outputHref:
-                  route === "/404/"
-                    ? new URL("./404.html", outputDir).href
-                    : new URL(`.${route}index.html`, outputDir).href,
-                isSSR: !isStatic,
-                prerender,
-                isolation,
-                hydration,
-                servePage: isCustom,
-              };
-
-              pages.push(page);
-
-              // handle collections
-              trackCollectionsForPage(page, compilation.collections); // collections;
-            } else {
-              console.warn(`Unsupported format detected for page => ${filename}`);
-            }
-          }
-        }
-
-        return { pages, apiRoutes };
-      };
-
-      console.debug("building from local sources...");
-
-      // test for SPA
-      if (await checkResourceExists(new URL("./index.html", userWorkspace))) {
-        graph = [
-          {
-            ...graph[0],
-            pageHref: new URL("./index.html", userWorkspace).href,
-            isSPA: true,
-          },
-        ];
-      } else {
-        const oldGraph = graph[0];
-        const pages = (await checkResourceExists(pagesDir))
-          ? await walkDirectoryForPages(pagesDir)
-          : { pages: graph, apiRoutes: apis };
-
-        graph = pages.pages;
-        apis = pages.apiRoutes;
-
-        const has404Page = graph.find((page) => page.route.endsWith("/404/"));
-
-        // if the _only_ page is a 404 page, still provide a default index.html
-        if (has404Page && graph.length === 1) {
-          graph = [oldGraph, ...graph];
-        } else if (!has404Page) {
-          graph = [
-            ...graph,
-            {
-              ...oldGraph,
-              id: "404",
-              outputHref: new URL("./404.html", outputDir).href,
-              pageHref: new URL("./404.html", pagesDir).href,
-              route: `${basePath}/404/`,
-              path: "404.html",
-              label: "Not Found",
-              title: "Page Not Found",
-            },
-          ];
-        }
-      }
-
-      const sourcePlugins = compilation.config.plugins.filter((plugin) => plugin.type === "source");
-
-      // make sure this assignment happens before plugins run
-      // to allow plugins access to current graph
-      compilation.graph = graph;
-      compilation.manifest = { apis };
-
-      if (sourcePlugins.length > 0) {
-        console.debug("building from external sources...");
-        for (const plugin of sourcePlugins) {
-          const instance = plugin.provider(compilation);
-          const data = await instance();
-
-          for (const node of data) {
-            const { body, route } = node;
-
-            if (!body || !route) {
-              const missingKey = !body ? "body" : "route";
-
-              reject(`ERROR: provided node does not provide a ${missingKey} property.`);
-            }
-
-            const page = {
-              pageHref: null,
-              imports: [],
-              resources: [],
-              outputHref: new URL(`.${route}index.html`, outputDir).href,
-              ...node,
-              route: encodeURIComponent(route).replace(/%2F/g, "/"),
-              data: {
-                ...node.data,
-                collection: node.collection ?? "",
-              },
-              external: true,
-            };
-
-            graph.push(page);
-
-            trackCollectionsForPage(page, compilation.collections);
-          }
-        }
-      }
-
-      resolve(compilation);
-    } catch (err) {
-      reject(err);
     }
-  });
+  }
+
+  const sourcePlugins = compilation.config.plugins.filter((plugin) => plugin.type === "source");
+
+  // make sure this assignment happens before plugins run
+  // to allow plugins access to current graph
+  compilation.graph = graph;
+  compilation.manifest = { apis };
+
+  if (sourcePlugins.length > 0) {
+    console.debug("building from external sources...");
+    for (const plugin of sourcePlugins) {
+      const instance = plugin.provider(compilation);
+      const data = await instance();
+
+      for (const node of data) {
+        const { body, route } = node;
+
+        if (!body || !route) {
+          const missingKey = !body ? "body" : "route";
+
+          return Promise.reject(`ERROR: provided node does not provide a ${missingKey} property.`);
+        }
+
+        const page = {
+          pageHref: null,
+          imports: [],
+          resources: [],
+          outputHref: new URL(`.${route}index.html`, outputDir).href,
+          ...node,
+          route: encodeURIComponent(route).replace(/%2F/g, "/"),
+          data: {
+            ...node.data,
+            collection: node.collection ?? "",
+          },
+          external: true,
+        };
+
+        graph.push(page);
+
+        trackCollectionsForPage(page, compilation.collections);
+      }
+    }
+  }
+
+  return Promise.resolve(compilation);
 };
 
 export { generateGraph };

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -124,14 +124,14 @@ const generateGraph = async (compilation) => {
           const { isolation } = await import(filenameUrl).then((module) => module);
 
           /*
-            * API Properties (per route)
-            *----------------------
-            * id: unique hyphen delimited string of the filename, relative to the page/api directory
-            * pageHref: href to the page's filesystem file
-            * outputHref: href of the filename to write to when generating a build
-            * route: URL route for a given page on outputFilePath
-            * isolation: if this should be run in isolated mode
-            */
+           * API Properties (per route)
+           *----------------------
+           * id: unique hyphen delimited string of the filename, relative to the page/api directory
+           * pageHref: href to the page's filesystem file
+           * outputHref: href of the filename to write to when generating a build
+           * route: URL route for a given page on outputFilePath
+           * isolation: if this should be run in isolated mode
+           */
           apiRoutes.set(`${basePath}${route}`, {
             id: decodeURIComponent(
               getIdFromRelativePathPath(relativePagePath, extension).replace("api-", ""),
@@ -153,13 +153,13 @@ const generateGraph = async (compilation) => {
           let hydration = false;
 
           /*
-            * check if additional nested directories exist to correctly determine route (minus filename)
-            * examples:
-            * - pages/index.{html,md,js} -> /
-            * - pages/about.{html,md,js} -> /about/
-            * - pages/blog/index.{html,md,js} -> /blog/
-            * - pages/blog/some-post.{html,md,js} -> /blog/some-post/
-            */
+           * check if additional nested directories exist to correctly determine route (minus filename)
+           * examples:
+           * - pages/index.{html,md,js} -> /
+           * - pages/about.{html,md,js} -> /about/
+           * - pages/blog/index.{html,md,js} -> /blog/
+           * - pages/blog/some-post.{html,md,js} -> /blog/some-post/
+           */
           if (relativePagePath.lastIndexOf("/index") > 0) {
             // https://github.com/ProjectEvergreen/greenwood/issues/455
             route =
@@ -234,13 +234,13 @@ const generateGraph = async (compilation) => {
           }
 
           /*
-            * Custom front matter - Variable Definitions
-            * --------------------------------------------------
-            * collection: the name of the collection for the page (as a string or array)
-            * order: the order of this item within the collection
-            * tocHeading: heading size to use a Table of Contents for a page
-            * tableOfContents: json object containing page's table of contents (list of headings)
-            */
+           * Custom front matter - Variable Definitions
+           * --------------------------------------------------
+           * collection: the name of the collection for the page (as a string or array)
+           * order: the order of this item within the collection
+           * tocHeading: heading size to use a Table of Contents for a page
+           * tableOfContents: json object containing page's table of contents (list of headings)
+           */
 
           // prune "reserved" attributes that are supported by Greenwood
           [...activeFrontmatterKeys, "layout"].forEach((key) => {
@@ -264,24 +264,24 @@ const generateGraph = async (compilation) => {
           }
 
           /*
-            * Page Properties
-            *----------------------
-            * id: unique hyphen delimited string of the filename, relative to the pages directory
-            * label: Display text for the page inferred, by default is the value of title
-            * title: used to customize the <title></title> tag of the page, inferred from the filename
-            * route: URL for accessing the page from the browser
-            * layout: the custom layout of the page
-            * data: custom page frontmatter
-            * imports: per page JS or CSS file imports specified from frontmatter
-            * resources: all script, style, etc resources for the entire page as URLs
-            * outputHref: href to the file in the output folder
-            * pageHref: href to the page's filesystem file
-            * isSSR: if this is a server side route
-            * prerender: if this page should be statically exported
-            * isolation: if this page should be run in isolated mode
-            * hydration: if this page needs hydration support
-            * servePage: signal that this is a custom page file type (static | dynamic)
-            */
+           * Page Properties
+           *----------------------
+           * id: unique hyphen delimited string of the filename, relative to the pages directory
+           * label: Display text for the page inferred, by default is the value of title
+           * title: used to customize the <title></title> tag of the page, inferred from the filename
+           * route: URL for accessing the page from the browser
+           * layout: the custom layout of the page
+           * data: custom page frontmatter
+           * imports: per page JS or CSS file imports specified from frontmatter
+           * resources: all script, style, etc resources for the entire page as URLs
+           * outputHref: href to the file in the output folder
+           * pageHref: href to the page's filesystem file
+           * isSSR: if this is a server side route
+           * prerender: if this page should be statically exported
+           * isolation: if this page should be run in isolated mode
+           * hydration: if this page needs hydration support
+           * servePage: signal that this is a custom page file type (static | dynamic)
+           */
           const page = {
             id: decodeURIComponent(getIdFromRelativePathPath(relativePagePath, extension)),
             label: decodeURIComponent(label),

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -184,14 +184,13 @@ const generateGraph = async (compilation) => {
             const routeWorkerUrl = compilation.config.plugins
               .filter((plugin) => plugin.type === "renderer")[0]
               .provider(compilation).executeModuleUrl;
+            const request = await requestAsObject(new Request(filenameUrl));
             let ssrFrontmatter;
 
-            // eslint-disable-next-line no-async-promise-executor
-            await new Promise(async (resolve, reject) => {
+            await new Promise((resolve, reject) => {
               const worker = new Worker(new URL("../lib/ssr-route-worker.js", import.meta.url));
-              const request = await requestAsObject(new Request(filenameUrl));
 
-              worker.on("message", async (result) => {
+              worker.on("message", (result) => {
                 prerender = result.prerender ?? false;
                 isolation = result.isolation ?? isolation;
                 hydration = result.hydration ?? hydration;

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -349,15 +349,15 @@ async function getHybridServer(compilation) {
         let html;
 
         if (matchingRoute.isolation || isolationMode) {
-          // eslint-disable-next-line no-async-promise-executor
-          await new Promise(async (resolve, reject) => {
+          // "faux" new Request here, a better way?
+          const request = await requestAsObject(new Request(url));
+
+          await new Promise((resolve, reject) => {
             const worker = new Worker(
               new URL("../lib/ssr-route-worker-isolation-mode.js", import.meta.url),
             );
-            // "faux" new Request here, a better way?
-            const request = await requestAsObject(new Request(url));
 
-            worker.on("message", async (result) => {
+            worker.on("message", (result) => {
               html = result;
 
               resolve();
@@ -392,13 +392,13 @@ async function getHybridServer(compilation) {
         let body, status, headers, statusText;
 
         if (apiRoute.isolation || isolationMode) {
-          // eslint-disable-next-line no-async-promise-executor
-          await new Promise(async (resolve, reject) => {
-            const worker = new Worker(new URL("../lib/api-route-worker.js", import.meta.url));
-            // "faux" new Request here, a better way?
-            const req = await requestAsObject(request);
+          // "faux" new Request here, a better way?
+          const req = await requestAsObject(request);
 
-            worker.on("message", async (result) => {
+          await new Promise((resolve, reject) => {
+            const worker = new Worker(new URL("../lib/api-route-worker.js", import.meta.url));
+
+            worker.on("message", (result) => {
               const responseAsObject = result;
 
               body = responseAsObject.body;

--- a/packages/cli/src/plugins/resource/plugin-api-routes.js
+++ b/packages/cli/src/plugins/resource/plugin-api-routes.js
@@ -27,8 +27,7 @@ class ApiRoutesResource {
       const workerUrl = new URL("../../lib/api-route-worker.js", import.meta.url);
       const req = await requestAsObject(request);
 
-      // eslint-disable-next-line no-async-promise-executor
-      const response = await new Promise(async (resolve, reject) => {
+      const response = await new Promise((resolve, reject) => {
         const worker = new Worker(workerUrl);
 
         worker.on("message", (result) => {

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -92,9 +92,9 @@ class StandardHtmlResource {
       const routeWorkerUrl = this.compilation.config.plugins
         .find((plugin) => plugin.type === "renderer")
         .provider().executeModuleUrl;
+      const req = await requestAsObject(request);
 
-      // eslint-disable-next-line no-async-promise-executor
-      await new Promise(async (resolve, reject) => {
+      await new Promise((resolve, reject) => {
         const worker = new Worker(new URL("../../lib/ssr-route-worker.js", import.meta.url));
 
         worker.on("message", (result) => {
@@ -119,7 +119,7 @@ class StandardHtmlResource {
           moduleUrl: routeModuleLocationUrl.href,
           compilation: JSON.stringify(this.compilation),
           page: JSON.stringify(matchingRoute),
-          request: await requestAsObject(request),
+          request: req,
         });
       });
     }

--- a/packages/plugin-graphql/src/core/cache.js
+++ b/packages/plugin-graphql/src/core/cache.js
@@ -9,48 +9,38 @@ import { getQueryHash } from "./common.js";
 
 /* Extract cache server-side */
 const createCache = async (req, context) => {
-  // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async (resolve, reject) => {
-    try {
-      const client = await new ApolloClient({
-        link: new HttpLink({
-          uri: "http://localhost:4000?q=internal" /* internal flag to prevent looping cache on request */,
-          fetch,
-        }),
-        cache: new InMemoryCache(),
-      });
-
-      /* Take the same query from request, and repeat the query for our server side cache */
-      const { query, variables } = req.body;
-      const { data } = await client.query({
-        query: gql`
-          ${query}
-        `,
-        variables,
-      });
-
-      if (data) {
-        const { outputDir } = context;
-        const cache = JSON.stringify(data);
-        const queryHash = getQueryHash(query, variables);
-        const hashFilename = `${queryHash}-cache.json`;
-        const cachePath = new URL(`./${hashFilename}`, outputDir);
-
-        if (!(await checkResourceExists(outputDir))) {
-          await fs.mkdir(outputDir);
-        }
-
-        if (!(await checkResourceExists(cachePath))) {
-          await fs.writeFile(cachePath, cache, "utf-8");
-        }
-      }
-
-      resolve();
-    } catch (err) {
-      console.error("create cache error", err);
-      reject(err);
-    }
+  const client = await new ApolloClient({
+    link: new HttpLink({
+      uri: "http://localhost:4000?q=internal" /* internal flag to prevent looping cache on request */,
+      fetch,
+    }),
+    cache: new InMemoryCache(),
   });
+
+  /* Take the same query from request, and repeat the query for our server side cache */
+  const { query, variables } = req.body;
+  const { data } = await client.query({
+    query: gql`
+      ${query}
+    `,
+    variables,
+  });
+
+  if (data) {
+    const { outputDir } = context;
+    const cache = JSON.stringify(data);
+    const queryHash = getQueryHash(query, variables);
+    const hashFilename = `${queryHash}-cache.json`;
+    const cachePath = new URL(`./${hashFilename}`, outputDir);
+
+    if (!(await checkResourceExists(outputDir))) {
+      await fs.mkdir(outputDir);
+    }
+
+    if (!(await checkResourceExists(cachePath))) {
+      await fs.writeFile(cachePath, cache, "utf-8");
+    }
+  }
 };
 
 export { createCache };

--- a/packages/plugin-import-commonjs/src/index.js
+++ b/packages/plugin-import-commonjs/src/index.js
@@ -53,8 +53,7 @@ class ImportCommonJsResource {
   async intercept(url, request, response) {
     const { pathname } = url;
 
-    // eslint-disable-next-line no-async-promise-executor
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       try {
         const options = {
           input: pathname,

--- a/packages/plugin-renderer-puppeteer/src/puppeteer-handler.js
+++ b/packages/plugin-renderer-puppeteer/src/puppeteer-handler.js
@@ -49,20 +49,11 @@ export default async function (compilation, callback) {
     return Promise.reject();
   }
 
-  // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async (resolve, reject) => {
-    try {
-      const pages = compilation.graph.filter((page) => !page.isSSR);
-      const port = compilation.config.devServer.port;
-      const offsetPort = port + 1; // don't try and start the dev server on the same port as the CLI
-      const serverAddress = `http://127.0.0.1:${offsetPort}`;
+  const pages = compilation.graph.filter((page) => !page.isSSR);
+  const port = compilation.config.devServer.port;
+  const offsetPort = port + 1; // don't try and start the dev server on the same port as the CLI
+  const serverAddress = `http://127.0.0.1:${offsetPort}`;
 
-      await runBrowser(serverAddress, pages);
-      browserRunner.close();
-
-      resolve();
-    } catch (err) {
-      reject(err);
-    }
-  });
+  await runBrowser(serverAddress, pages);
+  browserRunner.close();
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves https://github.com/ProjectEvergreen/greenwood/issues/1491

## Documentation 

N / A

## Summary of Changes

1. Move `generateCompilation` to be inside the `try / catch` block
1. Refactor out all usages of `async` executor functions

## TODO
1. [x] Actually, I wonder if the real issue is that things are getting swallowed because of our usage / ignoring of - https://eslint.org/docs/latest/rules/no-async-promise-executor
    - lifecycles / commands
    - Worker thread usages
 1. [x] how to best handle for dev / prod servers that need to "hang"?
 1. [x] Do we need / want to do anything about _register.js_ / _loader.js_ ? - I don't think so, since we're not wrapping anything in a `Promise` or anything funky that would swallow an error
 
 ----
 
~~_maybe_ this will help with #1490 ?~~