### PR TITLE
chore/upgrade EOL GitHub Actions runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci-loaders.yml
+++ b/.github/workflows/ci-loaders.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/ci-loaders.yml
+++ b/.github/workflows/ci-loaders.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

Our [jobs started getting cancelled](https://github.com/ProjectEvergreen/greenwood/actions/runs/14525406362/job/40755759200?pr=1477), and it looks like our Ubuntu version for GitHub Actions [are approaching EOL](https://github.com/actions/runner-images/issues/11101)
https://github.com/ProjectEvergreen/greenwood/actions/runs/14525406362/job/40755759200?pr=1477
> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

![Screenshot 2025-04-18 at 8 21 03 AM](https://github.com/user-attachments/assets/9063893d-ffde-49af-a9d9-40de3483918a)


## Documentation 

<!-- if this issue has been labeled with documentation, please make sure submit a PR to our website repo and link it -->
<!-- https://github.com/ProjectEvergreen/www.greenwoodjs.dev -->

## Summary of Changes

1. Upgrade Linux runners to ~~**ubunutu-latest**~~ **ubuntu-22.04**

> Looks like starting in >= ubuntu-23.04 some of our Chromimum related dependencies, so I guess will just kick that can down the road for a bit for now 😅 
> - https://github.com/betaflight/betaflight-configurator/issues/4145
> - https://github.com/cypress-io/cypress/issues/27972