### PR TITLE
bug/issue 1402 add missing compilation constructor prop

### DIFF
--- a/packages/cli/src/lib/execute-route-module.js
+++ b/packages/cli/src/lib/execute-route-module.js
@@ -32,7 +32,7 @@ async function executeRouteModule({
     } = module;
 
     if (module.default) {
-      const { html } = await renderToString(new URL(moduleUrl), false, request);
+      const { html } = await renderToString(new URL(moduleUrl), false, { request, compilation });
 
       data.body = html;
     } else {

--- a/packages/cli/src/types/ssr.d.ts
+++ b/packages/cli/src/types/ssr.d.ts
@@ -4,7 +4,7 @@ import type { Page } from "./content.js";
 
 // would be nice if we could enforce the user is using `extends HTMLElement`
 export type SsrRouteHandler = {
-  constructor?(compilation: Compilation, request: Request): string;
+  constructor?({ compilation: Compilation, request: Request }): void;
 };
 
 export type GetBody = (compilation: Compilation, page: Page, request: Request) => Promise<string>;

--- a/packages/cli/test/cases/develop.ssr/src/pages/post.js
+++ b/packages/cli/test/cases/develop.ssr/src/pages/post.js
@@ -1,5 +1,5 @@
 export default class PostPage extends HTMLElement {
-  constructor(request) {
+  constructor({ request }) {
     super();
 
     const params = new URLSearchParams(request.url.slice(request.url.indexOf("?")));

--- a/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
@@ -460,11 +460,18 @@ describe("Serve Greenwood With: ", function () {
         expect(heading[0].textContent).to.not.be.undefined;
       });
 
-      it("should have the expected body as a <p> tag in the body", function () {
+      it("should have the expected content as a <p> tag in the body", function () {
         const paragraph = dom.window.document.querySelectorAll("body > p");
 
         expect(paragraph.length).to.equal(1);
         expect(paragraph[0].textContent).to.not.be.undefined;
+      });
+
+      it("should have the expected content as a <p> tag in the body", function () {
+        const span = dom.window.document.querySelectorAll("body > span");
+
+        expect(span.length).to.equal(1);
+        expect(span[0].textContent).to.equal("Number of Blog Pages: 2");
       });
     });
 

--- a/packages/cli/test/cases/serve.default.ssr/src/pages/post.js
+++ b/packages/cli/test/cases/serve.default.ssr/src/pages/post.js
@@ -1,13 +1,14 @@
 export default class PostPage extends HTMLElement {
-  constructor(request) {
+  constructor({ request, compilation }) {
     super();
 
     const params = new URLSearchParams(request.url.slice(request.url.indexOf("?")));
     this.postId = params.get("id");
+    this.numPages = compilation.graph.filter((page) => page.route.startsWith("/blog/")).length;
   }
 
   async connectedCallback() {
-    const { postId } = this;
+    const { postId, numPages } = this;
     const post = await fetch(`https://jsonplaceholder.typicode.com/posts/${postId}`).then((resp) =>
       resp.json(),
     );
@@ -17,6 +18,7 @@ export default class PostPage extends HTMLElement {
       <h1>Fetched Post ID: ${id}</h1>
       <h2>${title}</h2>
       <p>${body}</p>
+      <span>Number of Blog Pages: ${numPages}</span>
     `;
   }
 }

--- a/packages/plugin-adapter-aws/test/cases/build.default/src/pages/post.js
+++ b/packages/plugin-adapter-aws/test/cases/build.default/src/pages/post.js
@@ -1,5 +1,5 @@
 export default class PostPage extends HTMLElement {
-  constructor(request) {
+  constructor({ request }) {
     super();
 
     const params = new URLSearchParams(request.url.slice(request.url.indexOf("?")));

--- a/packages/plugin-adapter-netlify/test/cases/build.default/src/pages/post.js
+++ b/packages/plugin-adapter-netlify/test/cases/build.default/src/pages/post.js
@@ -1,5 +1,5 @@
 export default class PostPage extends HTMLElement {
-  constructor(request) {
+  constructor({ request }) {
     super();
 
     const params = new URLSearchParams(request.url.slice(request.url.indexOf("?")));

--- a/packages/plugin-adapter-vercel/test/cases/build.default/src/pages/post.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.default/src/pages/post.js
@@ -1,5 +1,5 @@
 export default class PostPage extends HTMLElement {
-  constructor(request) {
+  constructor({ request }) {
     super();
 
     const params = new URLSearchParams(request.url.slice(request.url.indexOf("?")));


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1402 

## Documentation 

1. [ ] Need to update the docs for this - https://greenwoodjs.dev/docs/pages/server-rendering/#web-server-components

## Summary of Changes

1. Refactor constructor props to be an object
1. Add compilation as a property of said object
1. Update `SsrRouteHandler` types