### PR TITLE
Enhancement/issue 823 ensure greenwood cli and plugins are favoring idiomatic usages of async

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -38,13 +38,7 @@ const runProductionBuild = async (compilation) => {
       });
     }
 
-    await Promise.all(
-      servers.map(async (server) => {
-        await server.start();
-
-        return Promise.resolve(server);
-      }),
-    );
+    await Promise.all(servers.map((server) => server.start()));
 
     if (prerenderPlugin.executeModuleUrl) {
       await preRenderCompilationWorker(compilation, prerenderPlugin);

--- a/packages/cli/src/lifecycles/compile.js
+++ b/packages/cli/src/lifecycles/compile.js
@@ -58,9 +58,7 @@ const generateCompilation = async () => {
     console.info("Loading graph from build output...");
 
     if (!(await checkResourceExists(new URL("./graph.json", outputDir)))) {
-      return Promise.reject(
-        new Error("No build output detected.  Make sure you have run greenwood build"),
-      );
+      throw new Error("No build output detected.  Make sure you have run greenwood build");
     }
 
     compilation.graph = JSON.parse(await fs.readFile(new URL("./graph.json", outputDir), "utf-8"));
@@ -131,7 +129,7 @@ const generateCompilation = async () => {
     await fs.writeFile(new URL("./graph.json", scratchDir), JSON.stringify(compilation.graph));
   }
 
-  return Promise.resolve(compilation);
+  return compilation;
 };
 
 export { generateCompilation };

--- a/packages/cli/src/lifecycles/compile.js
+++ b/packages/cli/src/lifecycles/compile.js
@@ -58,7 +58,7 @@ const generateCompilation = async () => {
     console.info("Loading graph from build output...");
 
     if (!(await checkResourceExists(new URL("./graph.json", outputDir)))) {
-      throw new Error("No build output detected.  Make sure you have run greenwood build");
+      throw new Error("No build output detected. Make sure you have run greenwood build");
     }
 
     compilation.graph = JSON.parse(await fs.readFile(new URL("./graph.json", outputDir), "utf-8"));

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -15,20 +15,24 @@ const greenwoodPlugins = (
       new URL("./renderer/", greenwoodPluginsDirectoryUrl),
       new URL("./resource/", greenwoodPluginsDirectoryUrl),
       new URL("./server/", greenwoodPluginsDirectoryUrl),
-    ].map(async (pluginDirectoryUrl) => {
-      const files = await fs.readdir(pluginDirectoryUrl);
+    ].map((pluginDirectoryUrl) =>
+      (async () => {
+        const files = await fs.readdir(pluginDirectoryUrl);
 
-      return await Promise.all(
-        files.map(async (file) => {
-          const importUrl = new URL(`./${file}`, pluginDirectoryUrl);
-          // @ts-expect-error see https://github.com/microsoft/TypeScript/issues/42866
-          const pluginImport = await import(importUrl);
-          const plugin = pluginImport[Object.keys(pluginImport)[0]];
+        return await Promise.all(
+          files.map((file) =>
+            (async () => {
+              const importUrl = new URL(`./${file}`, pluginDirectoryUrl);
+              // @ts-expect-error see https://github.com/microsoft/TypeScript/issues/42866
+              const pluginImport = await import(importUrl);
+              const plugin = pluginImport[Object.keys(pluginImport)[0]];
 
-          return Array.isArray(plugin) ? plugin : [plugin];
-        }),
-      );
-    }),
+              return Array.isArray(plugin) ? plugin : [plugin];
+            })(),
+          ),
+        );
+      })(),
+    ),
   )
 )
   .flat(PLUGINS_FLATTENED_DEPTH)

