### PR TITLE
enhancement(init): hide logo FOUCE for init templates

### DIFF
--- a/packages/init/src/template-base-ts/src/pages/index.html
+++ b/packages/init/src/template-base-ts/src/pages/index.html
@@ -61,6 +61,10 @@
         }
       }
 
+      x-logo:not(:defined) {
+        display: none;
+      }
+
       x-logo {
         display: block;
         min-height: 100px;

--- a/packages/init/src/template-base-ts/src/pages/index.html
+++ b/packages/init/src/template-base-ts/src/pages/index.html
@@ -63,6 +63,8 @@
 
       x-logo:not(:defined) {
         display: none;
+        min-height: 100px;
+        margin-bottom: 125px;
       }
 
       x-logo {

--- a/packages/init/src/template-base/src/pages/index.html
+++ b/packages/init/src/template-base/src/pages/index.html
@@ -61,6 +61,10 @@
         }
       }
 
+      x-logo:not(:defined) {
+        display: none;
+      }
+
       x-logo {
         display: block;
         min-height: 100px;

--- a/packages/init/src/template-base/src/pages/index.html
+++ b/packages/init/src/template-base/src/pages/index.html
@@ -63,6 +63,8 @@
 
       x-logo:not(:defined) {
         display: none;
+        min-height: 100px;
+        margin-bottom: 125px;
       }
 
       x-logo {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

N / A

## Documentation 

N / A

## Summary of Changes

1. Add `is:not(:defined)` styles to eliminate logo FOUCE (flash of unstyled custom element)

----

**BEFORE**

https://github.com/user-attachments/assets/b758b4da-8210-402d-b18c-437df06a2b1c

**AFTER**

https://github.com/user-attachments/assets/bb269ece-eb2e-40e6-b0d1-f0ca7215f98d

> Note: videos were recorded before adding the heights / padding