### PR TITLE
bug(cli): issue 1475 handle SSR double rendering when SSR page has a `<body>` tag

### DIFF
--- a/packages/cli/src/lib/layout-utils.js
+++ b/packages/cli/src/lib/layout-utils.js
@@ -235,6 +235,7 @@ async function mergeContentIntoLayout(
     // we wrap SSR content in comments so we can extract it during prerendering to avoid double pre-rendering
     // https://github.com/ProjectEvergreen/greenwood/issues/1044
     // https://github.com/ProjectEvergreen/greenwood/issues/988#issuecomment-1288168858
+    // https://github.com/ProjectEvergreen/greenwood/pull/1559
     if (matchingRoute.isSSR && outletType === "content") {
       finalBody = `<!-- greenwood-ssr-start -->${finalBody}<!-- greenwood-ssr-end -->`;
     }

--- a/packages/cli/src/lib/layout-utils.js
+++ b/packages/cli/src/lib/layout-utils.js
@@ -219,7 +219,7 @@ async function mergeContentIntoLayout(
     // then we _do not_ favor the child contents in that case
     // this can happen in the case of context plugins in which pages may _only_ be used for loading a layout
     // https://github.com/ProjectEvergreen/greenwood/pull/1527
-    const finalBody =
+    let finalBody =
       parentBody && parentBody.match(outletRegex)
         ? parentBody.replace(outletRegex, childBody ?? childContents)
         : parentContents && parentContents.match(outletRegex) && outletType === "content"
@@ -231,6 +231,13 @@ async function mergeContentIntoLayout(
               : !childRoot.querySelector("html")
                 ? childContents
                 : "";
+
+    // we wrap SSR content in comments so we can extract it during prerendering to avoid double pre-rendering
+    // https://github.com/ProjectEvergreen/greenwood/issues/1044
+    // https://github.com/ProjectEvergreen/greenwood/issues/988#issuecomment-1288168858
+    if (matchingRoute.isSSR && outletType === "content") {
+      finalBody = `<!-- greenwood-ssr-start -->${finalBody}<!-- greenwood-ssr-end -->`;
+    }
 
     mergedContents = `<!DOCTYPE html>
       ${mergedHtml}

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -152,10 +152,7 @@ class StandardHtmlResource {
     } else if (matchingRoute.external) {
       body = matchingRoute.body;
     } else if (ssrBody) {
-      // we wrap SSR content in comments so we can extract it during prerendering to avoid double pre-rendering
-      // https://github.com/ProjectEvergreen/greenwood/issues/1044
-      // https://github.com/ProjectEvergreen/greenwood/issues/988#issuecomment-1288168858
-      body = `<!-- greenwood-ssr-start -->${ssrBody.replace(/\$/g, "$$$")}<!-- greenwood-ssr-end -->`;
+      body = ssrBody;
     }
 
     if (isSpaRoute) {

--- a/packages/cli/test/cases/build.default.ssr-prerender/build.default.ssr-prerender.spec.js
+++ b/packages/cli/test/cases/build.default.ssr-prerender/build.default.ssr-prerender.spec.js
@@ -1,6 +1,6 @@
 /*
  * Use Case
- * Run Greenwood with an SSR route that is prerender using configuration.
+ * Run Greenwood with an SSR route that is prerendered using configuration and checks for double SSR rendering.
  *
  * User Result
  * Should generate a bare bones Greenwood build for hosting a prerender SSR application.
@@ -132,9 +132,6 @@ describe("Build Greenwood With: ", function () {
         expect(heading[0].textContent.trim()).to.equal("This is the header component.");
       });
 
-      // specifically to test for these bugs
-      // https://github.com/ProjectEvergreen/greenwood/issues/1044
-      // https://github.com/ProjectEvergreen/greenwood/issues/988#issuecomment-1288168858
       it("should have the expected number of top level items pre-rendered for the <app-social-links> tag in the body", function () {
         // one set comes from the HTML, one from the SSR page
         const links = dom.window.document.querySelectorAll("body > app-social-links ul li a");

--- a/packages/cli/test/cases/build.default.ssr-prerender/build.default.ssr-prerender.spec.js
+++ b/packages/cli/test/cases/build.default.ssr-prerender/build.default.ssr-prerender.spec.js
@@ -39,6 +39,7 @@ const expect = chai.expect;
 // contains test cases for these bugs
 // https://github.com/ProjectEvergreen/greenwood/issues/1044
 // https://github.com/ProjectEvergreen/greenwood/issues/988#issuecomment-1288168858
+// https://github.com/ProjectEvergreen/greenwood/pull/1559
 describe("Build Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) with prerender configuration";
   const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");

--- a/packages/cli/test/cases/build.default.ssr-prerender/build.default.ssr-prerender.spec.js
+++ b/packages/cli/test/cases/build.default.ssr-prerender/build.default.ssr-prerender.spec.js
@@ -17,7 +17,11 @@
  *  src/
  *   components/
  *     footer.js
+ *     header.js
+ *     logo.js
+ *     social-links.js
  *   pages/
+ *     about.js
  *     index.js
  *   layouts/
  *     app.html
@@ -32,6 +36,9 @@ import { fileURLToPath } from "node:url";
 
 const expect = chai.expect;
 
+// contains test cases for these bugs
+// https://github.com/ProjectEvergreen/greenwood/issues/1044
+// https://github.com/ProjectEvergreen/greenwood/issues/988#issuecomment-1288168858
 describe("Build Greenwood With: ", function () {
   const LABEL = "A Server Rendered Application (SSR) with prerender configuration";
   const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
@@ -53,7 +60,7 @@ describe("Build Greenwood With: ", function () {
 
     runSmokeTest(["public", "index"], LABEL);
 
-    describe("Build command that prerenders SSR pages", function () {
+    describe("Build command that prerenders the SSR home page with multiple custom elements", function () {
       let dom;
 
       before(async function () {
@@ -79,9 +86,6 @@ describe("Build Greenwood With: ", function () {
         expect(heading[0].textContent.trim()).to.equal("This is the header component.");
       });
 
-      // specifically to test for these bugs
-      // https://github.com/ProjectEvergreen/greenwood/issues/1044
-      // https://github.com/ProjectEvergreen/greenwood/issues/988#issuecomment-1288168858
       it("should have the expected number of items pre-rendered for the two <app-social-links> tags", function () {
         // one set comes from the HTML, one from the SSR page
         const links = dom.window.document.querySelectorAll("body > app-social-links ul li a");
@@ -98,6 +102,65 @@ describe("Build Greenwood With: ", function () {
         expect(paragraph.length).to.equal(1);
         expect(paragraph[0].textContent.trim()).to.equal("This is the footer component.");
         expect(links.length).to.equal(3);
+      });
+    });
+
+    describe("Build command that prerenders the SSR about pages with shared custom elements", function () {
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./about/index.html"));
+      });
+
+      it("should have the expected SSR page content in the HTML", function () {
+        const headings = dom.window.document.querySelectorAll("body h1");
+
+        expect(headings.length).to.equal(1);
+        expect(headings[0].textContent).to.equal("Welcome to Greenwood!");
+      });
+
+      it("should have one top level <app-header> tag with an open shadowroot", function () {
+        const header = dom.window.document.querySelectorAll(
+          'app-header template[shadowrootmode="open"]',
+        );
+        const headerContentsDom = new JSDOM(header[0].innerHTML);
+        const heading = headerContentsDom.window.document.querySelectorAll("h1");
+
+        expect(header.length).to.equal(1);
+        expect(heading.length).to.equal(1);
+        expect(heading[0].textContent.trim()).to.equal("This is the header component.");
+      });
+
+      // specifically to test for these bugs
+      // https://github.com/ProjectEvergreen/greenwood/issues/1044
+      // https://github.com/ProjectEvergreen/greenwood/issues/988#issuecomment-1288168858
+      it("should have the expected number of top level items pre-rendered for the <app-social-links> tag in the body", function () {
+        // one set comes from the HTML, one from the SSR page
+        const links = dom.window.document.querySelectorAll("body > app-social-links ul li a");
+
+        expect(links.length).to.equal(3);
+      });
+
+      it("should have one top level <app-footer> tag with expected <app-social-link> items", function () {
+        const footer = dom.window.document.querySelectorAll("app-footer");
+        const paragraph = footer[0].querySelectorAll("p");
+        const links = footer[0].querySelectorAll("app-social-links ul li a");
+
+        expect(footer.length).to.equal(1);
+        expect(paragraph.length).to.equal(1);
+        expect(paragraph[0].textContent.trim()).to.equal("This is the footer component.");
+        expect(links.length).to.equal(3);
+      });
+
+      it("should have one top level <app-logo> tag and expected content", function () {
+        const logo = dom.window.document.querySelectorAll(
+          'app-logo template[shadowrootmode="open"]',
+        );
+        const logoContentsDom = new JSDOM(logo[0].innerHTML);
+        const paragraph = logoContentsDom.window.document.querySelectorAll("p");
+
+        expect(logo.length).to.equal(1);
+        expect(paragraph.length).to.equal(1);
       });
     });
   });

--- a/packages/cli/test/cases/build.default.ssr-prerender/src/components/logo.js
+++ b/packages/cli/test/cases/build.default.ssr-prerender/src/components/logo.js
@@ -1,0 +1,25 @@
+const template = document.createElement("template");
+
+template.innerHTML = `
+  <div class="my-logo">
+    <span class="spacer"></span>
+
+    <div>
+      <p>Logo goes here</p>
+    </div>
+  </div>
+`;
+
+export default class Logo extends HTMLElement {
+  connectedCallback() {
+    if (!this.shadowRoot) {
+      const message = "Message from logo component";
+      console.log({ message });
+
+      this.attachShadow({ mode: "open" });
+      this.shadowRoot?.appendChild(template.content.cloneNode(true));
+    }
+  }
+}
+
+customElements.define("app-logo", Logo);

--- a/packages/cli/test/cases/build.default.ssr-prerender/src/layouts/app.html
+++ b/packages/cli/test/cases/build.default.ssr-prerender/src/layouts/app.html
@@ -7,6 +7,7 @@
     <script type="module" src="/components/header.js"></script>
     <script type="module" src="/components/footer.js"></script>
     <script type="module" src="/components/social-links.js"></script>
+    <script type="module" src="/components/logo.js"></script>
   </head>
   <body>
     <app-header></app-header>

--- a/packages/cli/test/cases/build.default.ssr-prerender/src/pages/about.js
+++ b/packages/cli/test/cases/build.default.ssr-prerender/src/pages/about.js
@@ -1,0 +1,17 @@
+import "../components/logo.js";
+
+const html = `
+<body>
+  <main>
+    <h1>Welcome to Greenwood!</h1>
+
+    <app-logo></app-logo>
+  </main>
+</body>
+`;
+
+export default class HomePage extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = html;
+  }
+}


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

regression from #1475 

Observed in https://github.com/thescientist13/greenwood-native-typescript/pull/2#issuecomment-3015978140 that when an SSR page has a `<body>` or `<html>` tag, the SSR wrapper will be on the _outside_ and thus, won't be in the right place to avoid double prerendering (e.g. not _inside_ the `<body>` tag

<details>
  <pre>
    {
      body: '<!-- greenwood-ssr-start --><html><head></head><body>\n' +
        '  <main>\n' +
        '    <h1>Welcome to Greenwood!</h1>\n' +
        '\n' +
        '    <x-logo><template shadowrootmode="open">\n' +
        '  <div class="my-logo">\n' +
        '    <span class="spacer"></span>\n' +
        '\n' +
        '    <div>\n' +
        '      <svg width="100%" height="100%" viewBox="0 0 150 180" fill="#00b68f" xmlns="http://www.w3.org/2000/svg">   <defs>     <style>       .shading {         fill: #1ad6a9;       }     </style>   </defs>   <g>     <g>       <g>         <path d="M81.32,142.25c-1.07.63-1.58,1.9-1.26,3.09,5.15,19.17-7.94,33.56,4.33,33.56,10.15,0,16.65-.48,16.65-14.91,0-10.63-2.06-25.06-5.08-27.12-2.32-1.59-10.84,3.12-14.64,5.38Z"></path>         <path class="shading" d="M87.57,172.18c-.87.02-1.52-.8-1.32-1.64.13-.53.26-1.06.38-1.54,1.35-5.44,1.62-16.56-.67-25.59,2.65-1.11,6.78-2.61,8.45-3.15,1.43,4.2,2.65,15.98,2.65,23.73,0,4.62-1.04,6.8-2.01,7.29-1.29.65-4.43.84-7.47.9Z"></path>       </g>       <path d="M20.78.05c.35-2.48-43.96,89.96-4.22,131.69,38.68,40.62,107.46,7.08,110.82-31.56C130.45,64.79,101.48,11.12,20.78.05Z"></path>       <path class="shading" d="M119.87,99.53c-.9,10.31-9.73,30.5-34.22,40.27C76.61,67.13,38.01,20.47,26.37,8.54c39.28,6.82,61.55,23.92,73.47,37.44,14.07,15.96,21.56,35.98,20.03,53.55Z"></path>     </g>   </g> </svg>\n' +
        '    </div>\n' +
        '  </div>\n' +
        '</template></x-logo>\n' +
        '\n' +
        '    <h1>Edit <code>src/pages/index.html</code> to start making changes</h1>\n' +
        '\n' +
        '    <div class="card-wrapper">\n' +
        '      <div class="card">\n' +
        '        <h2>Getting Started</h2>\n' +
        '        <p>\n' +
        '          Follow our <a href="https://www.greenwoodjs.dev/guides/getting-started/">guide</a> on\n' +
        '          learning Greenwood for the first time.\n' +
        '        </p>\n' +
        '      </div>\n' +
        '\n' +
        '      <div class="card">\n' +
        '        <h2>Docs</h2>\n' +
        '        <p>\n' +
        "          Learn about Greenwood's\n" +
        '          <a href="https://www.greenwoodjs.dev/docs/">features and capabilities</a>.\n' +
        '        </p>\n' +
        '      </div>\n' +
        '\n' +
        '      <div class="card">\n' +
        '        <h2>Guides</h2>\n' +
        '        <p>\n' +
        '          Walkthroughs on ways to\n' +
        '          <a href="https://www.greenwoodjs.dev/guides/">build and deploy</a> with Greenwood.\n' +
        '        </p>\n' +
        '      </div>\n' +
        '\n' +
        '      <div class="card">\n' +
        '        <h2>Community</h2>\n' +
        '        <p>\n' +
        '          Come join us on <a href="https://github.com/ProjectEvergreen/greenwood">GitHub</a> and\n' +
        '          <a href="https://www.greenwoodjs.dev/discord/">Discord</a> to get involved.\n' +
        '        </p>\n' +
        '      </div>\n' +
        '    </div>\n' +
        '  </main>\n' +
        '\n' +
        '</body></html><!-- greenwood-ssr-end -->'
    }
  </pre>
</details>


## Documentation 

N / A

## Summary of Changes

1. Move SSR render wrapping to layout utils
1. Update test cases