### PR TITLE
chore/bump Windows GitHub Action to Node 22 (LTS)

### DIFF
--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [20]
+        node: [22]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

- https://github.com/ProjectEvergreen/greenwood/issues/1414#issuecomment-2781025824
- https://github.com/ProjectEvergreen/greenwood/pull/1380

## Documentation 

N / A

## Summary of Changes

1. Bumped this Windows GitHub Action to be on Node 22 like the rest

## TODO
1. [x] Should run this a few times to validate false positives - so far 2/2 🤞 
    ![Screenshot 2025-04-12 at 4 12 52 PM](https://github.com/user-attachments/assets/c2ea2650-9c67-4021-a017-29d7e5ceaf24)