### PR TITLE
bug(plugins): add missing plugin-graphql direct dependency

### DIFF
--- a/packages/plugin-graphql/package.json
+++ b/packages/plugin-graphql/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.14",
     "apollo-server": "^2.21.0",
+    "apollo-server-express": "^2.25.4",
     "graphql": "^15.5.0",
     "graphql-tag": "^2.10.1"
   },


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

N / A

## Documentation 

N / A

## Summary of Changes

1. As part of #1315 , realized **plugin-graphql** was missing a direct dependency in _package.json_