### PR TITLE
bug/issue 1428 ensure comments in HTML get parsed

### DIFF
--- a/packages/cli/src/lib/layout-utils.js
+++ b/packages/cli/src/lib/layout-utils.js
@@ -47,8 +47,9 @@ async function mergeContentIntoLayout(
   matchingRoute,
 ) {
   const activeFrontmatterTitleKey = "${globalThis.page.title}";
-  const parentRoot = parentContents && parse(parentContents);
-  const childRoot = parse(childContents);
+  // keep comments, especially for SSR placeholder markers
+  const parentRoot = parentContents && parse(parentContents, { comment: true });
+  const childRoot = parse(childContents, { comment: true });
   let mergedContents = "";
 
   if ((parentContents && !valid(parentContents)) || (childContents && !valid(childContents))) {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #1428 

After upgrading [this project](https://github.com/thescientist13/greenwood-lit-ssr/pull/35#issuecomment-3171988310) to https://github.com/ProjectEvergreen/greenwood/releases/tag/v0.33.0-alpha.5, was getting an error in this repo.

Comparing to previous builds, it looks like Lit's SSR comment markers are no longer present

**Expected**
<img width="1448" height="732" alt="Screenshot 2025-08-09 at 7 46 53 PM" src="https://github.com/user-attachments/assets/5a14a7f0-0949-46f2-a8c6-48aac381eb61" />

**Actual**
<img width="1498" height="652" alt="Screenshot 2025-08-09 at 7 46 43 PM" src="https://github.com/user-attachments/assets/06919d1c-8c87-47ef-aa7e-de08f9a6fbc6" />

## Documentation 

N / A

## Summary of Changes

1. Ensure we preserve comments in HTML (is now [opt-in for new versions of **node-html-parser**](https://github.com/taoqf/node-html-parser?tab=readme-ov-file#parsedata-options))