### PR TITLE
bug/issue 1518 fix the type for Greenwood CLI `run` function

### DIFF
--- a/packages/cli/src/types/index.d.ts
+++ b/packages/cli/src/types/index.d.ts
@@ -61,5 +61,5 @@ export type {
 export type CLI_COMMAND = "develop" | "build" | "serve";
 
 declare module "@greenwood/cli" {
-  export const run: (CLI_COMMAND) => Promise<void>;
+  export const run: (command: CLI_COMMAND) => Promise<void>;
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to https://github.com/ProjectEvergreen/greenwood/issues/1518

observed https://github.com/thescientist13/greenwood-native-typescript/pull/2 that when `noImplicitAny` was set in the project's _tsconfig.json_, this error was emitted when run `tsc` based type-checking
```sh
node_modules/@greenwood/cli/src/types/index.d.ts:64:22 - error TS7051: Parameter has a name but no type. Did you mean 'arg0: CLI_COMMAND'?

64   export const run: (CLI_COMMAND) => Promise<void>;
                        ~~~~~~~~~~~
```

> reproduction https://github.com/thescientist13/greenwood-native-typescript/pull/2#issuecomment-3040461876

## Documentation 

<!-- if this issue has been labeled with documentation, please make sure submit a PR to our website repo and link it -->
<!-- https://github.com/ProjectEvergreen/www.greenwoodjs.dev -->

## Summary of Changes

1. Correctly typed the `run` function