### PR TITLE
bug(cli): #1580 support valid tsconfig.json syntax with `useTsc` config option

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,8 +17,8 @@ export default [
       "public/*",
       "reports/*",
       "coverage/*",
-      // 'packages/plugin-graphql/README.md',
       "www/**",
+      "packages/cli/test/cases/build.config.typescript/tsconfig.json",
     ],
   },
   {

--- a/packages/cli/test/cases/build.config.typescript/tsconfig.json
+++ b/packages/cli/test/cases/build.config.typescript/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  // a comment
   "compilerOptions": {
     "target": "ES2020",
     "module": "preserve",


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1580 

## Documentation 

N / A

## Summary of Changes

1. support valid _tsconfig.json_ syntax when using `useTsc` config option by leveraging TypeScript's built-in config file loading / parsing 
1. Align `verbatimModuleSyntax` default compiler configuration with documented recommendations - https://greenwoodjs.dev/docs/resources/typescript/#setup