### PR TITLE
bug/issue 1475 tweak SSR pre-rendering markers settings for top level dynamic pages

### DIFF
--- a/packages/cli/src/lib/layout-utils.js
+++ b/packages/cli/src/lib/layout-utils.js
@@ -221,7 +221,7 @@ async function mergeContentIntoLayout(
       outletType === "content"
         ? /<content-outlet><\/content-outlet>/
         : /<page-outlet><\/page-outlet>/;
-    const finalBody =
+    let finalBody =
       parentBody && parentBody.match(outletRegex)
         ? parentBody.replace(outletRegex, childBody ?? childContents)
         : childRoot.querySelector("html") && childBody
@@ -229,6 +229,12 @@ async function mergeContentIntoLayout(
           : !childRoot.querySelector("html")
             ? childContents
             : "";
+
+    // we wrap SSR content in comments so we can extract it during prerendering to avoid double pre-rendering
+    // TODO is this a bit of a leaky abstraction?
+    if (matchingRoute.isSSR && outletType === "content") {
+      finalBody = `<!-- greenwood-ssr-start -->${finalBody}<!-- greenwood-ssr-end -->`;
+    }
 
     mergedContents = `<!DOCTYPE html>
       ${mergedHtml}

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -162,8 +162,7 @@ class StandardHtmlResource {
     } else if (matchingRoute.external) {
       body = matchingRoute.body;
     } else if (ssrBody) {
-      // we wrap SSR content in comments so we can extract it during prerendering to avoid double pre-rendering
-      body = `<!-- greenwood-ssr-start -->${ssrBody.replace(/\$/g, "$$$")}<!-- greenwood-ssr-end -->`;
+      body = ssrBody.replace(/\$/g, "$$$");
     }
 
     if (isSpaRoute) {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

regression related to #1475 

> reproduction - https://github.com/thescientist13/greenwood-native-typescript/pull/2

## Documentation 

N / A

## Summary of Changes

1. Top level pages were not properly getting marked with HTML prerendering markers

## TODO

1. Are we missing test coverage on this behavior
    - reproduction use case - why did it not break other projects?
    - checking for markers
    - double render test
1. [ ] is this fix a leaky abstraction?