### PR TITLE
bug(plugins): fix plugin array definition return types

### DIFF
--- a/greenwood.config.test-types.ts
+++ b/greenwood.config.test-types.ts
@@ -58,7 +58,7 @@ const config: Config = {
     greenwoodPluginGraphQL(),
     greenwoodPluginImportCommonJs(),
     greenwoodPluginImportJsx(),
-    greenwoodPluginImportRaw,
+    greenwoodPluginImportRaw(),
     greenwoodPluginIncludeHTML(),
     greenwoodPluginMarkdown({
       plugins: [

--- a/packages/plugin-adapter-aws/src/types/index.d.ts
+++ b/packages/plugin-adapter-aws/src/types/index.d.ts
@@ -1,6 +1,6 @@
 import type { AdapterPlugin } from "@greenwood/cli";
 
-export type AwsAdapter = () => Array<AdapterPlugin>;
+export type AwsAdapter = () => [AdapterPlugin];
 
 declare module "@greenwood/plugin-adapter-aws" {
   export const greenwoodPluginAdapterAws: AwsAdapter;

--- a/packages/plugin-adapter-netlify/src/types/index.d.ts
+++ b/packages/plugin-adapter-netlify/src/types/index.d.ts
@@ -1,6 +1,6 @@
 import type { AdapterPlugin } from "@greenwood/cli";
 
-export type NetlifyAdapter = () => Array<AdapterPlugin>;
+export type NetlifyAdapter = () => [AdapterPlugin];
 
 declare module "@greenwood/plugin-adapter-netlify" {
   export const greenwoodPluginAdapterNetlify: NetlifyAdapter;

--- a/packages/plugin-adapter-vercel/src/types/index.d.ts
+++ b/packages/plugin-adapter-vercel/src/types/index.d.ts
@@ -6,7 +6,7 @@ type VercelAdapterOptions = {
   runtime?: SUPPORTED_NODE_VERSIONS;
 };
 
-export type VercelAdapter = (options?: VercelAdapterOptions) => Array<AdapterPlugin>;
+export type VercelAdapter = (options?: VercelAdapterOptions) => [AdapterPlugin];
 
 declare module "@greenwood/plugin-adapter-vercel" {
   export const greenwoodPluginAdapterVercel: VercelAdapter;

--- a/packages/plugin-babel/src/types/index.d.ts
+++ b/packages/plugin-babel/src/types/index.d.ts
@@ -4,7 +4,7 @@ type BabelPluginOptions = {
   extendConfig?: boolean;
 };
 
-export type BabelPlugin = (options?: BabelPluginOptions) => Array<ResourcePlugin, RollupPlugin>;
+export type BabelPlugin = (options?: BabelPluginOptions) => [ResourcePlugin, RollupPlugin];
 
 declare module "@greenwood/plugin-babel" {
   export const greenwoodPluginBabel: BabelPlugin;

--- a/packages/plugin-google-analytics/src/types/index.d.ts
+++ b/packages/plugin-google-analytics/src/types/index.d.ts
@@ -5,9 +5,7 @@ export type GoogleAnalyticsPluginOptions = {
   anonymous?: boolean;
 };
 
-export type GoogleAnalyticsPlugin = (
-  options: GoogleAnalyticsPluginOptions,
-) => Array<ResourcePlugin>;
+export type GoogleAnalyticsPlugin = (options: GoogleAnalyticsPluginOptions) => [ResourcePlugin];
 
 declare module "@greenwood/plugin-google-analytics" {
   export const greenwoodPluginGoogleAnalytics: GoogleAnalyticsPlugin;

--- a/packages/plugin-graphql/src/types/index.d.ts
+++ b/packages/plugin-graphql/src/types/index.d.ts
@@ -2,7 +2,7 @@ import type { ResourcePlugin, ServerPlugin } from "@greenwood/cli";
 import "../queries/queries.d.ts";
 import "../core/client.d.ts";
 
-export type GraphQLPlugin = () => [ResourcePlugin, ServerPlugin];
+export type GraphQLPlugin = () => [ServerPlugin, ResourcePlugin];
 
 export type CollectionVariables = {
   name: string;

--- a/packages/plugin-graphql/src/types/index.d.ts
+++ b/packages/plugin-graphql/src/types/index.d.ts
@@ -2,7 +2,7 @@ import type { ResourcePlugin, ServerPlugin } from "@greenwood/cli";
 import "../queries/queries.d.ts";
 import "../core/client.d.ts";
 
-export type GraphQLPlugin = () => Array<ResourcePlugin, ServerPlugin>;
+export type GraphQLPlugin = () => [ResourcePlugin, ServerPlugin];
 
 export type CollectionVariables = {
   name: string;

--- a/packages/plugin-import-commonjs/src/types/index.d.ts
+++ b/packages/plugin-import-commonjs/src/types/index.d.ts
@@ -1,6 +1,6 @@
 import type { ResourcePlugin, RollupPlugin } from "@greenwood/cli";
 
-export type ImportCommonJSPlugin = () => Array<ResourcePlugin, RollupPlugin>;
+export type ImportCommonJSPlugin = () => [ResourcePlugin, RollupPlugin];
 
 declare module "@greenwood/plugin-import-commonjs" {
   export const greenwoodPluginImportCommonJs: ImportCommonJSPlugin;

--- a/packages/plugin-import-jsx/src/types/index.d.ts
+++ b/packages/plugin-import-jsx/src/types/index.d.ts
@@ -1,6 +1,6 @@
 import type { ResourcePlugin } from "@greenwood/cli";
 
-export type ImportJsxPlugin = () => Array<ResourcePlugin>;
+export type ImportJsxPlugin = () => [ResourcePlugin];
 
 declare module "@greenwood/plugin-import-jsx" {
   export const greenwoodPluginImportJsx: ImportJsxPlugin;

--- a/packages/plugin-import-raw/src/types/index.d.ts
+++ b/packages/plugin-import-raw/src/types/index.d.ts
@@ -6,7 +6,7 @@ type ImportRawPluginOptions = {
   matches?: string[];
 };
 
-export type ImportRawPlugin = (options?: ImportRawPluginOptions) => Array<ResourcePlugin>;
+export type ImportRawPlugin = (options?: ImportRawPluginOptions) => [ResourcePlugin];
 
 declare module "@greenwood/plugin-import-raw" {
   export const greenwoodPluginImportRaw: ImportRawPlugin;

--- a/packages/plugin-include-html/src/types/index.d.ts
+++ b/packages/plugin-include-html/src/types/index.d.ts
@@ -1,6 +1,6 @@
 import type { ResourcePlugin } from "@greenwood/cli";
 
-export type IncludeHtmlPlugin = () => Array<ResourcePlugin>;
+export type IncludeHtmlPlugin = () => [ResourcePlugin];
 
 declare module "@greenwood/plugin-include-html" {
   export const greenwoodPluginIncludeHTML: IncludeHtmlPlugin;

--- a/packages/plugin-markdown/src/types/index.d.ts
+++ b/packages/plugin-markdown/src/types/index.d.ts
@@ -6,7 +6,7 @@ export type MarkdownPluginOptions = {
   plugins?: MarkdownPluginItem[];
 };
 
-export type MarkdownPlugin = (options?: MarkdownPluginOptions) => Array<ResourcePlugin>;
+export type MarkdownPlugin = (options?: MarkdownPluginOptions) => [ResourcePlugin];
 
 declare module "@greenwood/plugin-markdown" {
   export const greenwoodPluginMarkdown: MarkdownPlugin;

--- a/packages/plugin-polyfills/src/types/index.d.ts
+++ b/packages/plugin-polyfills/src/types/index.d.ts
@@ -6,9 +6,7 @@ type PolyfillsPluginOptions = {
   lit?: boolean;
 };
 
-export type PolyfillsPlugin = (
-  options?: PolyfillsPluginOptions,
-) => Array<ResourcePlugin, CopyPlugin>;
+export type PolyfillsPlugin = (options?: PolyfillsPluginOptions) => [ResourcePlugin, CopyPlugin];
 
 declare module "@greenwood/plugin-polyfills" {
   export const greenwoodPluginPolyfills: PolyfillsPlugin;

--- a/packages/plugin-postcss/src/types/index.d.ts
+++ b/packages/plugin-postcss/src/types/index.d.ts
@@ -4,7 +4,7 @@ type PostCssPluginOptions = {
   extendConfig?: boolean;
 };
 
-export type PostCssPlugin = (options?: PostCssPluginOptions) => Array<ResourcePlugin>;
+export type PostCssPlugin = (options?: PostCssPluginOptions) => [ResourcePlugin];
 
 declare module "@greenwood/plugin-postcss" {
   export const greenwoodPluginPostCss: PostCssPlugin;

--- a/packages/plugin-renderer-lit/src/types/index.d.ts
+++ b/packages/plugin-renderer-lit/src/types/index.d.ts
@@ -1,6 +1,6 @@
 import type { RendererPlugin, ResourcePlugin } from "@greenwood/cli";
 
-export type LitRendererPlugin = () => Array<RendererPlugin, ResourcePlugin>;
+export type LitRendererPlugin = () => [RendererPlugin, ResourcePlugin];
 
 declare module "@greenwood/plugin-renderer-lit" {
   export const greenwoodPluginRendererLit: LitRendererPlugin;

--- a/packages/plugin-renderer-puppeteer/src/types/index.d.ts
+++ b/packages/plugin-renderer-puppeteer/src/types/index.d.ts
@@ -1,6 +1,6 @@
 import type { ResourcePlugin, RendererPlugin, ServerPlugin } from "@greenwood/cli";
 
-export type PuppeteerRendererPlugin = () => Array<ResourcePlugin, ServerPlugin, RendererPlugin>;
+export type PuppeteerRendererPlugin = () => [ResourcePlugin, ServerPlugin, RendererPlugin];
 
 declare module "@greenwood/plugin-renderer-puppeteer" {
   export const greenwoodPluginRendererPuppeteer: PuppeteerRendererPlugin;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

Was getting this issue in https://github.com/thescientist13/greenwood-lit-ssr/pull/38

```sh
➜  greenwood-lit-ssr git:(upgrade-greenwood-v0.33.1) ✗ pnpm run lint:types

> greenwood-demo-adapter-vercel@1.0.0 lint:types /Users/owenbuckley/Workspace/github/greenwood-lit-ssr
> tsc

node_modules/.pnpm/@greenwood+plugin-renderer-lit@0.33.1_@greenwood+cli@0.33.1_lit@3.2.1/node_modules/@greenwood/plugin-renderer-lit/src/types/index.d.ts:3:39 - error TS2314: Generic type 'Array<T>' requires 1 type argument(s).

3 export type LitRendererPlugin = () => Array<RendererPlugin, ResourcePlugin>;
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in node_modules/.pnpm/@greenwood+plugin-renderer-lit@0.33.1_@greenwood+cli@0.33.1_lit@3.2.1/node_modules/@greenwood/plugin-renderer-lit/src/types/index.d.ts:3
```

## Documentation 

N / A

## Summary of Changes

1. Correctly type plugin array type definitions
    - (seems like CSS Modules plugin was [doing it correctly](https://github.com/ProjectEvergreen/greenwood/blob/v0.33.1/packages/plugin-css-modules/src/types/index.d.ts#L3) the whole time?)