### PR TITLE
enhancement/add TypeScript type check script to init typescript template scaffolding

### DIFF
--- a/packages/init/src/template-base-ts/package.json
+++ b/packages/init/src/template-base-ts/package.json
@@ -3,7 +3,8 @@
     "dev": "NODE_OPTIONS='--experimental-strip-types' greenwood develop",
     "start": "NODE_OPTIONS='--experimental-strip-types' greenwood develop",
     "build": "NODE_OPTIONS='--experimental-strip-types' greenwood build",
-    "serve": "NODE_OPTIONS='--experimental-strip-types' greenwood serve"
+    "serve": "NODE_OPTIONS='--experimental-strip-types' greenwood serve",
+    "lint": "tsc"
   },
   "devDependencies": {
     "typescript": "^5.8.0"

--- a/packages/init/src/template-base-ts/tsconfig.json
+++ b/packages/init/src/template-base-ts/tsconfig.json
@@ -8,5 +8,5 @@
     "verbatimModuleSyntax": false,
     "noEmit": true
   },
-  "exclude": ["./public/", "./greenwood/"]
+  "exclude": ["./public/", "./greenwood/", "node_modules"]
 }

--- a/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
+++ b/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
@@ -105,6 +105,12 @@ describe("Initialize a new Greenwood project: ", function () {
         expect(scripts.serve).to.equal("NODE_OPTIONS='--experimental-strip-types' greenwood serve");
       });
 
+      it("the should have the correct lint script for type-checking", function () {
+        const scripts = pkgJson.scripts;
+
+        expect(scripts.lint).to.equal("tsc");
+      });
+
       it("the should have the correct Greenwood devDependency", function () {
         const initPkg = JSON.parse(
           fs.readFileSync(new URL("../../../package.json", import.meta.url), "utf-8"),
@@ -161,6 +167,7 @@ describe("Initialize a new Greenwood project: ", function () {
 
         expect(exclude).to.contain("./public/");
         expect(exclude).to.contain("./greenwood/");
+        expect(exclude).to.contain("node_modules");
       });
     });
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related #1279 

## Documentation 

N / A

## Summary of Changes

1. Add a lint check nom script to init typescript template scaffolding in _package.json_
1. Since [`include` default to `**/*`](https://www.typescriptlang.org/tsconfig/#include), added _node_modules_ to `exclude`