### PR TITLE
enhancement/issue 1427 enable full typechecking for the monorepo

### DIFF
--- a/greenwood.config.test-types.ts
+++ b/greenwood.config.test-types.ts
@@ -65,7 +65,7 @@ const config: Config = {
     greenwoodPluginGraphQL(),
     greenwoodPluginImportCommonJs(),
     greenwoodPluginImportJsx(),
-    greenwoodPluginImportRaw,
+    greenwoodPluginImportRaw(),
     greenwoodPluginIncludeHTML(),
     greenwoodPluginPolyfills(),
     greenwoodPluginPostCss(),

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lint:types": "tsc --project ./tsconfig.json",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
-    "prepare": "husky"
+    "prepare": "husky",
+    "postinstall": "patch-package"
   },
   "devDependencies": {
     "@babel/core": "^7.24.4",
@@ -59,6 +60,7 @@
     "lerna": "^3.16.4",
     "lint-staged": "^15.4.3",
     "mocha": "^9.1.3",
+    "patch-package": "^8.0.0",
     "prettier": "^3.4.2",
     "rimraf": "^5.0.10",
     "typescript": "^5.8.2"

--- a/packages/cli/src/data/client.js
+++ b/packages/cli/src/data/client.js
@@ -8,7 +8,6 @@ const PRERENDER = globalThis.__CONTENT_OPTIONS__?.PRERENDER === "true";
 const PORT = globalThis?.__CONTENT_OPTIONS__?.PORT ?? 1984;
 const BASE_PATH = globalThis?.__GWD_BASE_PATH__ ?? "";
 
-/** @type {import('../types/content.d.ts').Graph} */
 async function getContentAsData(key = "") {
   if (CONTENT_STATE && PRERENDER) {
     // fetch customized query files when a user has opted-in for prerendering with active content

--- a/packages/cli/src/loader.js
+++ b/packages/cli/src/loader.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { readAndMergeConfig } from "./lifecycles/config.js";
 import { initContext } from "./lifecycles/context.js";
 import { mergeResponse } from "./lib/resource-utils.js";

--- a/packages/cli/src/plugins/resource/plugin-typescript.js
+++ b/packages/cli/src/plugins/resource/plugin-typescript.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /*
  *
  * Manages resource related operations for TypeScript.

--- a/packages/cli/src/types/plugins.d.ts
+++ b/packages/cli/src/types/plugins.d.ts
@@ -32,7 +32,7 @@ export interface Plugin {
 // https://greenwoodjs.dev/docs/reference/plugins-api/#adapter
 export interface AdapterPlugin extends Plugin {
   type: Extract<PLUGIN_TYPES, "adapter">;
-  provider: (compilation: Compilation) => Promise<Function>;
+  provider: (compilation: Compilation) => Promise;
 }
 
 // https://greenwoodjs.dev/docs/reference/plugins-api/#context

--- a/packages/init/src/index.js
+++ b/packages/init/src/index.js
@@ -31,9 +31,9 @@ const PACKAGE_MANAGERS = [
 async function init() {
   try {
     const CWD = process.cwd();
-    const packageJson = (
-      await import(new URL("../package.json", import.meta.url), { with: { type: "json" } })
-    ).default;
+    const packageJson = // @ts-expect-error see https://github.com/microsoft/TypeScript/issues/42866
+      (await import(new URL("../package.json", import.meta.url), { with: { type: "json" } }))
+        .default;
     const { name, version } = packageJson;
 
     console.log(
@@ -50,18 +50,17 @@ async function init() {
       .option("-y, --yes", "Accept all default options")
       .option("--name <name>", "Name and directory location to scaffold your application with")
       .addOption(
-        new Option(
-          "--ts [choice]",
-          "Optionally configure your project with TypeScript",
-          DEFAULTS.ts,
-        ).choices(["yes", "no"]),
+        new Option("--ts [choice]", "Optionally configure your project with TypeScript")
+          .choices(["yes", "no"])
+          .default(DEFAULTS.ts),
       )
       .addOption(
         new Option(
           "-i, --install <choice>",
           "Install dependencies with the package manager of your choice",
-          DEFAULTS.install,
-        ).choices(PACKAGE_MANAGERS.map((manager) => manager.name.toLowerCase()).concat("no")),
+        )
+          .choices(PACKAGE_MANAGERS.map((manager) => manager.name.toLowerCase()).concat("no"))
+          .default(DEFAULTS.install),
       )
       .parse(process.argv)
       .opts();

--- a/packages/init/src/util.js
+++ b/packages/init/src/util.js
@@ -25,7 +25,7 @@ function setupPackageJson(outputDirUrl, { name, version }) {
   console.log("setting up package.json...");
 
   const packageJsonOutputUrl = new URL("./package.json", outputDirUrl);
-  const pkgJson = JSON.parse(fs.readFileSync(packageJsonOutputUrl));
+  const pkgJson = JSON.parse(fs.readFileSync(packageJsonOutputUrl, "utf-8"));
   const json = {};
 
   // setup standard fields

--- a/packages/plugin-css-modules/src/index.js
+++ b/packages/plugin-css-modules/src/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /*
  *
  * A plugin for enabling CSS Modules. :tm:

--- a/packages/plugin-google-analytics/src/index.js
+++ b/packages/plugin-google-analytics/src/index.js
@@ -52,7 +52,7 @@ class GoogleAnalyticsResource {
 }
 
 /** @type {import('./types/index.d.ts').GoogleAnalyticsPlugin} */
-const greenwoodPluginGoogleAnalytics = (options = {}) => {
+const greenwoodPluginGoogleAnalytics = (options) => {
   return [
     {
       type: "resource",

--- a/packages/plugin-import-commonjs/src/index.js
+++ b/packages/plugin-import-commonjs/src/index.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /*
  *
  * Detects and fully resolves import requests for CommonJS files in node_modules.

--- a/patches/wc-compiler+0.17.0.patch
+++ b/patches/wc-compiler+0.17.0.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/wc-compiler/src/index.d.ts b/node_modules/wc-compiler/src/index.d.ts
+index 3c32133..5d24936 100644
+--- a/node_modules/wc-compiler/src/index.d.ts
++++ b/node_modules/wc-compiler/src/index.d.ts
+@@ -16,4 +16,7 @@ export type renderFromHTML = (html: string, elementURLs: URL[]) => Promise<{
+   metadata: Metadata
+ }>
+ 
+-declare module "wc-compiler" { }
+\ No newline at end of file
++declare module "wc-compiler" { 
++  export const renderToString: renderToString;
++  export const renderFromHTML: renderFromHTML;
++}
+\ No newline at end of file

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,11 @@
     "skipLibCheck": true,
     "types": ["acorn", "acorn-walk", "mocha"]
   },
-  "include": ["./packages/*/src/types/*.d.ts", "./*.ts"],
   "exclude": [
+    ".greenwood/",
+    "coverage/",
     "public/",
+    "./packages/init/src/template-base/src/components/logo/logo.js",
     "./packages/cli/test/cases/develop.config.polyfills-import-attributes/src/components/hero.js",
     "./packages/**/test/**",
     "./test/**",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5839,6 +5839,11 @@
     merge-options "^3.0.4"
     p-event "^5.0.1"
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"
@@ -6574,6 +6579,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 atob-lite@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/atob-lite/-/atob-lite-2.0.0.tgz#0fef5ad46f1bd7a8502c65727f0367d5ee43d696"
@@ -7132,6 +7142,14 @@ call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
 
+call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
@@ -7149,6 +7167,14 @@ call-bind@^1.0.8:
     es-define-property "^1.0.0"
     get-intrinsic "^1.2.4"
     set-function-length "^1.2.2"
+
+call-bound@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
+  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    get-intrinsic "^1.3.0"
 
 call-me-maybe@^1.0.1:
   version "1.0.1"
@@ -7447,6 +7473,11 @@ ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
+ci-info@^3.7.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
 cjs-module-lexer@^1.0.0:
   version "1.0.0"
@@ -9278,7 +9309,7 @@ es-module-shims@^1.8.3:
   resolved "https://registry.yarnpkg.com/es-module-shims/-/es-module-shims-1.8.3.tgz#e3e61c54f197b5868d6d9c399168d1c27b3aaaf9"
   integrity sha512-NOE2WomYkoXeae8FcwPwZApxDwKerEWGOiqNo/P2JCBkJgKCLA5+PMZs8sr/1SPk9a8E+hUE9Wc+YZyGEiWHkw==
 
-es-object-atoms@^1.0.0:
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
@@ -10118,6 +10149,13 @@ find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flat-cache@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-4.0.1.tgz#0ece39fcb14ee012f4b0410bd33dd9c1f011127c"
@@ -10325,6 +10363,16 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-minipass@^1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
@@ -10485,6 +10533,22 @@ get-intrinsic@^1.2.4:
     hasown "^2.0.2"
     math-intrinsics "^1.1.0"
 
+get-intrinsic@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
 get-pkg-repo@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz#c73b489c06d80cc5536c2c853f9e05232056972d"
@@ -10511,7 +10575,7 @@ get-port@^6.1.2:
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-6.1.2.tgz#c1228abb67ba0e17fb346da33b15187833b9c08a"
   integrity sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==
 
-get-proto@^1.0.0:
+get-proto@^1.0.0, get-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
   integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
@@ -12160,7 +12224,7 @@ is-windows@^1.0.0, is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-is-wsl@2.2.0, is-wsl@^2.2.0:
+is-wsl@2.2.0, is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
@@ -12176,6 +12240,11 @@ isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 iserror@0.0.2, iserror@^0.0.2:
   version "0.0.2"
@@ -12388,6 +12457,17 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json-stable-stringify@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz#8903cfac42ea1a0f97f35d63a4ce0518f0cc6a70"
+  integrity sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    isarray "^2.0.5"
+    jsonify "^0.0.1"
+    object-keys "^1.1.1"
+
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -12409,6 +12489,20 @@ jsonfile@^4.0.0:
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonify@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
+  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
 
 jsonparse@^1.2.0:
   version "1.3.1"
@@ -12523,6 +12617,13 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 koa-body@^6.0.1:
   version "6.0.1"
@@ -14994,6 +15095,14 @@ open-props@^1.7.4:
   resolved "https://registry.yarnpkg.com/open-props/-/open-props-1.7.15.tgz#d5b870507869124d3591a9e82ad2c505b4cd2a6c"
   integrity sha512-TvyN35N02w1wmIsz6SUInEo0RaVvSvIj794qlHjkmeTFuBYu2vzV6LbZyE5D8/c5UsGtRudl4ScK1jkabPBpGw==
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 open@^8.0.4:
   version "8.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
@@ -15458,6 +15567,27 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+patch-package@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-8.0.0.tgz#d191e2f1b6e06a4624a0116bcb88edd6714ede61"
+  integrity sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^4.1.2"
+    ci-info "^3.7.0"
+    cross-spawn "^7.0.3"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^9.0.0"
+    json-stable-stringify "^1.0.2"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.6"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^7.5.3"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    yaml "^2.2.2"
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -19047,6 +19177,11 @@ universalify@^0.1.0, universalify@^0.1.2:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+universalify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
+  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
+
 unix-dgram@2.x:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/unix-dgram/-/unix-dgram-2.0.6.tgz#6d567b0eb6d7a9504e561532b598a46e34c5968b"
@@ -19703,6 +19838,11 @@ yaml@^2.1.3:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.3.1.tgz#02fe0975d23cd441242aa7204e09fc28ac2ac33b"
   integrity sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==
+
+yaml@^2.2.2:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.0.tgz#15f8c9866211bdc2d3781a0890e44d4fa1a5fff6"
+  integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==
 
 yaml@^2.7.0:
   version "2.7.0"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to https://github.com/ProjectEvergreen/greenwood/issues/1427

## Documentation 

N / A

## Summary of Changes

1. Enable full typecheck for the monorepo
1. Resolved a few misc issues

## TODO
1. [ ] Verify change to Adapter types are compatible
1. [ ] enable `noImplicitAny` per #1531 
1. [ ] Double check changes to init default options still work as expected
1. [ ] Why is greenwood type config not catching plugin errors? - https://github.com/ProjectEvergreen/greenwood/pull/1524/files#r2173252332
1. [ ] Upstream correct types into WCC