### PR TITLE
docs(plugins): update plugin deprecation notices in READMEs

### DIFF
--- a/packages/plugin-import-css/README.md
+++ b/packages/plugin-import-css/README.md
@@ -1,6 +1,6 @@
 # @greenwood/plugin-import-css
 
-> _**THIS PACKAGE HAS BEEN DEPRECATED**_
+> _**THIS PACKAGE HAS BEEN DEPRECATED**.  You can use [**@greenwood/plugin-import-raw**](https://greenwoodjs.dev/docs/plugins/raw/) to achieve the same result.
 
 ## Overview
 A Greenwood plugin to allow you use ESM (`import`) syntax to load your CSS.

--- a/packages/plugin-import-json/README.md
+++ b/packages/plugin-import-json/README.md
@@ -1,6 +1,6 @@
 # @greenwood/plugin-import-json
 
-> _**THIS PACKAGE HAS BEEN DEPRECATED**_
+> _**THIS PACKAGE HAS BEEN DEPRECATED**.  You can use [**@greenwood/plugin-import-raw**](https://greenwoodjs.dev/docs/plugins/raw/) to achieve the same result.
 
 ## Overview
 A Greenwood plugin to allow you use ESM (`import`) syntax to load your JSON.

--- a/packages/plugin-typescript/README.md
+++ b/packages/plugin-typescript/README.md
@@ -1,5 +1,7 @@
 # @greenwood/plugin-typescript
 
+> _**THIS PACKAGE HAS BEEN DEPRECATED**.  Greenwood now has [built-in support for TypeScript](https://greenwoodjs.dev/docs/resources/typescript/).
+
 ## Overview
 
 A Greenwood plugin for writing [**TypeScript**](https://www.typescriptlang.org/). For more information and complete docs on Greenwood, please visit [our website](https://www.greenwoodjs.dev).

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@greenwood/plugin-typescript",
   "version": "0.33.0-alpha.7",
+  "private": true,
   "description": "A Greenwood plugin for writing TypeScript.",
   "repository": "https://github.com/ProjectEvergreen/greenwood",
   "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-typescript",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

N / A

## Documentation 

N / A

## Summary of Changes

1. Add deprecation notice for TypeScript plugin
1. Set typescript plugin to `private`
1. Add useful follow up links / action items