### PR TITLE
bug/update types for Resource plugin serve lifecycles

### DIFF
--- a/packages/cli/src/types/plugins.d.ts
+++ b/packages/cli/src/types/plugins.d.ts
@@ -61,8 +61,8 @@ export type Resource = {
   servePage?: SERVE_PAGE_OPTIONS;
   shouldResolve?: (url: URL) => Promise<boolean>;
   resolve?: (url: URL) => Promise<Request>;
-  shouldServe?: (url: URL) => Promise<boolean>;
-  serve?: (url: URL) => Promise<Response>;
+  shouldServe?: (url: URL, request: Request) => Promise<boolean>;
+  serve?: (url: URL, request: Request) => Promise<Response>;
   shouldPreIntercept?: (url: URL, request: Request, response: Response) => Promise<boolean>;
   preIntercept?: (url: URL, request: Request, response: Response) => Promise<Response>;
   shouldIntercept?: (url: URL, request: Request, response: Response) => Promise<boolean>;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to https://github.com/ProjectEvergreen/greenwood/issues/1424

## Documentation 

N / A

## Summary of Changes

1. Add missing types to `serve` related lifecycles for Resource plugin type