### PR TITLE
bug/issue 1279 fix missing TS flag from init TS base template

### DIFF
--- a/packages/init/src/template-base-ts/package.json
+++ b/packages/init/src/template-base-ts/package.json
@@ -6,7 +6,7 @@
     "dev": "NODE_OPTIONS='--experimental-strip-types' greenwood develop",
     "start": "NODE_OPTIONS='--experimental-strip-types' greenwood develop",
     "build": "NODE_OPTIONS='--experimental-strip-types' greenwood build",
-    "serve": "greenwood serve"
+    "serve": "NODE_OPTIONS='--experimental-strip-types' greenwood serve"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.20.0",

--- a/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
+++ b/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
@@ -98,7 +98,7 @@ describe("Initialize a new Greenwood project: ", function () {
         expect(scripts.dev).to.equal("NODE_OPTIONS='--experimental-strip-types' greenwood develop");
         expect(scripts.start).to.equal(scripts.dev);
         expect(scripts.build).to.equal("NODE_OPTIONS='--experimental-strip-types' greenwood build");
-        expect(scripts.serve).to.equal("greenwood serve");
+        expect(scripts.serve).to.equal("NODE_OPTIONS='--experimental-strip-types' greenwood serve");
       });
 
       it("the should have the correct Greenwood devDependency", function () {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related #1279 

Saw that we need the TS flag for `greenwood serve` since we still rely on the configuration file (see #1282 )

```sh
> my-app@0.33.0-alpha.0 serve /Users/owenbuckley/Desktop/scratch/my-app
> greenwood serve

-------------------------------------------------------
Welcome to Greenwood (v0.33.0-alpha.0) ♻️
-------------------------------------------------------
Running Greenwood with the serve command.
Initializing project config
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/owenbuckley/Desktop/scratch/my-app/greenwood.config.ts
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:219:9)
    at defaultGetFormat (node:internal/modules/esm/get_format:245:36)
    at defaultLoad (node:internal/modules/esm/load:120:22)
    at async ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:580:32)
    at async ModuleJob._link (node:internal/modules/esm/module_job:116:19) {
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
}
 ELIFECYCLE  Command failed with exit code 1.
```

## Documentation 

N / A

## Summary of Changes

1. Have all NPM scripts include `--experimental-strip-types` flag