### PR TITLE
deps(cli,plugins): bump minimum WCC version to 0.17.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,7 +61,7 @@
     "livereload": "^0.9.1",
     "node-html-parser": "^7.0.1",
     "rollup": "^4.26.0",
-    "wc-compiler": "~0.17.0"
+    "wc-compiler": "~0.17.1"
   },
   "devDependencies": {
     "@aws-sdk/client-cloudfront": "^3.726.0",

--- a/packages/plugin-import-jsx/package.json
+++ b/packages/plugin-import-jsx/package.json
@@ -39,7 +39,7 @@
     "@greenwood/cli": "^0.33.0"
   },
   "dependencies": {
-    "wc-compiler": "~0.17.0"
+    "wc-compiler": "~0.17.1"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.33.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -20155,10 +20155,10 @@ wait-port@1.0.4:
     commander "^9.3.0"
     debug "^4.3.4"
 
-wc-compiler@~0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.17.0.tgz#f1faf7773f69ca4255c580c604f90ff030482660"
-  integrity sha512-08d31qhYjlJiTEfTEW3kpSdcNnx0j0eGaUIA1/+oyczJCxya7+tvbQ/Tz3wbS2kzd/t8iSxNYdfhpf43o6RVuA==
+wc-compiler@~0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/wc-compiler/-/wc-compiler-0.17.1.tgz#91e4dbfb06848afbc8f75fc4e22d6ef798df2c68"
+  integrity sha512-VnZe5NZFS29W1SygfSIX01lNq7iGr0jRXf6RX/ZG3YXFf8QSDYKqtAXniaMS7jOZEQHiA7Co1iAXCpYc6B5eMA==
   dependencies:
     "@projectevergreen/acorn-jsx-esm" "~0.1.0"
     acorn "^8.14.0"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

https://github.com/ProjectEvergreen/wcc/issues/203

**BEFORE**
<img width="910" height="346" alt="Screenshot 2025-09-24 at 9 07 24 PM" src="https://github.com/user-attachments/assets/d479fc00-fd4f-4938-a908-b5519435c3eb" />

**AFTER**
<img width="1231" height="338" alt="Screenshot 2025-09-24 at 9 07 42 PM" src="https://github.com/user-attachments/assets/8d15c38d-f6af-488b-b52d-3abfeacf6972" />

## Documentation 

N / A

## Summary of Changes

1. bump minimum WCC version to 0.17.1