### PR TITLE
chore(plugins): #1499 bump all plugin CLI `peerDependencies` to v0.33.0

### DIFF
--- a/packages/plugin-adapter-aws/package.json
+++ b/packages/plugin-adapter-aws/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.33.0-alpha.9"

--- a/packages/plugin-adapter-netlify/package.json
+++ b/packages/plugin-adapter-netlify/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "dependencies": {
     "netlify-cli": "^15.10.0",

--- a/packages/plugin-adapter-vercel/package.json
+++ b/packages/plugin-adapter-vercel/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.33.0-alpha.9"

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "dependencies": {
     "@babel/core": "^7.10.4",

--- a/packages/plugin-css-modules/package.json
+++ b/packages/plugin-css-modules/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "dependencies": {
     "acorn": "^8.14.0",

--- a/packages/plugin-google-analytics/package.json
+++ b/packages/plugin-google-analytics/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.33.0-alpha.9"

--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -41,7 +41,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "dependencies": {
     "@apollo/client": "^3.7.14",

--- a/packages/plugin-import-commonjs/package.json
+++ b/packages/plugin-import-commonjs/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "dependencies": {
     "@rollup/plugin-commonjs": "^28.0.0",

--- a/packages/plugin-import-jsx/package.json
+++ b/packages/plugin-import-jsx/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "dependencies": {
     "wc-compiler": "~0.17.0"

--- a/packages/plugin-import-raw/package.json
+++ b/packages/plugin-import-raw/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.33.0-alpha.9"

--- a/packages/plugin-include-html/package.json
+++ b/packages/plugin-include-html/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.33.0-alpha.9"

--- a/packages/plugin-markdown/package.json
+++ b/packages/plugin-markdown/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "dependencies": {
     "markdown-toc": "^1.2.0",

--- a/packages/plugin-polyfills/package.json
+++ b/packages/plugin-polyfills/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "dependencies": {
     "@webcomponents/webcomponentsjs": "^2.6.0"

--- a/packages/plugin-postcss/package.json
+++ b/packages/plugin-postcss/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "dependencies": {
     "postcss": "^8.4.49",

--- a/packages/plugin-renderer-lit/package.json
+++ b/packages/plugin-renderer-lit/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0",
+    "@greenwood/cli": "^0.33.0",
     "lit": "^3.1.0"
   },
   "dependencies": {

--- a/packages/plugin-renderer-puppeteer/package.json
+++ b/packages/plugin-renderer-puppeteer/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@greenwood/cli": "^0.32.0"
+    "@greenwood/cli": "^0.33.0"
   },
   "dependencies": {
     "@webcomponents/webcomponentsjs": "^2.6.0",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

#1499 

## Documentation 

<!-- if this issue has been labeled with documentation, please make sure submit a PR to our website repo and link it -->
<!-- https://github.com/ProjectEvergreen/www.greenwoodjs.dev -->

## Summary of Changes

1. bump all plugin peer deps to final release version `0.33.0`

## TODO
1. [x] rebase after #1571 