### PR TITLE
chore/update package json repository field with valid workspace values

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,7 +3,11 @@
   "version": "0.32.0",
   "description": "Greenwood CLI.",
   "type": "module",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/cli"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/cli",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/init",
   "version": "0.32.0",
   "description": "A package for scaffolding a new Greenwood project.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/init"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/init",
   "author": "Grant Hutchinson <grant@hutchdev.ca>",
   "license": "MIT",

--- a/packages/plugin-adapter-aws/package.json
+++ b/packages/plugin-adapter-aws/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-adapter-aws",
   "version": "0.32.0",
   "description": "A Greenwood plugin for supporting AWS serverless and edge runtimes.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-adapter-aws"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-adapter-aws",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-adapter-netlify/package.json
+++ b/packages/plugin-adapter-netlify/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-adapter-netlify",
   "version": "0.32.0",
   "description": "A Greenwood plugin for supporting Netlify serverless and edge runtimes.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-adapter-netlify"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-adapter-netlify",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-adapter-vercel/package.json
+++ b/packages/plugin-adapter-vercel/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-adapter-vercel",
   "version": "0.32.0",
   "description": "A Greenwood plugin for supporting Vercel serverless and edge runtimes.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-adapter-vercel"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-adapter-vercel",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-babel",
   "version": "0.32.0",
   "description": "A Greenwood plugin for using Babel and applying it to your JavaScript.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-babel"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-babel",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-css-modules/package.json
+++ b/packages/plugin-css-modules/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-css-modules",
   "version": "0.32.0",
   "description": "A Greenwood plugin for authoring CSS Modules",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-css-modules"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-css-modules",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-google-analytics/package.json
+++ b/packages/plugin-google-analytics/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-google-analytics",
   "version": "0.32.0",
   "description": "A Greenwood plugin adding support for Google Analytics JavaScript tracker.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-google-analytics"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-google-analytics",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-graphql",
   "version": "0.32.0",
   "description": "A plugin for using GraphQL for querying your content.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-graphql"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-graphql",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-import-commonjs/package.json
+++ b/packages/plugin-import-commonjs/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-import-commonjs",
   "version": "0.32.0",
   "description": "A plugin for loading CommonJS based modules in the browser using ESM (import / export) syntax.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-import-commonjs"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-import-commonjs",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-import-jsx/package.json
+++ b/packages/plugin-import-jsx/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-import-jsx",
   "version": "0.32.0",
   "description": "A Greenwood plugin to write JSX rendering Web Components compatible with WCC.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-import-jsx"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-import-jsx",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-import-raw/package.json
+++ b/packages/plugin-import-raw/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-import-raw",
   "version": "0.32.0",
   "description": "A Greenwood plugin to allow you to use ESM (import) syntax to load any file content as a string.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-import-raw"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-import-raw",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-include-html/package.json
+++ b/packages/plugin-include-html/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-include-html",
   "version": "0.32.0",
   "description": "A Greenwood plugin to let you render server side JS from HTML or JS at build time as HTML.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-include-html"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-include-html",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-polyfills/package.json
+++ b/packages/plugin-polyfills/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-polyfills",
   "version": "0.32.0",
   "description": "A Greenwood plugin adding support for Web Component related polyfills like Custom Elements and Shadow DOM.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-polyfills"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-polyfills",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-postcss/package.json
+++ b/packages/plugin-postcss/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-postcss",
   "version": "0.32.0",
   "description": "A Greenwood plugin for loading PostCSS configuration and applying it to your CSS.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-postcss"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-postcss",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-renderer-lit/package.json
+++ b/packages/plugin-renderer-lit/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-renderer-lit",
   "version": "0.32.0",
   "description": "A server-side rendering plugin for Lit based Greenwood projects.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-renderer-lit"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-renderer-lit",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",

--- a/packages/plugin-renderer-puppeteer/package.json
+++ b/packages/plugin-renderer-puppeteer/package.json
@@ -2,7 +2,11 @@
   "name": "@greenwood/plugin-renderer-puppeteer",
   "version": "0.32.0",
   "description": "A Greenwood plugin to allow headless browser rendering with Puppeteer.",
-  "repository": "https://github.com/ProjectEvergreen/greenwood",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-renderer-puppeteer"
+  },
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-renderer-puppeteer",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

Ran the CLI package through [**publint**](https://publint.dev/@greenwood/cli@0.32.0) and it flagged the `repository` field in our package.json as being invalid, as per the [NPM package.json spec](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository)

<img width="1023" alt="Screenshot 2025-04-21 at 12 37 29 PM" src="https://github.com/user-attachments/assets/5e391685-893f-4337-9f75-7d154b2f6963" />

## Documentation 

N / A

## Summary of Changes

1. Update all active workspace packages to have a valid entry for the `repository` field in _package.json_
1. Added `directory` sub-field to account for our monorepo