### PR TITLE
enhancement(init): enable `verbatimModuleSyntax: true` in init tsconfig.json

### DIFF
--- a/packages/init/src/template-base-ts/tsconfig.json
+++ b/packages/init/src/template-base-ts/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "allowImportingTsExtensions": true,
     "erasableSyntaxOnly": true,
-    "verbatimModuleSyntax": false,
+    "verbatimModuleSyntax": true,
     "noEmit": true
   },
   "exclude": ["./public/", "./greenwood/", "node_modules"]

--- a/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
+++ b/packages/init/test/cases/init.options.ts/init.options.ts.spec.js
@@ -160,7 +160,7 @@ describe("Initialize a new Greenwood project: ", function () {
         const { erasableSyntaxOnly, verbatimModuleSyntax, lib } = compilerOptions;
 
         expect(erasableSyntaxOnly).to.equal(true);
-        expect(verbatimModuleSyntax).to.equal(false);
+        expect(verbatimModuleSyntax).to.equal(true);
 
         expect(lib).to.contain(target.toUpperCase()); // should match compilerOptions.target
         expect(lib).to.contain("DOM");


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #1518 

## Documentation 

> _This aligns with our future facing recommendations - https://github.com/ProjectEvergreen/www.greenwoodjs.dev/issues/219_

## Summary of Changes

1. Set `verbatimModuleSyntax: true` in init _tsconfig.json_