### PR TITLE
chore(workspace): #1315 relax commitlint header casing rule

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,6 +13,6 @@ export default {
     "scope-empty": [2, "never"],
     "subject-case": [2, "always", "lower-case"],
     "body-case": [2, "always", "lower-case"],
-    "header-case": [2, "always", "lower-case"],
+    "header-case": [0, "always", "lower-case"],
   },
 };


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #1315 

## Documentation 

N / A

Looks like in #1609 having a `@import` in the body made commitlint mad lol
> fix(cli): #1608 handle nested relative CSS @import references
```sh
$ commitlint --edit $1
⧗   input: fix(cli): #1608 handle nested relative CSS @import references
✖   header must be lower-case [header-case]

✖   found 1 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
husky - commit-msg script failed (code 1)
git exited with error code 1
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Summary of Changes

1. relax casing rules for commitment