### PR TITLE
enhancement/issue 1439 handle excessive lifecycle running due to Worker threads triggering register function

### DIFF
--- a/packages/cli/src/register.js
+++ b/packages/cli/src/register.js
@@ -1,3 +1,5 @@
 import { register } from "node:module";
 
-register("./loader.js", import.meta.url);
+if (process.argv.filter((arg) => arg.endsWith(".bin/greenwood")).length === 1) {
+  register("./loader.js", import.meta.url);
+}

--- a/test/test-register.js
+++ b/test/test-register.js
@@ -1,3 +1,8 @@
 import { register } from "node:module";
 
-register("./test-loader.js", import.meta.url);
+console.log("@@@@ REGISTER", process.argv);
+
+if (process.argv.filter((arg) => arg.indexOf("greenwood/packages/cli/src/") > 0).length === 1) {
+  console.log("@@@@ REGISTER", process.argv);
+  register("./test-loader.js", import.meta.url);
+}


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1439 

## Documentation 

N / A

## Summary of Changes

1. Only invoke _register.js_ when using `--import` when it actually comes from Greenwood

## Question
1. [ ] Confirm if this is expected behavior / outreach (I think it is)
1. [ ] Is there a better way then checking `process.argv`?