### PR TITLE
enhancement/issue 1481 pre clean build output directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "lerna": "lerna",
-    "clean": "rimraf --glob ./**/.greenwood/** ./**/public/** ./coverage",
+    "clean": "rimraf --glob ./packages/**/.greenwood/** ./packages/**/public/** ./coverage",
     "clean:deps": "rimraf **/node_modules/**",
     "build": "cross-env __GWD_ROLLUP_MODE__=strict node . build",
     "serve": "node . serve",

--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -1,8 +1,6 @@
 import { bundleCompilation } from "../lifecycles/bundle.js";
-import { checkResourceExists } from "../lib/resource-utils.js";
 import { copyAssets } from "../lifecycles/copy.js";
 import { getDevServer } from "../lifecycles/serve.js";
-import fs from "fs/promises";
 import {
   preRenderCompilationWorker,
   preRenderCompilationCustom,
@@ -11,19 +9,12 @@ import {
 
 const runProductionBuild = async (compilation) => {
   const { prerender, activeContent, plugins } = compilation.config;
-  const outputDir = compilation.context.outputDir;
   const prerenderPlugin = compilation.config.plugins.find((plugin) => plugin.type === "renderer")
     ? compilation.config.plugins.find((plugin) => plugin.type === "renderer").provider(compilation)
     : {};
   const adapterPlugin = compilation.config.plugins.find((plugin) => plugin.type === "adapter")
     ? compilation.config.plugins.find((plugin) => plugin.type === "adapter").provider(compilation)
     : null;
-
-  if (!(await checkResourceExists(outputDir))) {
-    await fs.mkdir(outputDir, {
-      recursive: true,
-    });
-  }
 
   if (prerender) {
     // start any of the user's server plugins if needed

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -391,7 +391,9 @@ async function bundleSsrPages(compilation, optimizePlugins) {
         });
       }
 
-      // better way to write out this inline code?
+      // would be nice to find out a better way to write out / generate this inline code "facade"
+      // and how to calculate the relative path to the src/ page's entry point in the user's workspace
+      // https://github.com/ProjectEvergreen/greenwood/pull/1482#issuecomment-2905643391
       /* eslint-disable no-useless-escape */
       await fs.writeFile(
         entryFileOutputUrl,

--- a/packages/cli/src/lifecycles/compile.js
+++ b/packages/cli/src/lifecycles/compile.js
@@ -26,8 +26,32 @@ const generateCompilation = async () => {
 
   const { scratchDir, outputDir } = compilation.context;
 
-  if (!(await checkResourceExists(scratchDir))) {
-    await fs.mkdir(scratchDir);
+  if (process.env.__GWD_COMMAND__ !== "serve") {
+    // clear out the pre-build output dir first if it exists
+    if (await checkResourceExists(scratchDir)) {
+      await fs.rm(scratchDir, {
+        recursive: true,
+      });
+    }
+
+    // prep an empty directory for any pre-build output
+    await fs.mkdir(scratchDir, {
+      recursive: true,
+    });
+  }
+
+  if (process.env.__GWD_COMMAND__ === "build") {
+    // clear out the output dir first before we generate any build output
+    if (await checkResourceExists(outputDir)) {
+      await fs.rm(outputDir, {
+        recursive: true,
+      });
+    }
+
+    // prep an empty directory for the build output
+    await fs.mkdir(outputDir, {
+      recursive: true,
+    });
   }
 
   if (process.env.__GWD_COMMAND__ === "serve") {

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -1,6 +1,3 @@
-import fs from "fs/promises";
-import { checkResourceExists } from "../lib/resource-utils.js";
-
 const initContext = async ({ config }) => {
   const { workspace, pagesDirectory, layoutsDirectory } = config;
   const projectDirectory = new URL(`file://${process.cwd()}/`);
@@ -24,12 +21,6 @@ const initContext = async ({ config }) => {
     projectDirectory,
     layoutsDir,
   };
-
-  if (!(await checkResourceExists(scratchDir))) {
-    await fs.mkdir(scratchDir, {
-      recursive: true,
-    });
-  }
 
   return Promise.resolve(context);
 };

--- a/packages/cli/test/cases/build.plugins.adapter/build.config.plugins-adapter.spec.js
+++ b/packages/cli/test/cases/build.plugins.adapter/build.config.plugins-adapter.spec.js
@@ -234,8 +234,8 @@ describe("Build Greenwood With: ", function () {
 
   after(function () {
     runner.teardown([
-      ...getOutputTeardownFiles(outputPath),
       path.join(outputPath, "adapter-output"),
+      ...getOutputTeardownFiles(outputPath),
     ]);
   });
 });

--- a/packages/plugin-adapter-aws/src/index.js
+++ b/packages/plugin-adapter-aws/src/index.js
@@ -71,9 +71,11 @@ async function awsAdapter(compilation) {
   const ssrPages = compilation.graph.filter((page) => page.isSSR);
   const apiRoutes = compilation.manifest.apis;
 
-  if (!(await checkResourceExists(adapterOutputUrl))) {
-    await fs.mkdir(adapterOutputUrl, { recursive: true });
+  if (await checkResourceExists(adapterOutputUrl)) {
+    await fs.rm(adapterOutputUrl, { recursive: true });
   }
+
+  await fs.mkdir(adapterOutputUrl, { recursive: true });
 
   for (const page of ssrPages) {
     const outputType = "page";

--- a/packages/plugin-adapter-vercel/src/index.js
+++ b/packages/plugin-adapter-vercel/src/index.js
@@ -81,10 +81,11 @@ async function vercelAdapter(compilation, options) {
   const ssrPages = compilation.graph.filter((page) => page.isSSR);
   const apiRoutes = compilation.manifest.apis;
 
-  if (!(await checkResourceExists(adapterOutputUrl))) {
-    await fs.mkdir(adapterOutputUrl, { recursive: true });
+  if (await checkResourceExists(adapterOutputUrl)) {
+    await fs.rm(adapterOutputUrl, { recursive: true });
   }
 
+  await fs.mkdir(adapterOutputUrl, { recursive: true });
   await fs.writeFile(
     new URL("./.vercel/output/config.json", projectDirectory),
     JSON.stringify({

--- a/packages/plugin-css-modules/src/index.js
+++ b/packages/plugin-css-modules/src/index.js
@@ -176,13 +176,13 @@ class ScanForCssModulesResource {
     this.compilation = compilation;
     this.extensions = ["module.css"];
     this.contentType = "text/javascript";
+    const { scratchDir } = this.compilation.context;
 
-    if (!fs.existsSync(this.compilation.context.scratchDir)) {
-      fs.mkdirSync(this.compilation.context.scratchDir, { recursive: true });
-      fs.writeFileSync(
-        new URL(`./${MODULES_MAP_FILENAME}`, this.compilation.context.scratchDir),
-        JSON.stringify({}),
-      );
+    if (
+      fs.existsSync(scratchDir) &&
+      !fs.existsSync(new URL(`./${MODULES_MAP_FILENAME}`, scratchDir))
+    ) {
+      fs.writeFileSync(new URL(`./${MODULES_MAP_FILENAME}`, scratchDir), JSON.stringify({}));
     }
   }
 

--- a/packages/plugin-graphql/src/core/cache.js
+++ b/packages/plugin-graphql/src/core/cache.js
@@ -33,10 +33,6 @@ const createCache = async (req, context) => {
     const hashFilename = `${queryHash}-cache.json`;
     const cachePath = new URL(`./${hashFilename}`, outputDir);
 
-    if (!(await checkResourceExists(outputDir))) {
-      await fs.mkdir(outputDir);
-    }
-
     if (!(await checkResourceExists(cachePath))) {
       await fs.writeFile(cachePath, cache, "utf-8");
     }

--- a/packages/plugin-graphql/src/core/server.js
+++ b/packages/plugin-graphql/src/core/server.js
@@ -22,7 +22,11 @@ const graphqlServer = async (compilation) => {
 
       // make sure to ignore introspection requests from being generated as an output cache file
       // https://stackoverflow.com/a/58040379/417806
-      if (req.query.q !== "internal" && req.body.operationName !== "IntrospectionQuery") {
+      if (
+        process.env.__GWD_COMMAND__ === "build" &&
+        req.query.q !== "internal" &&
+        req.body.operationName !== "IntrospectionQuery"
+      ) {
         await createCache(req, context);
       }
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1481 

## Documentation 

N / A

## Summary of Changes

1. Pre-clean (and consolidate logic for) output and scratch directories
1. Pre-clean adapters build output
1. Optimize GraphQL query caching for build command only
1. Optimize CSS Modules scratch output

## TODO
1. [x] ~~(nice to have / new issue) output scratch directory within node modules~~ - deferred for now https://github.com/ProjectEvergreen/greenwood/pull/1482#issuecomment-2905643391
    - pre-test in a project 
    - would need / want to align with docs and init .gitignore