### PR TITLE
bug/issue 1279 fix init project scaffolding version being to set to current Greenwood version

### DIFF
--- a/packages/init/src/template-base-ts/package.json
+++ b/packages/init/src/template-base-ts/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "template-base-ts",
-  "type": "module",
   "scripts": {
     "dev": "NODE_OPTIONS='--experimental-strip-types' greenwood develop",
     "start": "NODE_OPTIONS='--experimental-strip-types' greenwood develop",
@@ -8,7 +6,6 @@
     "serve": "NODE_OPTIONS='--experimental-strip-types' greenwood serve"
   },
   "devDependencies": {
-    "@greenwood/cli": "^0.20.0",
     "typescript": "^5.8.0"
   }
 }

--- a/packages/init/src/template-base-ts/package.json
+++ b/packages/init/src/template-base-ts/package.json
@@ -1,6 +1,5 @@
 {
   "name": "template-base-ts",
-  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "NODE_OPTIONS='--experimental-strip-types' greenwood develop",

--- a/packages/init/src/template-base/package.json
+++ b/packages/init/src/template-base/package.json
@@ -1,13 +1,8 @@
 {
-  "name": "template-base",
-  "type": "module",
   "scripts": {
     "dev": "greenwood develop",
     "start": "greenwood develop",
     "build": "greenwood build",
     "serve": "greenwood serve"
-  },
-  "devDependencies": {
-    "@greenwood/cli": "^0.20.0"
   }
 }

--- a/packages/init/src/template-base/package.json
+++ b/packages/init/src/template-base/package.json
@@ -1,6 +1,5 @@
 {
   "name": "template-base",
-  "version": "0.0.1",
   "type": "module",
   "scripts": {
     "dev": "greenwood develop",

--- a/packages/init/src/util.js
+++ b/packages/init/src/util.js
@@ -24,22 +24,23 @@ function copyTemplate(templateDirUrl, outputDirUrl) {
 function setupPackageJson(outputDirUrl, { name, version }) {
   console.log("setting up package.json...");
 
-  const packageJsonUrl = new URL("./package.json", outputDirUrl);
-  const json = JSON.parse(fs.readFileSync(packageJsonUrl));
-  const devDeps = json.devDependencies;
+  const packageJsonOutputUrl = new URL("./package.json", outputDirUrl);
+  const pkgJson = JSON.parse(fs.readFileSync(packageJsonOutputUrl));
+  const json = {};
 
+  // setup standard fields
   json.name = name === "." ? path.basename(outputDirUrl.pathname) : name;
   json.version = "0.1.0";
+  json.type = "module";
+  json.scripts = pkgJson.scripts;
 
-  // ensure all Greenwood deps have their version set to the version from the CLI's package.json
-  for (const dep in devDeps) {
-    if (dep.startsWith("@greenwood/")) {
-      // we should change this to a ^ once Greenwood reaches 1.0
-      json.devDependencies[dep] = `~${version}`;
-    }
-  }
+  // add / merge Greenwood dependencies (first)
+  json.devDependencies = {
+    "@greenwood/cli": `~${version}`,
+    ...(pkgJson.devDependencies ?? {}),
+  };
 
-  fs.writeFileSync(packageJsonUrl, JSON.stringify(json, null, 2));
+  fs.writeFileSync(packageJsonOutputUrl, JSON.stringify(json, null, 2));
 }
 
 function setupGitIgnore(outputDirUrl, { patterns = [] } = {}) {

--- a/packages/init/src/util.js
+++ b/packages/init/src/util.js
@@ -29,7 +29,7 @@ function setupPackageJson(outputDirUrl, { name, version }) {
   const devDeps = json.devDependencies;
 
   json.name = name === "." ? path.basename(outputDirUrl.pathname) : name;
-  json.version = version;
+  json.version = "0.1.0";
 
   // ensure all Greenwood deps have their version set to the version from the CLI's package.json
   for (const dep in devDeps) {

--- a/packages/init/test/cases/init.options.default/init.options.default.spec.js
+++ b/packages/init/test/cases/init.options.default/init.options.default.spec.js
@@ -90,6 +90,10 @@ describe("Initialize a new Greenwood project: ", function () {
         expect(pkgJson.name).to.equal(APP_NAME);
       });
 
+      it("the should have the correct version", function () {
+        expect(pkgJson.version).to.equal("0.1.0");
+      });
+
       it("the should have the correct Greenwood scripts", function () {
         const scripts = pkgJson.scripts;
 

--- a/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
+++ b/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
@@ -106,11 +106,24 @@ describe("Initialize a new Greenwood project: ", function () {
       });
 
       it("the should have the correct Greenwood devDependency", function () {
-        const scriptPkg = JSON.parse(
+        const initPkg = JSON.parse(
           fs.readFileSync(new URL("../../../package.json", import.meta.url), "utf-8"),
         );
 
-        expect(pkgJson.devDependencies["@greenwood/cli"]).to.equal(`~${scriptPkg.version}`);
+        expect(pkgJson.devDependencies["@greenwood/cli"]).to.equal(`~${initPkg.version}`);
+      });
+
+      it("the should have TypeScript as a dependency", function () {
+        const templatePkg = JSON.parse(
+          fs.readFileSync(
+            new URL("../../../src/template-base-ts/package.json", import.meta.url),
+            "utf-8",
+          ),
+        );
+
+        expect(pkgJson.devDependencies["typescript"].version).to.equal(
+          templatePkg.devDependencies["typescript"].version,
+        );
       });
     });
 

--- a/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
+++ b/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
@@ -92,6 +92,10 @@ describe("Initialize a new Greenwood project: ", function () {
         expect(pkgJson.type).to.equal("module");
       });
 
+      it("the should have the correct version", function () {
+        expect(pkgJson.version).to.equal("0.1.0");
+      });
+
       it("the should have the correct Greenwood scripts", function () {
         const scripts = pkgJson.scripts;
 

--- a/packages/init/test/cases/init.options.yes/init.options.yes.spec.js
+++ b/packages/init/test/cases/init.options.yes/init.options.yes.spec.js
@@ -90,6 +90,10 @@ describe("Initialize a new Greenwood project: ", function () {
         expect(pkgJson.type).to.equal("module");
       });
 
+      it("the should have the correct version", function () {
+        expect(pkgJson.version).to.equal("0.1.0");
+      });
+
       it("the should have the correct Greenwood scripts", function () {
         const scripts = pkgJson.scripts;
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #1279 

Observed that in the generated _package.json_, the `version` field was being set to the current Greenwood version.  Ideally it should be something like "**0.1.0**"

```sh
> my-app@0.33.0-alpha.0 serve /Users/owenbuckley/Desktop/scratch/my-app
> greenwood serve

-------------------------------------------------------
Welcome to Greenwood (v0.33.0-alpha.0) ♻️
-------------------------------------------------------
Running Greenwood with the serve command.
Initializing project config
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/owenbuckley/Desktop/scratch/my-app/greenwood.config.ts
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:219:9)
    at defaultGetFormat (node:internal/modules/esm/get_format:245:36)
    at defaultLoad (node:internal/modules/esm/load:120:22)
    at async ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:580:32)
    at async ModuleJob._link (node:internal/modules/esm/module_job:116:19) {
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
}
 ELIFECYCLE  Command failed with exit code 1.
➜  my-app node -v
v22.15.0
➜  my-app cat package.json
{
  "name": "my-app",
  "version": "0.33.0-alpha.0",
  "type": "module",
  "scripts": {
    "dev": "NODE_OPTIONS='--experimental-strip-types' greenwood develop",
    "start": "NODE_OPTIONS='--experimental-strip-types' greenwood develop",
    "build": "NODE_OPTIONS='--experimental-strip-types' greenwood build",
    "serve": "greenwood serve"
  },
  "devDependencies": {
    "@greenwood/cli": "~0.33.0-alpha.0",
    "typescript": "^5.8.0"
  }
}%
```


## Documentation 

N / A

## Summary of Changes

1. Hardcode scaffolding `version` field in _package.json_ to `0.1.0`
1. Misc refactoring to assert all expected fields through the setup script

## Questions

1. [x] Is `0.1.0` fine?  Do we even need / want to set a version? - yes
1. [x] Hardcode `type` field too?  (to "module") - yes