### PR TITLE
chore(workspace): callout breaking change prompt in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -295,6 +295,8 @@ The following will be required:
 - **scope**
 - **issue reference** (can technically be empty)
 
+⚠️ **Note**: The breaking change prompt / option is broken in commitlint; [[1](https://github.com/conventional-changelog/commitlint/issues/4191)], [[2](https://github.com/conventional-changelog/commitlint/issues/4100)].  Please call out breaking changes in your PR.
+
 > _To test the CI build scripts locally, run the commands mentioned in the Continuous Integration section of this document.  (basically just make sure linting, formatting, and test tasks are all passing)._
 
 ## Release Management


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

N / A

## Documentation 

N / A

## Summary of Changes

1. Noticed breaking changes prompt was failing **commitlint**, so added a callout since it is actually broken in **commitlint**