### PR TITLE
fix(cli): #1323 refine serving logic for node modules plugin

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-active-content.js
+++ b/packages/cli/src/plugins/resource/plugin-active-content.js
@@ -74,7 +74,7 @@ class ContentAsDataResource {
   async shouldIntercept(url, request, response) {
     const { activeContent } = this.compilation.config;
 
-    return response.headers.get("Content-Type")?.indexOf(this.contentType[0]) >= 0 && activeContent;
+    return activeContent && response.headers.get("Content-Type")?.indexOf(this.contentType[0]) >= 0;
   }
 
   async intercept(url, request, response) {
@@ -139,7 +139,7 @@ class ContentAsDataResource {
   async shouldOptimize(url, response) {
     const { activeContent } = this.compilation.config;
 
-    return response.headers.get("Content-Type")?.indexOf(this.contentType[0]) >= 0 && activeContent;
+    return activeContent && response.headers.get("Content-Type")?.indexOf(this.contentType[0]) >= 0;
   }
 
   async optimize(url, response) {

--- a/packages/cli/src/plugins/resource/plugin-active-content.js
+++ b/packages/cli/src/plugins/resource/plugin-active-content.js
@@ -139,7 +139,7 @@ class ContentAsDataResource {
   async shouldOptimize(url, response) {
     const { activeContent } = this.compilation.config;
 
-    return response.headers.get("Content-Type").indexOf(this.contentType[0]) >= 0 && activeContent;
+    return response.headers.get("Content-Type")?.indexOf(this.contentType[0]) >= 0 && activeContent;
   }
 
   async optimize(url, response) {

--- a/packages/cli/src/plugins/resource/plugin-node-modules.js
+++ b/packages/cli/src/plugins/resource/plugin-node-modules.js
@@ -41,14 +41,19 @@ class NodeModulesResource {
   }
 
   async shouldServe(url) {
-    const { href, protocol } = url;
+    const { href, protocol, pathname } = url;
 
-    return protocol === "file:" && (await checkResourceExists(new URL(href)));
+    return (
+      protocol === "file:" &&
+      pathname.indexOf("/node_modules/") >= 0 &&
+      (await checkResourceExists(new URL(href)))
+    );
   }
 
   async serve(url) {
     const body = await fs.readFile(url, "utf-8");
 
+    // most likely a JavaScript file, but perhaps we should further refine based on extension?
     return new Response(body, {
       headers: new Headers({
         "Content-Type": this.contentType,

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -15,7 +15,7 @@ import { parse } from "node-html-parser";
 class StandardHtmlResource {
   constructor(compilation) {
     this.compilation = compilation;
-    this.extensions = [".html"];
+    this.extensions = ["html"];
     this.contentType = "text/html";
   }
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

#1323 / #1322

> As part of exploring Bun support - https://github.com/thescientist13/greenwood-bun/pull/5#issuecomment-3315405169

## Documentation 

N / A

## Summary of Changes

1. Make sure Node Modules resource plugin is only serving files from _node_modules_
1. Misc plugin tweaks
    - standardize HTML resource plugin extension
    - check for `Content-Type` header first in Active Content resource plugin
    
## TODO
1. [x] ~~any chance this addresses https://github.com/ProjectEvergreen/greenwood/issues/1463~~? - already fixed

> somewhat related, technically _tsconfig.json_ supports JSON5, which means things like comments and dangling commas will break [here](https://github.com/ProjectEvergreen/greenwood/blob/v0.33.0/packages/cli/src/plugins/resource/plugin-typescript.js#L28) (e.g. for Greenwood, a _tsconfig.json_ will **have** to be JSON serializable)