### PR TITLE
enhancement/issue 1518 split side effect from CLI entry point to dedicated bin file

### DIFF
--- a/greenwood.config.test-types.ts
+++ b/greenwood.config.test-types.ts
@@ -1,4 +1,4 @@
-import type { Config, ExternalSourcePage } from "@greenwood/cli";
+import { type Config, type ExternalSourcePage, run } from "@greenwood/cli";
 import { greenwoodPluginAdapterAws } from "@greenwood/plugin-adapter-aws";
 import { greenwoodPluginAdapterVercel } from "@greenwood/plugin-adapter-vercel";
 import { greenwoodPluginAdapterNetlify } from "@greenwood/plugin-adapter-netlify";
@@ -18,7 +18,8 @@ import { greenwoodPluginRendererPuppeteer } from "@greenwood/plugin-renderer-pup
 import { getContentByRoute } from "@greenwood/cli/src/data/client.js";
 
 const foo = await getContentByRoute("foo");
-console.log(foo);
+
+console.log({ run, foo });
 
 import ChildrenQuery from "@greenwood/plugin-graphql/src/queries/children.gql";
 import CollectionQuery from "@greenwood/plugin-graphql/src/queries/collection.gql";

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "repository": "https://github.com/ProjectEvergreen/greenwood",
   "author": "Owen Buckley <owen@thegreenhouse.io>",
   "license": "MIT",
