### PR TITLE
enhancement/add recommended lib compiler setting to init template TypeScript scaffolding

### DIFF
--- a/packages/init/src/template-base-ts/tsconfig.json
+++ b/packages/init/src/template-base-ts/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2020",
     "module": "preserve",
     "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": false,

--- a/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
+++ b/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
@@ -156,10 +156,14 @@ describe("Initialize a new Greenwood project: ", function () {
 
       it("should have the expected recommended compiler options", function () {
         const { compilerOptions } = tsConfigJson;
-        const { erasableSyntaxOnly, verbatimModuleSyntax } = compilerOptions;
+        const { erasableSyntaxOnly, verbatimModuleSyntax, lib } = compilerOptions;
 
         expect(erasableSyntaxOnly).to.equal(true);
         expect(verbatimModuleSyntax).to.equal(false);
+
+        expect(lib).to.contain("ES2020");
+        expect(lib).to.contain("DOM");
+        expect(lib).to.contain("DOM.Iterable");
       });
 
       it("should have the expected exclude configuration for Greenwood build output", function () {

--- a/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
+++ b/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
@@ -134,6 +134,7 @@ describe("Initialize a new Greenwood project: ", function () {
     });
 
     describe("initial tsconfig.json contents", function () {
+      const target = "es2020";
       let tsConfigJson;
 
       before(function () {
@@ -147,7 +148,7 @@ describe("Initialize a new Greenwood project: ", function () {
         const { target, module, moduleResolution, allowImportingTsExtensions, noEmit } =
           compilerOptions;
 
-        expect(target).to.equal("es2020");
+        expect(target).to.equal(target);
         expect(module).to.equal("preserve");
         expect(moduleResolution).to.equal("bundler");
         expect(allowImportingTsExtensions).to.equal(true);
@@ -161,7 +162,7 @@ describe("Initialize a new Greenwood project: ", function () {
         expect(erasableSyntaxOnly).to.equal(true);
         expect(verbatimModuleSyntax).to.equal(false);
 
-        expect(lib).to.contain("ES2020");
+        expect(lib).to.contain(target.toUpperCase()); // should match compilerOptions.target
         expect(lib).to.contain("DOM");
         expect(lib).to.contain("DOM.Iterable");
       });


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related #1279 

## Documentation 

1. [x] TODO (depending on if we think we should add this and a test case) - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/issues/219

## Summary of Changes

1. Add recommended [lib](https://www.typescriptlang.org/tsconfig/#lib) settings to init _tsconfig.json_

----

For reference:
- Next - `"lib": ["dom", "dom.iterable", "esnext"]` (**esnext** does NOT matches `target` setting)
- Vite - `"lib": ["ES2022", "DOM", "DOM.Iterable"],`  (**ES2022** matches `target` setting)
- Sveltekit - `"lib": ["esnext", "DOM", "DOM.Iterable"]` (**esnext** matches `target` setting)
