### PR TITLE
bug/issue 1475 page contents overriding layouts content when no outlet tag is being used

### DIFF
--- a/packages/cli/src/lib/layout-utils.js
+++ b/packages/cli/src/lib/layout-utils.js
@@ -221,10 +221,7 @@ async function mergeContentIntoLayout(
     const finalBody =
       parentBody && parentBody.match(outletRegex)
         ? parentBody.replace(outletRegex, childBody ?? childContents)
-        : parentContents &&
-            (childContents || childContents === "") &&
-            !parentBody?.match(outletRegex) &&
-            outletType === "content"
+        : parentContents && outletType === "content"
           ? parentBody
           : childRoot.querySelector("html") && childBody
             ? childBody

--- a/packages/cli/src/lib/layout-utils.js
+++ b/packages/cli/src/lib/layout-utils.js
@@ -216,11 +216,13 @@ async function mergeContentIntoLayout(
         : /<page-outlet><\/page-outlet>/;
     // we need to make sure that if parent layouts don't have an "outlet" tag
     // then we _do not_ favor the child contents in that case
+    // this can happen in the case of context plugins in which pages may _only_ be used for loading a layout
+    // https://github.com/ProjectEvergreen/greenwood/pull/1527
     const finalBody =
       parentBody && parentBody.match(outletRegex)
         ? parentBody.replace(outletRegex, childBody ?? childContents)
         : parentContents &&
-            childContents &&
+            (childContents || childContents === "") &&
             !parentBody?.match(outletRegex) &&
             outletType === "content"
           ? parentBody

--- a/packages/cli/src/lib/layout-utils.js
+++ b/packages/cli/src/lib/layout-utils.js
@@ -269,10 +269,20 @@ async function getPageLayout(pageContents, compilation, matchingRoute, ssrLayout
     layoutContents = ssrLayout;
   } else if (layout && (customPluginPageLayouts.length > 0 || hasCustomStaticLayout)) {
     // has a custom layout from markdown frontmatter or context plugin
-    layoutContents =
+    const contents =
       customPluginPageLayouts.length > 0
-        ? await fs.readFile(new URL(`./${layout}.html`, customPluginPageLayouts[0]), "utf-8")
+        ? await fs.readFile(customPluginPageLayouts[0], "utf-8")
         : await fs.readFile(new URL(`./${layout}.html`, userLayoutsDir), "utf-8");
+
+    if (pageContents) {
+      layoutContents = contents;
+    } else {
+      pageContents = contents;
+    }
+    // layoutContents =
+    //   customPluginPageLayouts.length > 0
+    //     ? await fs.readFile(new URL(`./${layout}.html`, customPluginPageLayouts[0]), "utf-8")
+    //     : await fs.readFile(new URL(`./${layout}.html`, userLayoutsDir), "utf-8");
   } else if (customPluginDefaultPageLayouts.length > 0 || (!is404Page && hasPageLayout)) {
     // has a dynamic default page layout from context plugin
     layoutContents =

--- a/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
+++ b/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
@@ -94,7 +94,7 @@ describe("Build Greenwood With: ", function () {
         expect(tags.length).to.equal(1);
       });
 
-      it("should not have any content from the index page since index layout has no <content-outlet></content-outlet>", function () {
+      it("should NOT have any content from the index page since index layout has no <content-outlet></content-outlet> tag", function () {
         const h3 = dom.window.document.querySelectorAll("body h3");
         const h4 = dom.window.document.querySelectorAll("body h3");
 

--- a/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
+++ b/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
@@ -40,7 +40,7 @@ describe("Build Greenwood With: ", function () {
     this.context = {
       publicDir: path.join(outputPath, "public"),
     };
-    runner = new Runner(true);
+    runner = new Runner();
   });
 
   describe(LABEL, function () {

--- a/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
+++ b/packages/cli/test/cases/build.plugins.context/build.plugins.context.spec.js
@@ -16,6 +16,7 @@
  *   pages/
  *     slides/
  *       index.md
+ *     about-me.md
  *     index.md
  */
 import chai from "chai";
@@ -39,7 +40,7 @@ describe("Build Greenwood With: ", function () {
     this.context = {
       publicDir: path.join(outputPath, "public"),
     };
-    runner = new Runner();
+    runner = new Runner(true);
   });
 
   describe(LABEL, function () {
@@ -65,11 +66,48 @@ describe("Build Greenwood With: ", function () {
 
     runSmokeTest(["public", "index"], LABEL);
 
-    describe("Custom Default App and Page Layout", function () {
+    describe("App and Custom Index Page Layouts for the home page", function () {
       let dom;
 
       before(async function () {
         dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "index.html"));
+      });
+
+      it("should have expected text from from a mock package layout/app.html in node_modules/", function () {
+        const pageLayoutHeading = dom.window.document.querySelectorAll("body h1")[0];
+
+        expect(pageLayoutHeading.textContent).to.be.equal(
+          "This is a custom app layout from the custom layouts directory.",
+        );
+      });
+
+      it("should have expected <body> content from the index layout", function () {
+        const customElement = dom.window.document.querySelectorAll("body presenter-mode");
+
+        expect(customElement.length).to.equal(1);
+      });
+
+      it("should have expected <head> content from the index layout", function () {
+        const scriptTags = dom.window.document.querySelectorAll("head script");
+        const tags = Array.from(scriptTags).filter((tag) => tag.getAttribute("type") === "module");
+
+        expect(tags.length).to.equal(1);
+      });
+
+      it("should not have any content from the index page since index layout has no <content-outlet></content-outlet>", function () {
+        const h3 = dom.window.document.querySelectorAll("body h3");
+        const h4 = dom.window.document.querySelectorAll("body h3");
+
+        expect(h3.length).to.equal(0);
+        expect(h4.length).to.equal(0);
+      });
+    });
+
+    describe("Default App and Page Layouts for the about page", function () {
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "about-me/index.html"));
       });
 
       it("should have expected text from from a mock package layout/app.html in node_modules/", function () {
@@ -90,10 +128,10 @@ describe("Build Greenwood With: ", function () {
 
       it("should have expected text from user workspace pages/index.md", function () {
         const pageHeadingPrimary = dom.window.document.querySelectorAll("body h3")[0];
-        const pageHeadingSecondary = dom.window.document.querySelectorAll("body h4")[0];
+        const pageHeadingSecondary = dom.window.document.querySelectorAll("body p")[0];
 
-        expect(pageHeadingPrimary.textContent).to.be.equal("Context Plugin Theme Pack Test");
-        expect(pageHeadingSecondary.textContent).to.be.equal("From user workspace pages/index.md");
+        expect(pageHeadingPrimary.textContent).to.be.equal("About Me");
+        expect(pageHeadingSecondary.textContent).to.be.equal("Hello from me!");
       });
     });
 

--- a/packages/cli/test/cases/build.plugins.context/fixtures/my-layouts/index.html
+++ b/packages/cli/test/cases/build.plugins.context/fixtures/my-layouts/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <script type="module">
+      document.addEventListener("slide-selected", (event) => {
+        document.querySelector("slide-viewer").setAttribute("slide", JSON.stringify(event.detail));
+      });
+    </script>
+  </head>
+  <body>
+    <main>
+      <presenter-mode></presenter-mode>
+    </main>
+  </body>
+</html>

--- a/packages/cli/test/cases/build.plugins.context/src/pages/about-me.md
+++ b/packages/cli/test/cases/build.plugins.context/src/pages/about-me.md
@@ -1,0 +1,3 @@
+### About Me
+
+Hello from me!

--- a/packages/cli/test/cases/build.plugins.context/src/pages/index.md
+++ b/packages/cli/test/cases/build.plugins.context/src/pages/index.md
@@ -1,3 +1,7 @@
+---
+layout: index
+---
+
 ### Context Plugin Theme Pack Test
 
 #### From user workspace pages/index.md


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

regression related to #1475 

> reproduction repo - https://github.com/thescientist13/greenwood-starter-presentation/pull/75#issuecomment-3015995026

## Documentation 

N / A

## Summary of Changes

1. Handling context plugin layouts / pages merging

## TODO
1. [x] add test case to figure out why this wasn't caught
1. [x] figure out how to express and / or comment this behavior