### PR TITLE
docs(workspace): #1476 fix website output layout templating

### DIFF
--- a/www/src/layouts/app.html
+++ b/www/src/layouts/app.html
@@ -41,7 +41,7 @@
     <div class="gwd-wrapper">
       <app-header></app-header>
 
-      <outlet for="page"></outlet>
+      <output for="page"></output>
 
       <app-footer src="../includes/footer.js"></app-footer>
     </div>

--- a/www/src/layouts/blog.html
+++ b/www/src/layouts/blog.html
@@ -17,7 +17,7 @@
     <div class="gwd-content-wrapper">
       <div class="gwd-content">
         <eve-container fluid>
-          <outlet for="content"></outlet>
+          <output for="content"></output>
         </eve-container>
       </div>
     </div>

--- a/www/src/layouts/docs.html
+++ b/www/src/layouts/docs.html
@@ -30,7 +30,7 @@
       <div class="gwd-content">
         <eve-container fluid>
           <app-scroll>
-            <outlet for="content"></outlet>
+            <output for="content"></output>
           </app-scroll>
         </eve-container>
         <div id="github-edit-button-container">


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #1476 

For the find / replace on the _www/_ folder lol 😅 

<img width="1873" height="854" alt="Screenshot 2025-11-19 at 9 07 27 PM" src="https://github.com/user-attachments/assets/47111b3c-0c80-461b-817e-b4e886b93b45" />


## Documentation 

N / A

## Summary of Changes

1. Properly use `<output>` tag for layout templating