-  "main": "./packages/cli/src/index.js",
   "type": "module",
   "workspaces": {
     "packages": [
@@ -17,9 +16,9 @@
     "lerna": "lerna",
     "clean": "rimraf --glob ./packages/**/.greenwood/** ./packages/**/public/** ./coverage",
     "clean:deps": "rimraf **/node_modules/**",
-    "build": "cross-env __GWD_ROLLUP_MODE__=strict node . build",
-    "serve": "node . serve",
-    "develop": "node . develop",
+    "build": "cross-env __GWD_ROLLUP_MODE__=strict greenwood build",
+    "serve": "greenwood serve",
+    "develop": "greenwood develop",
     "test": "cross-env BROWSERSLIST_IGNORE_OLD_DATA=true __GWD_ROLLUP_MODE__=strict NODE_NO_WARNINGS=1 c8 mocha --exclude \"./packages/**/test/cases/loaders-*/**\" --exclude \"./packages/**/test/cases/*.typescript*/**\" \"./packages/**/**/*.spec.js\"",
     "test:loaders": "cross-env BROWSERSLIST_IGNORE_OLD_DATA=true __GWD_ROLLUP_MODE__=strict NODE_NO_WARNINGS=1 node --import $(pwd)/test/test-register.js ./node_modules/mocha/bin/mocha --exclude \"./packages/**/test/cases/*.typescript*/**\" \"./packages/**/**/*.spec.js\"",
     "test:loaders:win": "cross-env BROWSERSLIST_IGNORE_OLD_DATA=true __GWD_ROLLUP_MODE__=strict NODE_NO_WARNINGS=1 node --import file:\\\\%cd%\\test\\test-register.js ./node_modules/mocha/bin/mocha --exclude \"./packages/init/test/cases/**\" --exclude \"./packages/**/test/cases/*.typescript*/**\" \"./packages/**/**/*.spec.js\"",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
     "./src/*": "./src/*"
   },
   "bin": {
-    "greenwood": "./src/index.js"
+    "greenwood": "./src/bin.js"
   },
   "files": [
     "src/"

--- a/packages/cli/src/bin.js
+++ b/packages/cli/src/bin.js
@@ -1,14 +1,11 @@
 #!/usr/bin/env node
 
-import fs from "fs/promises";
 import program from "commander";
 import { run } from "./index.js";
 
-const greenwoodPackageJson = JSON.parse(
-  // TODO should this be based on process.cwd like our context lifecycle is?
-  // TODO this could be JSON Module import
-  await fs.readFile(new URL("../package.json", import.meta.url), "utf-8"),
-);
+const greenwoodPackageJson = (
+  await import(new URL("../package.json", import.meta.url), { with: { type: "json" } })
+).default;
 
 let command = "";
 

--- a/packages/cli/src/bin.js
+++ b/packages/cli/src/bin.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+import fs from "fs/promises";
+import program from "commander";
+import { run } from "./index.js";
+
+const greenwoodPackageJson = JSON.parse(
+  // TODO should this be based on process.cwd like our context lifecycle is?
+  // TODO this could be JSON Module import
+  await fs.readFile(new URL("../package.json", import.meta.url), "utf-8"),
+);
+
+let command = "";
+
+console.info("-------------------------------------------------------");
+console.info(`Welcome to Greenwood (v${greenwoodPackageJson.version}) ♻️`);
+console.info("-------------------------------------------------------");
+
+program
+  .version(greenwoodPackageJson.version)
+  .arguments("<script-mode>")
+  .usage("<script-mode> [options]");
+
+program
+  .command("build")
+  .description("Build a static site for production.")
+  .action((cmd) => {
+    command = cmd._name;
+  });
+
+program
+  .command("develop")
+  .description("Start a local development server.")
+  .action((cmd) => {
+    command = cmd._name;
+  });
+
+program
+  .command("serve")
+  .description("View a production build locally with a basic web server.")
+  .action((cmd) => {
+    command = cmd._name;
+  });
+
+program
+  .command("eject")
+  .option("-a, --all", "eject all configurations including babel, postcss, browserslistrc")
+  .description("Eject greenwood configurations.")
+  .action((cmd) => {
+    command = cmd._name;
+  });
+
+program.parse(process.argv);
+
+if (program.parse.length === 0) {
+  program.help();
+}
+
+run(command);

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -1,6 +1,6 @@
 import { generateCompilation } from "./lifecycles/compile.js";
 
-const run = async (command) => {
+async function run(command) {
   process.env.__GWD_COMMAND__ = command;
 
   try {
@@ -37,6 +37,6 @@ const run = async (command) => {
     console.error(err);
     process.exit(1);
   }
-};
+}
 
 export { run };

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -1,61 +1,6 @@
-#!/usr/bin/env node
-
 import { generateCompilation } from "./lifecycles/compile.js";
-import fs from "node:fs/promises";
-import program from "commander";
 
-const greenwoodPackageJson = JSON.parse(
-  await fs.readFile(new URL("../package.json", import.meta.url), "utf-8"),
-);
-let cmdOption = {};
-let command = "";
-
-console.info("-------------------------------------------------------");
-console.info(`Welcome to Greenwood (v${greenwoodPackageJson.version}) ♻️`);
-console.info("-------------------------------------------------------");
-
-program
-  .version(greenwoodPackageJson.version)
-  .arguments("<script-mode>")
-  .usage("<script-mode> [options]");
-
-program
-  .command("build")
-  .description("Build a static site for production.")
-  .action((cmd) => {
-    command = cmd._name;
-  });
-
-program
-  .command("develop")
-  .description("Start a local development server.")
-  .action((cmd) => {
-    command = cmd._name;
-  });
-
-program
-  .command("serve")
-  .description("View a production build locally with a basic web server.")
-  .action((cmd) => {
-    command = cmd._name;
-  });
-
-program
-  .command("eject")
-  .option("-a, --all", "eject all configurations including babel, postcss, browserslistrc")
-  .description("Eject greenwood configurations.")
-  .action((cmd) => {
-    command = cmd._name;
-    cmdOption.all = cmd.all;
-  });
-
-program.parse(process.argv);
-
-if (program.parse.length === 0) {
-  program.help();
-}
-
-const run = async () => {
+const run = async (command) => {
   process.env.__GWD_COMMAND__ = command;
 
   try {
@@ -94,4 +39,4 @@ const run = async () => {
   }
 };
 
-run();
+export { run };

--- a/packages/cli/src/types/index.d.ts
+++ b/packages/cli/src/types/index.d.ts
@@ -57,3 +57,9 @@ export type {
   GetLayout,
   GetFrontmatter,
 };
+
+export type COMMANDS = "develop" | "build" | "serve";
+
+declare module "@greenwood/cli" {
+  export const run: (COMMANDS) => Promise<void>;
+}

--- a/packages/cli/src/types/index.d.ts
+++ b/packages/cli/src/types/index.d.ts
@@ -58,8 +58,8 @@ export type {
   GetFrontmatter,
 };
 
-export type COMMANDS = "develop" | "build" | "serve";
+export type CLI_COMMAND = "develop" | "build" | "serve";
 
 declare module "@greenwood/cli" {
-  export const run: (COMMANDS) => Promise<void>;
+  export const run: (CLI_COMMAND) => Promise<void>;
 }

--- a/packages/cli/test/cases/build.config.active-frontmatter/build.config.active-frontmatter.spec.js
+++ b/packages/cli/test/cases/build.config.active-frontmatter/build.config.active-frontmatter.spec.js
@@ -34,7 +34,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Active Frontmatter";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.default/build.config.default.spec.js
+++ b/packages/cli/test/cases/build.config.default/build.config.default.spec.js
@@ -22,7 +22,7 @@ import { fileURLToPath } from "node:url";
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Empty Configuration and Default Workspace";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.error-dev-server-extensions/build.config.error-dev-server-extensions.spec.js
+++ b/packages/cli/test/cases/build.config.error-dev-server-extensions/build.config.error-dev-server-extensions.spec.js
@@ -26,7 +26,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.error-dev-server-hud/build.config.error-dev-server-hud.spec.js
+++ b/packages/cli/test/cases/build.config.error-dev-server-hud/build.config.error-dev-server-hud.spec.js
@@ -26,7 +26,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.error-isolation/build.config.error-isolation.spec.js
+++ b/packages/cli/test/cases/build.config.error-isolation/build.config.error-isolation.spec.js
@@ -24,7 +24,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.error-layouts-directory/build.config.error-layouts-directory.spec.js
+++ b/packages/cli/test/cases/build.config.error-layouts-directory/build.config.error-layouts-directory.spec.js
@@ -24,7 +24,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.error-optimization/build.config.error-optimization.spec.js
+++ b/packages/cli/test/cases/build.config.error-optimization/build.config.error-optimization.spec.js
@@ -24,7 +24,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.error-pages-directory/build.config.error-pages-directory.spec.js
+++ b/packages/cli/test/cases/build.config.error-pages-directory/build.config.error-pages-directory.spec.js
@@ -24,7 +24,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.error-polyfill-import-attributes/build.config.error-polyfill-import-attributes.spec.js
+++ b/packages/cli/test/cases/build.config.error-polyfill-import-attributes/build.config.error-polyfill-import-attributes.spec.js
@@ -26,7 +26,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.error-polyfill-import-maps/build.config.error-polyfill-import-maps.spec.js
+++ b/packages/cli/test/cases/build.config.error-polyfill-import-maps/build.config.error-polyfill-import-maps.spec.js
@@ -26,7 +26,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.error-prerender/build.config.error-prerender.spec.js
+++ b/packages/cli/test/cases/build.config.error-prerender/build.config.error-prerender.spec.js
@@ -24,7 +24,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.error-workspace-absolute/build.config.error-workspace-absolute.spec.js
+++ b/packages/cli/test/cases/build.config.error-workspace-absolute/build.config.error-workspace-absolute.spec.js
@@ -24,7 +24,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.error-workspace/build.config.error-workspace.spec.js
+++ b/packages/cli/test/cases/build.config.error-workspace/build.config.error-workspace.spec.js
@@ -24,7 +24,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.layouts-directory/build.config.layouts-directory.spec.js
+++ b/packages/cli/test/cases/build.config.layouts-directory/build.config.layouts-directory.spec.js
@@ -34,7 +34,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom Pages Directory from Configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.markdown-custom.plugins/build.config.markdown-custom.spec.js
+++ b/packages/cli/test/cases/build.config.markdown-custom.plugins/build.config.markdown-custom.spec.js
@@ -37,7 +37,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom Markdown Configuration and Default Workspace";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-default/build.config-optimization-default.spec.js
@@ -39,7 +39,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Optimization Configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const expectedCss = fs
     .readFileSync(path.join(outputPath, "./fixtures/expected.css"), "utf-8")

--- a/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
@@ -38,7 +38,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Inline Optimization Configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-none/build.config-optimization-none.spec.js
@@ -35,7 +35,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "None Optimization Configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.optimization-overrides/build.config-optimization-overrides.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-overrides/build.config-optimization-overrides.spec.js
@@ -33,7 +33,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Optimization Overrides";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.optimization-static/build.config-optimization-static.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-static/build.config-optimization-static.spec.js
@@ -32,7 +32,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Static Optimization Configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.pages-directory/build.config.pages-directory.spec.js
+++ b/packages/cli/test/cases/build.config.pages-directory/build.config.pages-directory.spec.js
@@ -32,7 +32,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom Pages Directory from Configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.prerender-collections/build.config.prerender-collections.spec.js
+++ b/packages/cli/test/cases/build.config.prerender-collections/build.config.prerender-collections.spec.js
@@ -42,7 +42,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Prerender Configuration turned on using Content As Data collections";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.prerender-html-web-components/build.config.prerender-html-web-components.spec.js
+++ b/packages/cli/test/cases/build.config.prerender-html-web-components/build.config.prerender-html-web-components.spec.js
@@ -34,7 +34,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Prerender Configuration and HTML (Light DOM) Web Components";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.prerender-markdown/build.config.prerender-markdown.spec.js
+++ b/packages/cli/test/cases/build.config.prerender-markdown/build.config.prerender-markdown.spec.js
@@ -33,7 +33,7 @@ const expect = chai.expect;
 // https://github.com/ProjectEvergreen/greenwood/issues/1375
 describe("Build Greenwood With: ", function () {
   const LABEL = "Markdown with prerendering and HTML entities";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.prerender/build.config.prerender.spec.js
+++ b/packages/cli/test/cases/build.config.prerender/build.config.prerender.spec.js
@@ -32,7 +32,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Prerender Configuration turned on";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
+++ b/packages/cli/test/cases/build.config.static-router/build.config.static-router.spec.js
@@ -34,7 +34,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Static Router Configuration and Hybrid Workspace";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.config.typescript/build.config.typescript.spec.js
+++ b/packages/cli/test/cases/build.config.typescript/build.config.typescript.spec.js
@@ -42,7 +42,7 @@ const expect = chai.expect;
 describe("Serve Greenwood With: ", function () {
   const LABEL =
     "A Server Rendered Application (SSR) with API Routes in TypeScript with custom tsconfig.json";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost:8080";
   let runner;

--- a/packages/cli/test/cases/build.config.workspace-custom/build.config.workspace-custom.spec.js
+++ b/packages/cli/test/cases/build.config.workspace-custom/build.config.workspace-custom.spec.js
@@ -32,7 +32,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom Configuration for Workspace (www) and Default Greenwood configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
+++ b/packages/cli/test/cases/build.default.import-node-modules/build.default.import-node-modules.spec.js
@@ -34,7 +34,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Importing packages from node modules";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.markdown/build.default.markdown.spec.js
+++ b/packages/cli/test/cases/build.default.markdown/build.default.markdown.spec.js
@@ -28,7 +28,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Markdown";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.meta-files/build.default.meta-files.spec.js
+++ b/packages/cli/test/cases/build.default.meta-files/build.default.meta-files.spec.js
@@ -28,7 +28,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Workspace with common meta file";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.meta/build.default.meta.spec.js
+++ b/packages/cli/test/cases/build.default.meta/build.default.meta.spec.js
@@ -36,7 +36,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom Meta Tags and Nested Workspace";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.quick-start-npx/build.default.quick-start-npx.spec.js
+++ b/packages/cli/test/cases/build.default.quick-start-npx/build.default.quick-start-npx.spec.js
@@ -28,7 +28,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Workspace and emulating npx";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.spa/build.default.spa.spec.js
+++ b/packages/cli/test/cases/build.default.spa/build.default.spa.spec.js
@@ -35,7 +35,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "A Single Page Application (SPA)";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.ssr-prerender/build.default.ssr-prerender.spec.js
+++ b/packages/cli/test/cases/build.default.ssr-prerender/build.default.ssr-prerender.spec.js
@@ -34,7 +34,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) with prerender configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.ssr-static-export/build.default.ssr-static-export.spec.js
+++ b/packages/cli/test/cases/build.default.ssr-static-export/build.default.ssr-static-export.spec.js
@@ -34,7 +34,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) that is statically exported";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.static-asset-bundling/build.default.static-asset-bundling.spec.js
+++ b/packages/cli/test/cases/build.default.static-asset-bundling/build.default.static-asset-bundling.spec.js
@@ -34,7 +34,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and static asset bundling";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.title/build.default.title.spec.js
+++ b/packages/cli/test/cases/build.default.title/build.default.title.spec.js
@@ -33,7 +33,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom Title Tag and Default Workspace";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-404-markdown/build.default.workspace-404-markdown.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-404-markdown/build.default.workspace-404-markdown.spec.js
@@ -39,7 +39,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", function () {
   const LABEL =
     "Default Greenwood Configuration and Workspace w/Custom 404 Page in markdown and App Layout";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-404/build.default.workspace-404.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-404/build.default.workspace-404.spec.js
@@ -38,7 +38,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Workspace w/Custom 404 Page and App Layout";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-assets/build.default.workspace-assets.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-assets/build.default.workspace-assets.spec.js
@@ -24,7 +24,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "A Custom Assets Folder";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-frontmatter-imports/build.default.workspace-frontmatter-imports.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-frontmatter-imports/build.default.workspace-frontmatter-imports.spec.js
@@ -48,7 +48,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Workspace with Frontmatter Imports";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-getting-started/build.default.workspace-getting-started.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-getting-started/build.default.workspace-getting-started.spec.js
@@ -43,7 +43,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom Workspace based on the Getting Started guide and repo";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-javascript-css-remote/build.default.workspace-javascript-css-remote.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css-remote/build.default.workspace-javascript-css-remote.spec.js
@@ -29,7 +29,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Loading remote JavaScript and CSS using <script> and <link> tags";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-javascript-css/build.default.workspace-javascript-css.spec.js
@@ -33,7 +33,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Including JavaScript and CSS using <script>, <style>, and <link> tags";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-layouts-app/build.default.workspace-layouts-app.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-layouts-app/build.default.workspace-layouts-app.spec.js
@@ -32,7 +32,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Workspace w/Custom App Layout";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-layouts-empty/build.default.workspace-layouts-empty.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-layouts-empty/build.default.workspace-layouts-empty.spec.js
@@ -38,7 +38,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", function () {
   const LABEL =
     'Default Greenwood Configuration and Workspace w/Custom Page Layout for HTML "forgiveness"';
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-layouts-page-and-app-dynamic/build.default.workspace-layouts-page-and-app-dynamic.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-layouts-page-and-app-dynamic/build.default.workspace-layouts-page-and-app-dynamic.spec.js
@@ -33,7 +33,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", function () {
   const LABEL =
     "Default Greenwood Configuration and Workspace w/Custom Dynamic App and Page Layouts using JavaScript";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-layouts-page-and-app/build.default.workspace-layouts-page-and-app.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-layouts-page-and-app/build.default.workspace-layouts-page-and-app.spec.js
@@ -39,7 +39,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Workspace w/Custom App and Page Layouts";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-layouts-page-bare-merging/build.default.workspace-layouts-page-bare-merging.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-layouts-page-bare-merging/build.default.workspace-layouts-page-bare-merging.spec.js
@@ -30,7 +30,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration w/ Bare Page Merging";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-layouts-page/build.default.workspace-layouts-page.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-layouts-page/build.default.workspace-layouts-page.spec.js
@@ -32,7 +32,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Workspace w/Custom Page Layout";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-layouts-relative-paths/build.default.workspace-layouts-relative-paths.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-layouts-relative-paths/build.default.workspace-layouts-relative-paths.spec.js
@@ -45,7 +45,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", function () {
   const LABEL =
     "Default Greenwood Configuration and Workspace w/Custom App and Page Layout using relative paths";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-nested/build.default.workspace-nested.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-nested/build.default.workspace-nested.spec.js
@@ -57,7 +57,7 @@ function generatePageHref(pagePath) {
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Default Workspace w/ Nested Directories";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-special-characters/build.default.workspace-special-characters.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-special-characters/build.default.workspace-special-characters.spec.js
@@ -31,7 +31,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", function () {
   const LABEL =
     "Default Greenwood Configuration and Workspace with special characters in page names";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-top-level-pages/build.default.workspace-top-level-pages.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-top-level-pages/build.default.workspace-top-level-pages.spec.js
@@ -31,7 +31,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Default Workspace w/ Top Level Pages";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default.workspace-user-directory-mapping/build.default.workspace-user-directory-mapping.spec.js
+++ b/packages/cli/test/cases/build.default.workspace-user-directory-mapping/build.default.workspace-user-directory-mapping.spec.js
@@ -44,7 +44,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Workspace w/Naming Collisions";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.default/build.default.spec.js
+++ b/packages/cli/test/cases/build.default/build.default.spec.js
@@ -26,7 +26,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Workspace";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.plugins.adapter/build.config.plugins-adapter.spec.js
+++ b/packages/cli/test/cases/build.plugins.adapter/build.config.plugins-adapter.spec.js
@@ -47,7 +47,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Generic Adapter Plugin with SSR Pages + API Routes";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
+++ b/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
@@ -31,7 +31,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom Context Plugin and Default Workspace (aka Theme Packs)";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.plugins.copy/build.plugins.copy.spec.js
+++ b/packages/cli/test/cases/build.plugins.copy/build.plugins.copy.spec.js
@@ -25,7 +25,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "A Custom Copy Plugin";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.plugins.error-name/build.plugins.error-name.spec.js
+++ b/packages/cli/test/cases/build.plugins.error-name/build.plugins.error-name.spec.js
@@ -29,7 +29,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.plugins.error-provider/build.plugins.error-provider.spec.js
+++ b/packages/cli/test/cases/build.plugins.error-provider/build.plugins.error-provider.spec.js
@@ -30,7 +30,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.plugins.error-type/build.plugins.error-type.spec.js
+++ b/packages/cli/test/cases/build.plugins.error-type/build.plugins.error-type.spec.js
@@ -30,7 +30,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.plugins.resource/build.config.plugins-resource.spec.js
+++ b/packages/cli/test/cases/build.plugins.resource/build.config.plugins-resource.spec.js
@@ -41,7 +41,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom FooResource Plugin and Default Workspace";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
+++ b/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
@@ -46,7 +46,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom Sources Plugin and Custom Layout";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const publicDir = path.join(outputPath, "public");
   let runner;

--- a/packages/cli/test/cases/build.typescript.default/build.typescript.default.spec.js
+++ b/packages/cli/test/cases/build.typescript.default/build.typescript.default.spec.js
@@ -37,7 +37,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default TypeScript type-stripping";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/develop.config.active-content/develop.config.active-content.spec.js
+++ b/packages/cli/test/cases/develop.config.active-content/develop.config.active-content.spec.js
@@ -40,7 +40,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "Active Content";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/cli/test/cases/develop.config.base-path/develop.config.base-path.spec.js
+++ b/packages/cli/test/cases/develop.config.base-path/develop.config.base-path.spec.js
@@ -43,7 +43,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "Base Path Configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/cli/test/cases/develop.config.polyfills-import-attributes/develop.config.polyfills-import-attributes.spec.js
+++ b/packages/cli/test/cases/develop.config.polyfills-import-attributes/develop.config.polyfills-import-attributes.spec.js
@@ -34,7 +34,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "Import Attributes Polyfill Configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/cli/test/cases/develop.config.polyfills-import-maps/develop.config.polyfills-import-maps.spec.js
+++ b/packages/cli/test/cases/develop.config.polyfills-import-maps/develop.config.polyfills-import-maps.spec.js
@@ -33,7 +33,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "Import Maps Polyfill Configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/cli/test/cases/develop.default.hud-disabled/develop.default.hud-disabled.spec.js
+++ b/packages/cli/test/cases/develop.default.hud-disabled/develop.default.hud-disabled.spec.js
@@ -27,7 +27,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Workspace w/HUD disabled";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/cli/test/cases/develop.default.hud/develop.default.hud.spec.js
+++ b/packages/cli/test/cases/develop.default.hud/develop.default.hud.spec.js
@@ -27,7 +27,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Workspace w/HUD enabled";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -57,7 +57,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Workspace";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
+++ b/packages/cli/test/cases/develop.plugins.context/develop.plugins.context.spec.js
@@ -33,7 +33,7 @@ const packageJson = JSON.parse(
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "Custom Context Plugin and Default Workspace (aka Theme Packs)";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/cli/test/cases/develop.spa/develop.spa.spec.js
+++ b/packages/cli/test/cases/develop.spa/develop.spa.spec.js
@@ -31,7 +31,7 @@ function removeWhiteSpace(string = "") {
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "A Single Page Application (SPA)";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const BODY_REGEX = /<body>(.*)<\/body>/s;

--- a/packages/cli/test/cases/develop.ssr/develop.ssr.spec.js
+++ b/packages/cli/test/cases/develop.ssr/develop.ssr.spec.js
@@ -36,7 +36,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "A Server Rendered Project (SSR)";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://127.0.0.1:1984";
   let runner;

--- a/packages/cli/test/cases/develop.typescript.default/develop.typescript.default.spec.js
+++ b/packages/cli/test/cases/develop.typescript.default/develop.typescript.default.spec.js
@@ -26,7 +26,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "TypeScript support for resolving .ts files";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/cli/test/cases/develop.typescript.ssr/develop.typescript.ssr.spec.js
+++ b/packages/cli/test/cases/develop.typescript.ssr/develop.typescript.ssr.spec.js
@@ -32,7 +32,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) with API Routes in TypeScript";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://127.0.0.1:1984";
   let runner;

--- a/packages/cli/test/cases/eject.default/eject.default.spec.js
+++ b/packages/cli/test/cases/eject.default/eject.default.spec.js
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Eject Greenwood", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
   let configFiles;

--- a/packages/cli/test/cases/loaders-build.html-web-components/loaders-html-webcomponents.spec.js
+++ b/packages/cli/test/cases/loaders-build.html-web-components/loaders-html-webcomponents.spec.js
@@ -33,7 +33,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Prerendering with HTML Web Components";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/loaders-build.import-attributes/loaders-build.import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-build.import-attributes/loaders-build.import-attributes.spec.js
@@ -34,7 +34,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Import Attributes used in static pages";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost:8080";
   let runner;

--- a/packages/cli/test/cases/loaders-build.plugins.resource-page/loaders-build.plugins.resource-page.spec.js
+++ b/packages/cli/test/cases/loaders-build.plugins.resource-page/loaders-build.plugins.resource-page.spec.js
@@ -50,7 +50,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom Static and Dynamic Page Loaders";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/loaders-build.prerender-import-attributes/loaders-build.prerender-import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-build.prerender-import-attributes/loaders-build.prerender-import-attributes.spec.js
@@ -37,7 +37,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "ESM Import Attribute for CSS and JSON with prerendering";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/loaders-develop.ssr-import-attributes/loaders-develop.ssr-import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-develop.ssr-import-attributes/loaders-develop.ssr-import-attributes.spec.js
@@ -34,7 +34,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "Import Attributes used in API Routes and SSR Pages";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://127.0.0.1:1984";
   let runner;

--- a/packages/cli/test/cases/loaders-serve.config.polyfill-import-attributes/loaders-serve.config.polyfills-import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-serve.config.polyfill-import-attributes/loaders-serve.config.polyfills-import-attributes.spec.js
@@ -40,7 +40,7 @@ const expect = chai.expect;
 
 describe("Serve Greenwood With: ", function () {
   const LABEL = "Import Attributes Polyfill Configuration and prerendering";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputUrl = new URL(".", import.meta.url);
   const outputPath = fileURLToPath(outputUrl);
   const hostname = "http://127.0.0.1:8080";

--- a/packages/cli/test/cases/loaders-serve.default.ssr-import-attributes/loaders-serve.default.ssr-import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-serve.default.ssr-import-attributes/loaders-serve.default.ssr-import-attributes.spec.js
@@ -37,7 +37,7 @@ const expect = chai.expect;
 
 describe("Serve Greenwood With: ", function () {
   const LABEL = "Import Attributes used in API Routes and SSR Pages";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost:8080";
   let runner;

--- a/packages/cli/test/cases/serve.config.base-path/serve.config.base-path.spec.js
+++ b/packages/cli/test/cases/serve.config.base-path/serve.config.base-path.spec.js
@@ -43,7 +43,7 @@ const expect = chai.expect;
 
 describe("Serve Greenwood With: ", function () {
   const LABEL = "Base Path Configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const publicPath = path.join(outputPath, "public/");
   const hostname = "http://127.0.0.1:8080";

--- a/packages/cli/test/cases/serve.config.static-router/serve.config.static-router.spec.js
+++ b/packages/cli/test/cases/serve.config.static-router/serve.config.static-router.spec.js
@@ -32,7 +32,7 @@ const expect = chai.expect;
 
 describe("Serve Greenwood With: ", function () {
   const LABEL = "Static Router Configuration and Hybrid Workspace";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://127.0.0.1:8080";
   let runner;

--- a/packages/cli/test/cases/serve.default.api/serve.default.api.spec.js
+++ b/packages/cli/test/cases/serve.default.api/serve.default.api.spec.js
@@ -36,7 +36,7 @@ const expect = chai.expect;
 
 describe("Serve Greenwood With: ", function () {
   const LABEL = "API Routes";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://127.0.0.1:8080";
   let runner;

--- a/packages/cli/test/cases/serve.default.error/serve.default.error.spec.js
+++ b/packages/cli/test/cases/serve.default.error/serve.default.error.spec.js
@@ -23,7 +23,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Serve Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/serve.default.ssr-prerender-api-hybrid/serve.default.ssr-prerender-api-hybrid.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr-prerender-api-hybrid/serve.default.ssr-prerender-api-hybrid.spec.js
@@ -38,7 +38,7 @@ const expect = chai.expect;
 // https://github.com/ProjectEvergreen/greenwood/issues/1099
 describe("Serve Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) with prerender configuration and API routes";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const hostname = "http://127.0.0.1:8080";
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;

--- a/packages/cli/test/cases/serve.default.ssr-prerender/serve.default.ssr-prerender.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr-prerender/serve.default.ssr-prerender.spec.js
@@ -35,7 +35,7 @@ const expect = chai.expect;
 
 describe("Serve Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) with prerender configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const hostname = "http://127.0.0.1:8080";
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;

--- a/packages/cli/test/cases/serve.default.ssr-static-export/serve.default.ssr-static-export.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr-static-export/serve.default.ssr-static-export.spec.js
@@ -34,7 +34,7 @@ const expect = chai.expect;
 
 describe("Serve Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) that is statically exported";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const hostname = "http://127.0.0.1:8080";
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;

--- a/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr/serve.default.ssr.spec.js
@@ -46,7 +46,7 @@ const expect = chai.expect;
 
 describe("Serve Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR)";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://127.0.0.1:8181";
   let runner;

--- a/packages/cli/test/cases/serve.default/serve.default.spec.js
+++ b/packages/cli/test/cases/serve.default/serve.default.spec.js
@@ -45,7 +45,7 @@ const expect = chai.expect;
 
 describe("Serve Greenwood With: ", function () {
   const LABEL = "Default Greenwood Configuration and Workspace";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost:8181";
   let runner;

--- a/packages/cli/test/cases/serve.spa/serve.spa.spec.js
+++ b/packages/cli/test/cases/serve.spa/serve.spa.spec.js
@@ -33,7 +33,7 @@ function removeWhiteSpace(string = "") {
 
 describe("Serve Greenwood With: ", function () {
   const LABEL = "A Single Page Application (SPA)";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const BODY_REGEX = /<body>(.*)<\/body>/s;

--- a/packages/cli/test/cases/serve.typescript.prerender/serve.typescript.prerender.spec.js
+++ b/packages/cli/test/cases/serve.typescript.prerender/serve.typescript.prerender.spec.js
@@ -32,7 +32,7 @@ const expect = chai.expect;
 describe("Serve Greenwood With: ", function () {
   const LABEL =
     "A Prerendered Application (SSR) with an HTML page importing a TypeScript component";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://127.0.0.1:8080";
   let runner;

--- a/packages/cli/test/cases/serve.typescript.ssr/serve.typescript.ssr.spec.js
+++ b/packages/cli/test/cases/serve.typescript.ssr/serve.typescript.ssr.spec.js
@@ -38,7 +38,7 @@ const expect = chai.expect;
 
 describe("Serve Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) with API Routes in TypeScript";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost:8080";
   let runner;

--- a/packages/cli/test/cases/theme-pack/theme-pack.build.spec.js
+++ b/packages/cli/test/cases/theme-pack/theme-pack.build.spec.js
@@ -38,7 +38,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Development environment for a Theme Pack";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/cli/test/cases/theme-pack/theme-pack.develop.spec.js
+++ b/packages/cli/test/cases/theme-pack/theme-pack.develop.spec.js
@@ -40,7 +40,7 @@ const packageJson = JSON.parse(
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "Development environment for a Theme Pack";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/init/test/cases/build.default/build.default.spec.js
+++ b/packages/init/test/cases/build.default/build.default.spec.js
@@ -43,7 +43,7 @@ describe("Initialize a new Greenwood project: ", function () {
     });
 
     describe(`should build with the Greenwood CLI and have all standard build output files`, function () {
-      const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+      const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
 
       before(function () {
         runner.setup(initOutputPath);

--- a/packages/init/test/cases/develop.default/develop.default.spec.js
+++ b/packages/init/test/cases/develop.default/develop.default.spec.js
@@ -44,7 +44,7 @@ describe("Initialize a new Greenwood project: ", function () {
     });
 
     describe("should run the Greenwood dev server", function () {
-      const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+      const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
 
       before(async function () {
         runner.setup(initOutputPath);

--- a/packages/init/test/cases/init.options.install-npm/init.options.install-npm.spec.js
+++ b/packages/init/test/cases/init.options.install-npm/init.options.install-npm.spec.js
@@ -42,7 +42,7 @@ describe("Initialize a new Greenwood project: ", function () {
     });
 
     describe("should install with npm", function () {
-      const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+      const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
 
       before(function () {
         runner.setup(initOutputPath);

--- a/packages/init/test/cases/init.options.install-pnpm/init.options.install-pnpm.spec.js
+++ b/packages/init/test/cases/init.options.install-pnpm/init.options.install-pnpm.spec.js
@@ -42,7 +42,7 @@ describe("Initialize a new Greenwood project: ", function () {
     });
 
     describe("should install with pnpm", function () {
-      const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+      const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
 
       before(function () {
         runner.setup(initOutputPath);

--- a/packages/init/test/cases/init.options.install-yarn/init.options.install-yarn.spec.js
+++ b/packages/init/test/cases/init.options.install-yarn/init.options.install-yarn.spec.js
@@ -42,7 +42,7 @@ describe("Initialize a new Greenwood project: ", function () {
     });
 
     describe("should install with Yarn", function () {
-      const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+      const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
 
       before(function () {
         runner.setup(initOutputPath);

--- a/packages/plugin-adapter-aws/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-adapter-aws/test/cases/build.default/build.default.spec.js
@@ -56,7 +56,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "AWS Adapter plugin output";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const awsOutputFolder = new URL("./.aws-output/", import.meta.url);
   const awsApiFunctionsOutputUrl = new URL("./api/", awsOutputFolder);

--- a/packages/plugin-adapter-netlify/test/cases/build.config.base-path/build.config.base-path.spec.js
+++ b/packages/plugin-adapter-netlify/test/cases/build.config.base-path/build.config.base-path.spec.js
@@ -42,7 +42,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", function () {
   const LABEL = "Netlify Adapter plugin output w/ base path configuration";
   const basePath = "/my-app";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const netlifyFunctionsOutputUrl = new URL("./netlify/functions/", import.meta.url);
   let runner;

--- a/packages/plugin-adapter-netlify/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-adapter-netlify/test/cases/build.default/build.default.spec.js
@@ -57,7 +57,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Netlify Adapter plugin output";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const netlifyFunctionsOutputUrl = new URL("./netlify/functions/", import.meta.url);
   const hostname = "http://www.example.com";

--- a/packages/plugin-adapter-vercel/test/cases/build.config.base-path/build.config.base-path.spec.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.config.base-path/build.config.base-path.spec.js
@@ -44,7 +44,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", function () {
   const LABEL = "Vercel Adapter plugin output and custom base path";
   const basePath = "/my-app";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const vercelOutputFolder = new URL("./.vercel/output/", import.meta.url);
   const vercelFunctionsOutputUrl = new URL("./functions/", vercelOutputFolder);

--- a/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/build.default.options-runtime.spec.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.default.options-runtime/build.default.options-runtime.spec.js
@@ -42,7 +42,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Vercel Adapter plugin output with runtime option set";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const vercelOutputFolder = new URL("./.vercel/output/", import.meta.url);
   const vercelFunctionsOutputUrl = new URL("./functions/", vercelOutputFolder);

--- a/packages/plugin-adapter-vercel/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.default/build.default.spec.js
@@ -59,7 +59,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Vercel Adapter plugin output";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const vercelOutputFolder = new URL("./.vercel/output/", import.meta.url);
   const vercelFunctionsOutputUrl = new URL("./functions/", vercelOutputFolder);

--- a/packages/plugin-babel/test/cases/default/default.spec.js
+++ b/packages/plugin-babel/test/cases/default/default.spec.js
@@ -38,7 +38,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Babel configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-babel/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-babel/test/cases/options.extend-config/options.extend-config.spec.js
@@ -48,7 +48,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom Babel Options for extending Default Configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-css-modules/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-css-modules/test/cases/build.default/build.default.spec.js
@@ -44,7 +44,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Configuration for CSS Modules";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
   let updateAStyleBlockRef;

--- a/packages/plugin-css-modules/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-css-modules/test/cases/develop.default/develop.default.spec.js
@@ -42,7 +42,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "Default Configuration for CSS Modules";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/plugin-css-modules/test/cases/loaders-build.prerender/loaders-build.prerender.spec.js
+++ b/packages/plugin-css-modules/test/cases/loaders-build.prerender/loaders-build.prerender.spec.js
@@ -48,7 +48,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default Configuration for CSS Modules with pre-rendering";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
   let updateAStyleBlockRef;

--- a/packages/plugin-google-analytics/test/cases/default/default.spec.js
+++ b/packages/plugin-google-analytics/test/cases/default/default.spec.js
@@ -36,7 +36,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", function () {
   const LABEL = "Google Analytics Plugin with default options and Default Workspace";
   const mockAnalyticsId = "UA-123456-1";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-google-analytics/test/cases/error-analytics-id/error-analytics-id.spec.js
+++ b/packages/plugin-google-analytics/test/cases/error-analytics-id/error-analytics-id.spec.js
@@ -29,7 +29,7 @@ import { fileURLToPath } from "node:url";
 const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
+++ b/packages/plugin-google-analytics/test/cases/option-anonymous/option-anonymous.spec.js
@@ -38,7 +38,7 @@ describe("Build Greenwood With: ", function () {
   const LABEL =
     "Google Analytics Plugin with IP Anonymization tracking set to false and Default Workspace";
   const mockAnalyticsId = "UA-123456-1";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-graphql/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-graphql/test/cases/develop.default/develop.default.spec.js
@@ -28,7 +28,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "GraphQL plugin for resolving client facing files";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/plugin-graphql/test/cases/loaders-prerender.query-children/loaders-prerender.query-children.spec.js
+++ b/packages/plugin-graphql/test/cases/loaders-prerender.query-children/loaders-prerender.query-children.spec.js
@@ -39,7 +39,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", function () {
   const LABEL = "Prerendered Children from GraphQL";
   const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-graphql/test/cases/qraphql-server/graphql-server.spec.js
+++ b/packages/plugin-graphql/test/cases/qraphql-server/graphql-server.spec.js
@@ -23,7 +23,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "GraphQL Server";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "localhost";
   const port = 4000;

--- a/packages/plugin-graphql/test/cases/query-children/query-children.spec.js
+++ b/packages/plugin-graphql/test/cases/query-children/query-children.spec.js
@@ -39,7 +39,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", function () {
   const LABEL = "Children from GraphQL";
   const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-graphql/test/cases/query-collection/query-collection.spec.js
+++ b/packages/plugin-graphql/test/cases/query-collection/query-collection.spec.js
@@ -39,7 +39,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", async function () {
   const LABEL = "CollectionQuery from GraphQL";
   const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-graphql/test/cases/query-custom-frontmatter/query-custom-frontmatter.spec.js
+++ b/packages/plugin-graphql/test/cases/query-custom-frontmatter/query-custom-frontmatter.spec.js
@@ -41,7 +41,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom GraphQuery for Front Matter from GraphQL";
   const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-graphql/test/cases/query-custom-schema/query-custom-schema.spec.js
+++ b/packages/plugin-graphql/test/cases/query-custom-schema/query-custom-schema.spec.js
@@ -36,7 +36,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom Query from GraphQL";
   const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
+++ b/packages/plugin-graphql/test/cases/query-graph/query-graph.spec.js
@@ -37,7 +37,7 @@ const expect = chai.expect;
 describe("Build Greenwood With: ", function () {
   const LABEL = "Graph from GraphQL";
   const apolloStateRegex = /window.__APOLLO_STATE__ = true/;
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-import-commonjs/test/cases/default/default.spec.js
+++ b/packages/plugin-import-commonjs/test/cases/default/default.spec.js
@@ -39,7 +39,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Import CommonJs Plugin with default options";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-import-css/test/cases/default/default.spec.js
+++ b/packages/plugin-import-css/test/cases/default/default.spec.js
@@ -37,7 +37,7 @@ const expect = chai.expect;
 
 xdescribe("Build Greenwood With: ", function () {
   const LABEL = "Import CSS Plugin with default options";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-css/test/cases/develop.default/develop.default.spec.js
@@ -32,7 +32,7 @@ const expect = chai.expect;
 
 xdescribe("Develop Greenwood With: ", function () {
   const LABEL = "Import CSS plugin for using ESM with .css files";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/plugin-import-css/test/cases/exp-build.prerender/exp-build.prerender.spec.js
+++ b/packages/plugin-import-css/test/cases/exp-build.prerender/exp-build.prerender.spec.js
@@ -41,7 +41,7 @@ const expect = chai.expect;
 
 xdescribe("(Experimental) Build Greenwood With: ", function () {
   const LABEL = "Import CSS Plugin with static pre-rendering";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-import-css/test/cases/exp-serve.ssr/exp-serve.ssr.spec.js
+++ b/packages/plugin-import-css/test/cases/exp-serve.ssr/exp-serve.ssr.spec.js
@@ -40,7 +40,7 @@ const expect = chai.expect;
 
 xdescribe("Serve Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) with API Routes importing CSS";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost:8080";
   let runner;

--- a/packages/plugin-import-json/test/cases/default/default.spec.js
+++ b/packages/plugin-import-json/test/cases/default/default.spec.js
@@ -39,7 +39,7 @@ const expect = chai.expect;
 
 xdescribe("Build Greenwood With: ", function () {
   const LABEL = "Import JSON Plugin with default options";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-json/test/cases/develop.default/develop.default.spec.js
@@ -33,7 +33,7 @@ const expect = chai.expect;
 
 xdescribe("Develop Greenwood With: ", function () {
   const LABEL = "Import JSON plugin for using ESM with .json files";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/plugin-import-json/test/cases/exp-build.prerender/exp-build.prerender.spec.js
+++ b/packages/plugin-import-json/test/cases/exp-build.prerender/exp-build.prerender.spec.js
@@ -41,7 +41,7 @@ const expect = chai.expect;
 
 xdescribe("(Experimental) Build Greenwood With: ", function () {
   const LABEL = "Import JSON Plugin with static pre-rendering";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-import-json/test/cases/exp-serve.ssr/exp-serve.ssr.spec.js
+++ b/packages/plugin-import-json/test/cases/exp-serve.ssr/exp-serve.ssr.spec.js
@@ -37,7 +37,7 @@ const expect = chai.expect;
 
 xdescribe("Serve Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) with API Routes importing JSON";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost:8080";
   let runner;

--- a/packages/plugin-import-jsx/test/cases/default/default.prerender.spec.js
+++ b/packages/plugin-import-jsx/test/cases/default/default.prerender.spec.js
@@ -40,7 +40,7 @@ const expect = chai.expect;
 
 describe("(Experimental) Build Greenwood With: ", function () {
   const LABEL = "Import JSX Plugin for client side bundling";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-import-jsx/test/cases/loaders-build.prerender/loaders-build.prerender.spec.js
+++ b/packages/plugin-import-jsx/test/cases/loaders-build.prerender/loaders-build.prerender.spec.js
@@ -42,7 +42,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Import JSX Plugin with static pre-rendering";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-import-raw/test/cases/build.matchers/build.matchers.spec.js
+++ b/packages/plugin-import-raw/test/cases/build.matchers/build.matchers.spec.js
@@ -40,7 +40,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Import Raw Plugin with matchers configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-import-raw/test/cases/default/default.spec.js
+++ b/packages/plugin-import-raw/test/cases/default/default.spec.js
@@ -37,7 +37,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Import Raw Plugin with default options";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-import-raw/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-raw/test/cases/develop.default/develop.default.spec.js
@@ -33,7 +33,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "Import Raw plugin for using ESM with arbitrary files as strings";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/plugin-import-raw/test/cases/loaders-build.prerender/loaders-build.prerender.spec.js
+++ b/packages/plugin-import-raw/test/cases/loaders-build.prerender/loaders-build.prerender.spec.js
@@ -41,7 +41,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Import Raw Plugin with static pre-rendering for CSS as a string";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-import-raw/test/cases/loaders-serve.ssr/loaders-serve.ssr.spec.js
+++ b/packages/plugin-import-raw/test/cases/loaders-serve.ssr/loaders-serve.ssr.spec.js
@@ -40,7 +40,7 @@ const expect = chai.expect;
 
 describe("Serve Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) with API Routes importing raw CSS";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost:8080";
   let runner;

--- a/packages/plugin-include-html/test/cases/build.default-custom-element/build.default.custom-element.spec.js
+++ b/packages/plugin-include-html/test/cases/build.default-custom-element/build.default.custom-element.spec.js
@@ -37,7 +37,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With HTML Include Plugin: ", function () {
   const LABEL = "Using Custom Element feature";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-include-html/test/cases/build.default-link-tag/build.default.link-tag.spec.js
+++ b/packages/plugin-include-html/test/cases/build.default-link-tag/build.default.link-tag.spec.js
@@ -37,7 +37,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With HTML Include Plugin: ", function () {
   const LABEL = "Using Link Tag feature";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-polyfills/test/cases/default/default.spec.js
+++ b/packages/plugin-polyfills/test/cases/default/default.spec.js
@@ -44,7 +44,7 @@ const expectedPolyfillFiles = [
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Polyfill Plugin with default options and Default Workspace";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-polyfills/test/cases/dsd/dsd.spec.js
+++ b/packages/plugin-polyfills/test/cases/dsd/dsd.spec.js
@@ -32,7 +32,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Declarative Shadow DOM Polyfill Plugin with default options and Default Workspace";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-polyfills/test/cases/lit/lit.spec.js
+++ b/packages/plugin-polyfills/test/cases/lit/lit.spec.js
@@ -35,7 +35,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Lit Polyfill Plugin with default options and Default Workspace";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-postcss/test/cases/default/default.spec.js
+++ b/packages/plugin-postcss/test/cases/default/default.spec.js
@@ -37,7 +37,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default PostCSS configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-postcss/test/cases/loaders-default.import-attributes/loaders-default.import-attributes.spec.js
+++ b/packages/plugin-postcss/test/cases/loaders-default.import-attributes/loaders-default.import-attributes.spec.js
@@ -41,7 +41,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Default PostCSS configuration and CSS Import Attributes";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-postcss/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-postcss/test/cases/options.extend-config/options.extend-config.spec.js
@@ -44,7 +44,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Custom PostCSS configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-renderer-lit/test/cases/build.prerender.getting-started/build.prerender.getting-started.spec.js
+++ b/packages/plugin-renderer-lit/test/cases/build.prerender.getting-started/build.prerender.getting-started.spec.js
@@ -50,7 +50,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With Custom Lit Renderer for SSG prerendering: ", function () {
   const LABEL = "For SSG prerendering of Getting Started example";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-renderer-lit/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-renderer-lit/test/cases/develop.default/develop.default.spec.js
@@ -33,7 +33,7 @@ const expect = chai.expect;
 
 describe("Develop Greenwood With: ", function () {
   const LABEL = "Lit Renderer";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://127.0.0.1:1984";
   let runner;

--- a/packages/plugin-renderer-lit/test/cases/loaders-build.prerender.import-attributes/loaders-build.prerender.import-attributes.spec.js
+++ b/packages/plugin-renderer-lit/test/cases/loaders-build.prerender.import-attributes/loaders-build.prerender.import-attributes.spec.js
@@ -42,7 +42,7 @@ const expect = chai.expect;
 // https://github.com/ProjectEvergreen/greenwood/issues/1463
 xdescribe("Build Greenwood With Custom Lit Renderer for SSG prerendering: ", function () {
   const LABEL = "For SSG prerendering of Getting Started example";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-renderer-lit/test/cases/serve.default/serve.default.spec.js
+++ b/packages/plugin-renderer-lit/test/cases/serve.default/serve.default.spec.js
@@ -43,7 +43,7 @@ const expect = chai.expect;
 
 describe("Serve Greenwood With: ", function () {
   const LABEL = "Custom Lit Renderer for SSR";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost:8080";
   let runner;

--- a/packages/plugin-renderer-puppeteer/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-renderer-puppeteer/test/cases/build.default/build.default.spec.js
@@ -38,7 +38,7 @@ const expect = chai.expect;
 
 describe("Build Greenwood With: ", function () {
   const LABEL = "Puppeteer prerendering enabled";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-typescript/test/cases/default/default.spec.js
+++ b/packages/plugin-typescript/test/cases/default/default.spec.js
@@ -48,7 +48,7 @@ const expect = chai.expect;
 
 xdescribe("Build Greenwood With: ", function () {
   const LABEL = "Default TypeScript configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-typescript/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-typescript/test/cases/develop.default/develop.default.spec.js
@@ -26,7 +26,7 @@ const expect = chai.expect;
 
 xdescribe("Develop Greenwood With: ", function () {
   const LABEL = "TypeScript plugin for resolving .ts files";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;

--- a/packages/plugin-typescript/test/cases/loaders-build.resource-page/loaders-build.resource-page.spec.js
+++ b/packages/plugin-typescript/test/cases/loaders-build.resource-page/loaders-build.resource-page.spec.js
@@ -36,7 +36,7 @@ const expect = chai.expect;
 
 xdescribe("Build Greenwood With: ", function () {
   const LABEL = "Custom TypeScript Plugin and Default Workspace serving a page";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/packages/plugin-typescript/test/cases/loaders-develop.ssr/loaders-develop.ssr.spec.js
+++ b/packages/plugin-typescript/test/cases/loaders-develop.ssr/loaders-develop.ssr.spec.js
@@ -37,7 +37,7 @@ const expect = chai.expect;
 
 xdescribe("Develop Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) with API Routes in TypeScript";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://127.0.0.1:1984";
   let runner;

--- a/packages/plugin-typescript/test/cases/loaders-serve.prerender-ssr/loaders-serve.prerender-ssr.spec.js
+++ b/packages/plugin-typescript/test/cases/loaders-serve.prerender-ssr/loaders-serve.prerender-ssr.spec.js
@@ -35,7 +35,7 @@ const expect = chai.expect;
 xdescribe("Serve Greenwood With: ", function () {
   const LABEL =
     "A Prerendered Application (SSR) with an HTML page importing a TypeScript component";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://127.0.0.1:8080";
   let runner;

--- a/packages/plugin-typescript/test/cases/loaders-serve.ssr/loaders-serve.ssr.spec.js
+++ b/packages/plugin-typescript/test/cases/loaders-serve.ssr/loaders-serve.ssr.spec.js
@@ -39,7 +39,7 @@ const expect = chai.expect;
 
 xdescribe("Serve Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) with API Routes in TypeScript";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost:8080";
   let runner;

--- a/packages/plugin-typescript/test/cases/options.extend-config/options.extend-config.spec.js
+++ b/packages/plugin-typescript/test/cases/options.extend-config/options.extend-config.spec.js
@@ -48,7 +48,7 @@ const expect = chai.expect;
 
 xdescribe("Build Greenwood With: ", function () {
   const LABEL = "Custom TypeScript Options for extending Default Configuration";
-  const cliPath = path.join(process.cwd(), "packages/cli/src/index.js");
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "preserve",
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": false,
+    "verbatimModuleSyntax": true,
     "noEmit": true,
     "checkJs": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

https://github.com/ProjectEvergreen/greenwood/issues/1518#issuecomment-2993815683

## Documentation 

1. [x] https://github.com/ProjectEvergreen/www.greenwoodjs.dev/issues/219

## Summary of Changes

1. Export the `run` function side effect in the CLI entry point (this is nice, because now our entry point has no side-effects)
1. Created dedicated `bin` entry point file and updated CLI `bin` field
1. Update test cases for new `bin` entry point path

## TODOs / Questions
1. [x] Misc refactoring in _bin.js_
1. [x] If this does resolve [the original observed issue](https://github.com/thescientist13/greenwood-loops), then should we recommend this convention in the [website docs]( https://greenwoodjs.dev/docs/resources/typescript/) / init scaffolding [_tsconfig.json_](https://github.com/ProjectEvergreen/greenwood/blob/v0.33.0-alpha.1/packages/init/src/template-base-ts/tsconfig.json#L7) (probably yes since I think it leans well into type stripping / being more explicit?)