--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -129,13 +129,13 @@ const readAndMergeConfig = async () => {
     // workspace validation
     if (workspace) {
       if (!(workspace instanceof URL)) {
-        return Promise.reject("Configuration error: workspace must be an instance of URL");
+        throw new Error("Configuration error: workspace must be an instance of URL");
       }
 
       if (await checkResourceExists(workspace)) {
         customConfig.workspace = workspace;
       } else {
-        return Promise.reject(
+        throw new Error(
           "Configuration error: Workspace doesn't exist! Please double check your configuration.",
         );
       }
@@ -147,14 +147,14 @@ const readAndMergeConfig = async () => {
     ) {
       customConfig.optimization = optimization;
     } else if (optimization) {
-      return Promise.reject(
+      throw new Error(
         `Configuration error: provided optimization "${optimization}" is not supported.  Please use one of: ${optimizations.join(", ")}.`,
       );
     }
 
     if (activeContent) {
       if (typeof activeContent !== "boolean") {
-        return Promise.reject("Configuration error: activeContent must be a boolean");
+        throw new Error("Configuration error: activeContent must be a boolean");
       }
       customConfig.activeContent = activeContent;
     }
@@ -164,7 +164,7 @@ const readAndMergeConfig = async () => {
 
       flattened.forEach((plugin) => {
         if (!plugin.type || pluginTypes.indexOf(plugin.type) < 0) {
-          return Promise.reject(
+          throw new Error(
             `Configuration error: plugins must be one of type "${pluginTypes.join(", ")}". got "${plugin.type}" instead.`,
           );
         }
@@ -172,7 +172,7 @@ const readAndMergeConfig = async () => {
         if (!plugin.provider || typeof plugin.provider !== "function") {
           const providerTypeof = typeof plugin.provider;
 
-          return Promise.reject(
+          throw new Error(
             `Configuration error: plugins provider must be a function. got ${providerTypeof} instead.`,
           );
         }
@@ -180,7 +180,7 @@ const readAndMergeConfig = async () => {
         if (!plugin.name || typeof plugin.name !== "string") {
           const nameTypeof = typeof plugin.name;
 
-          return Promise.reject(
+          throw new Error(
             `Configuration error: plugins must have a name. got ${nameTypeof} instead.`,
           );
         }
@@ -208,7 +208,7 @@ const readAndMergeConfig = async () => {
         if (typeof devServer.hud === "boolean") {
           customConfig.devServer.hud = devServer.hud;
         } else {
-          return Promise.reject(
+          throw new Error(
             `Configuration error: devServer hud options must be a boolean.  Passed value was: ${devServer.hud}`,
           );
         }
@@ -216,7 +216,7 @@ const readAndMergeConfig = async () => {
 
       if (devServer.port) {
         if (!Number.isInteger(devServer.port)) {
-          return Promise.reject(
+          throw new Error(
             `Configuration error: devServer port must be an integer.  Passed value was: ${devServer.port}`,
           );
         } else {
@@ -232,7 +232,7 @@ const readAndMergeConfig = async () => {
         if (Array.isArray(devServer.extensions)) {
           customConfig.devServer.extensions = devServer.extensions;
         } else {
-          return Promise.reject(
+          throw new Error(
             "Configuration error: provided extensions is not an array.  Please provide an array like ['txt', 'foo']",
           );
         }
@@ -246,9 +246,7 @@ const readAndMergeConfig = async () => {
 
     if (port) {
       if (!Number.isInteger(port)) {
-        return Promise.reject(
-          `Configuration error: port must be an integer.  Passed value was: ${port}`,
-        );
+        throw new Error(`Configuration error: port must be an integer.  Passed value was: ${port}`);
       } else {
         customConfig.port = port;
       }
@@ -256,7 +254,7 @@ const readAndMergeConfig = async () => {
 
     if (basePath) {
       if (typeof basePath !== "string") {
-        return Promise.reject(
+        throw new Error(
           `Configuration error: basePath must be a string.  Passed value was: ${basePath}`,
         );
       } else {
@@ -267,7 +265,7 @@ const readAndMergeConfig = async () => {
     if (pagesDirectory && typeof pagesDirectory === "string") {
       customConfig.pagesDirectory = pagesDirectory;
     } else if (pagesDirectory) {
-      return Promise.reject(
+      throw new Error(
         `Configuration error: provided pagesDirectory "${pagesDirectory}" is not supported.  Please make sure to pass something like 'docs/'`,
       );
     }
@@ -275,7 +273,7 @@ const readAndMergeConfig = async () => {
     if (layoutsDirectory && typeof layoutsDirectory === "string") {
       customConfig.layoutsDirectory = layoutsDirectory;
     } else if (layoutsDirectory) {
-      return Promise.reject(
+      throw new Error(
         `Configuration error: provided layoutsDirectory "${layoutsDirectory}" is not supported.  Please make sure to pass something like 'layouts/'`,
       );
     }
@@ -284,7 +282,7 @@ const readAndMergeConfig = async () => {
       if (typeof prerender === "boolean") {
         customConfig.prerender = prerender;
       } else {
-        return Promise.reject(
+        throw new Error(
           `Configuration error: prerender must be a boolean; true or false.  Passed value was typeof: ${typeof prerender}`,
         );
       }
@@ -299,7 +297,7 @@ const readAndMergeConfig = async () => {
       if (typeof isolation === "boolean") {
         customConfig.isolation = isolation;
       } else {
-        return Promise.reject(
+        throw new Error(
           `Configuration error: isolation must be a boolean; true or false.  Passed value was typeof: ${typeof staticRouter}`,
         );
       }
@@ -309,7 +307,7 @@ const readAndMergeConfig = async () => {
       if (typeof staticRouter === "boolean") {
         customConfig.staticRouter = staticRouter;
       } else {
-        return Promise.reject(
+        throw new Error(
           `Configuration error: staticRouter must be a boolean; true or false.  Passed value was typeof: ${typeof staticRouter}`,
         );
       }
@@ -324,7 +322,7 @@ const readAndMergeConfig = async () => {
         if (typeof importMaps === "boolean") {
           customConfig.polyfills.importMaps = true;
         } else {
-          return Promise.reject(
+          throw new Error(
             `Configuration error: polyfills.importMaps must be a boolean; true or false.  Passed value was typeof: ${typeof importMaps}`,
           );
         }
@@ -334,7 +332,7 @@ const readAndMergeConfig = async () => {
         if (Array.isArray(importAttributes)) {
           customConfig.polyfills.importAttributes = importAttributes;
         } else {
-          Promise.reject(
+          throw new Error(
             `Configuration error: polyfills.importAttributes must be an array of types; ['css', 'json'].  Passed value was typeof: ${typeof importAttributes}`,
           );
         }
@@ -345,7 +343,7 @@ const readAndMergeConfig = async () => {
       if (typeof useTsc === "boolean") {
         customConfig.useTsc = useTsc;
       } else {
-        return Promise.reject(
+        throw new Error(
           `Configuration error: useTsc must be a boolean; true or false.  Passed value was typeof: ${typeof useTsc}`,
         );
       }
@@ -357,7 +355,7 @@ const readAndMergeConfig = async () => {
     }
   }
 
-  return Promise.resolve({ ...defaultConfig, ...customConfig });
+  return { ...defaultConfig, ...customConfig };
 };
 
 export { readAndMergeConfig };

--- a/packages/cli/src/lifecycles/context.js
+++ b/packages/cli/src/lifecycles/context.js
@@ -22,7 +22,7 @@ const initContext = async ({ config }) => {
     layoutsDir,
   };
 
-  return Promise.resolve(context);
+  return context;
 };
 
 export { initContext };

--- a/packages/cli/src/lifecycles/copy.js
+++ b/packages/cli/src/lifecycles/copy.js
@@ -7,10 +7,10 @@ async function rreaddir(dir, allFiles = []) {
   allFiles.push(...files);
 
   await Promise.all(
-    files.map(
-      async (f) =>
+    files.map((f) =>
+      (async () =>
         (await fs.stat(f)).isDirectory() &&
-        (await rreaddir(new URL(`file://${f.pathname}/`), allFiles)),
+        (await rreaddir(new URL(`file://${f.pathname}/`), allFiles)))(),
     ),
   );
 

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -206,7 +206,7 @@ const generateGraph = async (compilation) => {
               worker.on("error", reject);
               worker.on("exit", (code) => {
                 if (code !== 0) {
-                  return Promise.reject(new Error(`Worker stopped with exit code ${code}`));
+                  throw new Error(`Worker stopped with exit code ${code}`);
                 }
               });
 
@@ -380,7 +380,7 @@ const generateGraph = async (compilation) => {
         if (!body || !route) {
           const missingKey = !body ? "body" : "route";
 
-          return Promise.reject(`ERROR: provided node does not provide a ${missingKey} property.`);
+          throw new Error(`ERROR: provided node does not provide a ${missingKey} property.`);
         }
 
         const page = {
@@ -404,7 +404,7 @@ const generateGraph = async (compilation) => {
     }
   }
 
-  return Promise.resolve(compilation);
+  return compilation;
 };
 
 export { generateGraph };

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -187,23 +187,23 @@ async function staticRenderCompilation(compilation) {
   console.info("pages to generate", `\n ${pages.map((page) => page.route).join("\n ")}`);
 
   await Promise.all(
-    pages.map(async (page) => {
-      const { route, outputHref } = page;
-      const scratchUrl = toScratchUrl(outputHref, context);
-      const url = new URL(`http://localhost:${config.port}${route}`);
-      const request = new Request(url);
+    pages.map((page) =>
+      (async () => {
+        const { route, outputHref } = page;
+        const scratchUrl = toScratchUrl(outputHref, context);
+        const url = new URL(`http://localhost:${config.port}${route}`);
+        const request = new Request(url);
 
-      let body = await (await servePage(url, request, plugins)).text();
-      body = await (await interceptPage(url, request, plugins, body)).text();
+        let body = await (await servePage(url, request, plugins)).text();
+        body = await (await interceptPage(url, request, plugins, body)).text();
 
-      await trackResourcesForRoute(body, compilation, route);
-      await createOutputDirectory(route, new URL(scratchUrl.href.replace("index.html", "")));
-      await fs.writeFile(scratchUrl, body);
+        await trackResourcesForRoute(body, compilation, route);
+        await createOutputDirectory(route, new URL(scratchUrl.href.replace("index.html", "")));
+        await fs.writeFile(scratchUrl, body);
 
-      console.info("generated page...", route);
-
-      return Promise.resolve();
-    }),
+        console.info("generated page...", route);
+      })(),
+    ),
   );
 }
 

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -40,13 +40,13 @@ async function getDevServer(compilation) {
     try {
       const url = new URL(`http://localhost:${compilation.config.port}${ctx.url}`);
       const initRequest = transformKoaRequestIntoStandardRequest(url, ctx.request);
-      const request = await resourcePlugins.reduce(async (requestPromise, plugin) => {
-        const intermediateRequest = await requestPromise;
-        return plugin.shouldResolve &&
-          (await plugin.shouldResolve(url, intermediateRequest.clone()))
-          ? Promise.resolve(await plugin.resolve(url, intermediateRequest.clone()))
-          : Promise.resolve(await requestPromise);
-      }, Promise.resolve(initRequest));
+
+      let request = initRequest;
+      for (const plugin of resourcePlugins) {
+        if (plugin.shouldResolve && (await plugin.shouldResolve(url, request.clone()))) {
+          request = await plugin.resolve(url, request.clone());
+        }
+      }
 
       ctx.url = request.url;
     } catch (e) {
@@ -69,9 +69,8 @@ async function getDevServer(compilation) {
       for (const plugin of resourcePlugins) {
         if (plugin.shouldServe && (await plugin.shouldServe(url, request))) {
           const current = await plugin.serve(url, request);
-          const merged = mergeResponse(response.clone(), current.clone());
 
-          response = merged.clone();
+          response = mergeResponse(response.clone(), current.clone());
         }
       }
 
@@ -100,24 +99,18 @@ async function getDevServer(compilation) {
         status,
         headers: new Headers(header),
       });
-      const response = await resourcePlugins.reduce(async (responsePromise, plugin) => {
-        const intermediateResponse = await responsePromise;
+
+      let response = initResponse;
+      for (const plugin of resourcePlugins) {
         if (
           plugin.shouldPreIntercept &&
-          (await plugin.shouldPreIntercept(url, request, intermediateResponse.clone()))
+          (await plugin.shouldPreIntercept(url, request, response.clone()))
         ) {
-          const current = await plugin.preIntercept(
-            url,
-            request,
-            await intermediateResponse.clone(),
-          );
-          const merged = mergeResponse(intermediateResponse.clone(), current);
+          const current = await plugin.preIntercept(url, request, response.clone());
 
-          return Promise.resolve(merged);
-        } else {
-          return Promise.resolve(await responsePromise);
+          response = mergeResponse(response.clone(), current);
         }
-      }, Promise.resolve(initResponse.clone()));
+      }
 
       ctx.body = response.body ? Readable.from(response.body) : "";
       ctx.message = response.statusText;
@@ -143,20 +136,18 @@ async function getDevServer(compilation) {
         status,
         headers: new Headers(header),
       });
-      const response = await resourcePlugins.reduce(async (responsePromise, plugin) => {
-        const intermediateResponse = await responsePromise;
+
+      let response = initResponse;
+      for (const plugin of resourcePlugins) {
         if (
           plugin.shouldIntercept &&
-          (await plugin.shouldIntercept(url, request, intermediateResponse.clone()))
+          (await plugin.shouldIntercept(url, request, response.clone()))
         ) {
-          const current = await plugin.intercept(url, request, await intermediateResponse.clone());
-          const merged = mergeResponse(intermediateResponse.clone(), current);
+          const current = await plugin.intercept(url, request, response.clone());
 
-          return Promise.resolve(merged);
-        } else {
-          return Promise.resolve(await responsePromise);
+          response = mergeResponse(response.clone(), current);
         }
-      }, Promise.resolve(initResponse.clone()));
+      }
 
       ctx.body = response.body ? Readable.from(response.body) : "";
       ctx.message = response.statusText;
@@ -302,11 +293,13 @@ async function getStaticServer(compilation, composable) {
           status: ctx.response.status,
           headers: new Headers(ctx.response.header),
         });
-        const response = await resourcePlugins.reduce(async (responsePromise, plugin) => {
-          return plugin.shouldServe && (await plugin.shouldServe(url, request))
-            ? Promise.resolve(await plugin.serve(url, request))
-            : responsePromise;
-        }, Promise.resolve(initResponse));
+
+        let response = initResponse;
+        for (const plugin of resourcePlugins) {
+          if (plugin.shouldServe && (await plugin.shouldServe(url, request))) {
+            response = await plugin.serve(url, request);
+          }
+        }
 
         if (response.ok) {
           ctx.body = Readable.from(response.body);

--- a/packages/plugin-graphql/src/schema/graph.js
+++ b/packages/plugin-graphql/src/schema/graph.js
@@ -66,7 +66,7 @@ const getParsedHeadingsFromPage = (tableOfContents = [], headingLevel) => {
 };
 
 const getPagesFromGraph = async (root, query, context) => {
-  return Promise.resolve(context.graph);
+  return context.graph;
 };
 
 const getChildrenFromParentRoute = async (root, query, context) => {
@@ -84,7 +84,7 @@ const getChildrenFromParentRoute = async (root, query, context) => {
     }
   });
 
-  return Promise.resolve(pages);
+  return pages;
 };
 
 const graphTypeDefs = gql`

--- a/packages/plugin-renderer-puppeteer/src/plugins/server.js
+++ b/packages/plugin-renderer-puppeteer/src/plugins/server.js
@@ -15,8 +15,6 @@ class PuppeteerServer {
       (await getDevServer(this.compilation)).listen(offsetPort, async () => {
         console.info(`Started puppeteer prerender server at http://localhost:${offsetPort}`);
       });
-    } else {
-      await Promise.resolve();
     }
   }
 }

--- a/packages/plugin-renderer-puppeteer/src/puppeteer-handler.js
+++ b/packages/plugin-renderer-puppeteer/src/puppeteer-handler.js
@@ -47,8 +47,7 @@ export default async function (compilation, callback) {
     console.info(
       "For more information please see this guide - https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md",
     );
-
-    return Promise.reject();
+    throw e;
   }
 
   const pages = compilation.graph.filter((page) => !page.isSSR);

--- a/packages/plugin-renderer-puppeteer/src/puppeteer-handler.js
+++ b/packages/plugin-renderer-puppeteer/src/puppeteer-handler.js
@@ -5,19 +5,21 @@ export default async function (compilation, callback) {
   const runBrowser = async (serverUrl, pages) => {
     try {
       return Promise.all(
-        pages.map(async (page) => {
-          const { route } = page;
-          console.info("prerendering page...", route);
+        pages.map((page) =>
+          (async () => {
+            const { route } = page;
+            console.info("prerendering page...", route);
 
-          return await browserRunner.serialize(`${serverUrl}${route}`).then(async (html) => {
-            console.info(`prerendering complete for page ${route}.`);
+            return await browserRunner.serialize(`${serverUrl}${route}`).then(async (html) => {
+              console.info(`prerendering complete for page ${route}.`);
 
-            // clean this up here to avoid sending webcomponents-bundle to rollup
-            html = html.replace(/<script src="(.*webcomponents-bundle.js)"><\/script>/, "");
+              // clean this up here to avoid sending webcomponents-bundle to rollup
+              html = html.replace(/<script src="(.*webcomponents-bundle.js)"><\/script>/, "");
 
-            await callback(page, html);
-          });
-        }),
+              await callback(page, html);
+            });
+          })(),
+        ),
       );
     } catch (e) {
       console.error(e);

--- a/test/smoke-test.js
+++ b/test/smoke-test.js
@@ -269,7 +269,7 @@ function serve(label) {
 }
 
 async function runSmokeTest(testCases, label) {
-  testCases.forEach(async (testCase) => {
+  testCases.forEach((testCase) => {
     switch (testCase) {
       case "index":
         defaultIndex(label);

--- a/www/pages/plugins/server.md
+++ b/www/pages/plugins/server.md
@@ -46,9 +46,9 @@ class LiveReloadServer extends ServerInterface {
   async start() {
     const { userWorkspace } = this.compilation.context;
 
-    return this.liveReloadServer.watch(userWorkspace, () => {
+    return this.liveReloadServer.watch(userWorkspace, async () => {
       console.info(`Now watching directory "${userWorkspace}" for changes.`);
-      return Promise.resolve(true);
+      return true;
     });
   }
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

<!-- Include a link to the issue (e.g. Resolves #12) -->
https://github.com/ProjectEvergreen/greenwood/issues/823

## Documentation 

<!-- if this issue has been labeled with documentation, please make sure submit a PR to our website repo and link it -->
<!-- https://github.com/ProjectEvergreen/www.greenwoodjs.dev -->
N/A

## Summary of Changes

<!-- Briefly summarize the changes made, lists are appreciated, ideally with checklists

1. [x] Thing I fixed
1. [x] Other thing I updated
1. [x] Docs I updated
-->
1. wrap async `map` callbacks with sync function to return array of pending promises instead of making the map itself run asynchronously
2. convert async `reduce` callbacks to `for..in` loops
3. remove unnecessary `Promise.resolve` calls