### PR TITLE
enhancement(cli): #1639 configure rollup bundle output for import attributes

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -4,7 +4,9 @@ import path from "node:path";
 import { checkResourceExists, normalizePathnameForWindows } from "../lib/resource-utils.js";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
+import * as acorn from "acorn";
 import * as walk from "acorn-walk";
+import { ACORN_OPTIONS } from "@greenwood/cli/src/lib/parsing-utils.js";
 
 // https://github.com/rollup/rollup/issues/2121
 // would be nice to get rid of this
@@ -321,10 +323,7 @@ function greenwoodImportMetaUrl(compilation) {
         return null;
       }
 
-      // ideally we would use our own custom Acorn config + parsing
-      // but need to wait for Rollup to remove `assert` which will break Acorn, which only understands `with`
-      // https://github.com/rollup/rollup/issues/5685
-      const ast = this.parse(await response.text());
+      const ast = acorn.parse(await response.text(), ACORN_OPTIONS);
       const assetUrls = [];
       let modifiedCode = false;
 
@@ -459,10 +458,6 @@ function greenwoodImportMetaUrl(compilation) {
 // to corresponding static bundles, instead of being bundled and shipped as JavaScript
 // e.g. import theme from './theme.css' with { type: 'css' }
 //   -> import theme from './theme.ab345dcc.css' with { type: 'css' }
-//
-// this includes:
-// - replace all instances of assert with with (until Rollup supports with keyword)
-// - sync externalized import attribute paths with bundled CSS paths
 function greenwoodSyncImportAttributes(compilation) {
   const unbundledAssetsRefMapper = {};
   const { basePath, polyfills } = compilation.config;
@@ -485,15 +480,9 @@ function greenwoodSyncImportAttributes(compilation) {
           return;
         }
 
-        // ideally we would use our own custom Acorn config + parsing
-        // but need to wait for Rollup to remove `assert` which will break Acorn, which only understands `with`
-        // https://github.com/rollup/rollup/issues/5685
-        const ast = this.parse(code);
+        const ast = acorn.parse(code, ACORN_OPTIONS);
 
         walk.simple(ast, {
-          // Rollup currently emits externals with assert keyword and
-          // ideally we get import attributes through the actual AST
-          // https://github.com/ProjectEvergreen/greenwood/issues/1218
           ImportDeclaration(node) {
             const { value } = node.source;
             const extension = value.split(".").pop();
@@ -502,19 +491,16 @@ function greenwoodSyncImportAttributes(compilation) {
               let preBundled = false;
               let inlineOptimization = false;
 
+              // TODO: hmmm, seems the `polyfill=type` logic is not needed here and lower in this file?
               if (importAttributes && importAttributes.includes(extension)) {
                 importAttributes.forEach((attribute) => {
                   if (attribute === extension) {
                     bundles[bundle].code = bundles[bundle].code.replace(
-                      new RegExp(`"assert{type:"${attribute}"}`, "g"),
+                      new RegExp(`"with{type:"${attribute}"}`, "g"),
                       `?polyfill=type-${extension}"`,
                     );
                   }
                 });
-              } else {
-                // waiting on Rollup to formally support `with`
-                // https://github.com/rollup/rollup/issues/5685
-                bundles[bundle].code = bundles[bundle].code.replace(/assert{/g, "with{");
               }
 
               // check for app level assets, like say a shared theme.css
@@ -695,6 +681,9 @@ const getRollupConfigForBrowserScripts = async (compilation) => {
         chunkFileNames: "[name].[hash].js",
         assetFileNames: "[name].[hash].[ext]",
         sourcemap: true,
+        // force import attributes (`with`) until Rollup properly emits import attributes by default (currently uses `assert`)
+        // https://github.com/rollup/rollup/issues/5685#issuecomment-2379581091
+        importAttributesKey: "with",
       },
       plugins: [
         greenwoodResourceLoader(compilation, true),
@@ -750,6 +739,9 @@ const getRollupConfigForApiRoutes = async (compilation) => {
           dir: `${normalizePathnameForWindows(outputDir)}/api`,
           entryFileNames: `${id}.js`,
           chunkFileNames: `${id}.[hash].js`,
+          // force import attributes (`with`) until Rollup properly emits import attributes by default (currently uses `assert`)
+          // https://github.com/rollup/rollup/issues/5685#issuecomment-2379581091
+          importAttributesKey: "with",
         },
         plugins: [
           greenwoodResourceLoader(compilation),
@@ -796,6 +788,9 @@ const getRollupConfigForSsrPages = async (compilation, inputs) => {
         dir: normalizePathnameForWindows(outputDir),
         entryFileNames: `${id}.route.js`,
         chunkFileNames: `${id}.route.chunk.[hash].js`,
+        // force import attributes (`with`) until Rollup properly emits import attributes by default (currently uses `assert`)
+        // https://github.com/rollup/rollup/issues/5685#issuecomment-2379581091
+        importAttributesKey: "with",
       },
       plugins: [
         greenwoodResourceLoader(compilation),

--- a/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
+++ b/packages/cli/test/cases/build.config.optimization-inline/build.config-optimization-inline.spec.js
@@ -113,7 +113,7 @@ describe("Build Greenwood With: ", function () {
           ).filter((tag) => !tag.getAttribute("data-gwd"))[1];
 
           expect(scriptTag.textContent).to.contain(
-            "class t extends HTMLElement{constructor(){super(),this.list=[]}find(t){this.list.findIndex((e=>new RegExp(`^${t}$`).test(e.route)))}}export{t as Foobar};",
+            "class t extends HTMLElement{constructor(){super(),this.list=[]}find(t){this.list.findIndex(e=>new RegExp(`^${t}$`).test(e.route))}}export{t as Foobar};",
           );
         });
       });
@@ -128,7 +128,7 @@ describe("Build Greenwood With: ", function () {
 
           expect(scriptTag.type).to.be.equal("module");
           expect(scriptTag.textContent).to.contain(
-            "class t extends HTMLElement{constructor(){super(),this.list=[]}find(t){this.list.findIndex((e=>new RegExp(`^${t}$`).test(e.route)))}}export{t as Baz};",
+            "class t extends HTMLElement{constructor(){super(),this.list=[]}find(t){this.list.findIndex(e=>new RegExp(`^${t}$`).test(e.route))}}export{t as Baz};",
           );
         });
       });

--- a/packages/cli/test/cases/build.default.ssr-static-export/build.default.ssr-static-export.spec.js
+++ b/packages/cli/test/cases/build.default.ssr-static-export/build.default.ssr-static-export.spec.js
@@ -26,7 +26,7 @@ import chai from "chai";
 import fs from "node:fs";
 import { JSDOM } from "jsdom";
 import path from "node:path";
-import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { getOutputTeardownFiles, HASH_REGEX } from "../../../../../test/utils.js";
 import { runSmokeTest } from "../../../../../test/smoke-test.js";
 import { Runner } from "gallinago";
 import { fileURLToPath } from "node:url";
@@ -97,7 +97,7 @@ describe("Build Greenwood With: ", function () {
       it("should have a bundled script for the footer component", function () {
         const footerScript = Array.from(
           dom.window.document.querySelectorAll("head > script[type]"),
-        ).filter((script) => /footer.*[a-z0-9].js/.test(script.src));
+        ).filter((script) => new RegExp(`footer\\.${HASH_REGEX}\\.js`).test(script.src));
 
         expect(footerScript.length).to.be.equal(1);
         expect(footerScript[0].type).to.be.equal("module");

--- a/packages/cli/test/cases/loaders-build.import-attributes/loaders-build.import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-build.import-attributes/loaders-build.import-attributes.spec.js
@@ -83,7 +83,7 @@ describe("Build Greenwood With: ", function () {
         const scriptContents = fs.readFileSync(scripts[0], "utf-8");
 
         expect(scriptContents).to.contain(
-          'const e=new CSSStyleSheet;e.replaceSync(".spectrum-Card{--spectrum-card-background-color',
+          'const d=new CSSStyleSheet;d.replaceSync(".spectrum-Card{--spectrum-card-background-color',
         );
       });
 

--- a/packages/cli/test/cases/loaders-build.prerender-import-attributes/loaders-build.prerender-import-attributes.spec.js
+++ b/packages/cli/test/cases/loaders-build.prerender-import-attributes/loaders-build.prerender-import-attributes.spec.js
@@ -71,7 +71,7 @@ describe("Build Greenwood With: ", function () {
 
         expect(scripts.length).to.equal(1);
         expect(scriptContents).to.match(
-          new RegExp(`import e from"/hero\\.${HASH_REGEX}\\.css"with\\{type:"css"\\};`),
+          new RegExp(`import t from"/hero\\.${HASH_REGEX}\\.css"with\\{type:"css"\\};`),
         );
       });
 

--- a/packages/cli/test/cases/serve.default.ssr-static-export/serve.default.ssr-static-export.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr-static-export/serve.default.ssr-static-export.spec.js
@@ -26,7 +26,7 @@ import chai from "chai";
 import glob from "glob-promise";
 import { JSDOM } from "jsdom";
 import path from "node:path";
-import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { getOutputTeardownFiles, HASH_REGEX } from "../../../../../test/utils.js";
 import { runSmokeTest } from "../../../../../test/smoke-test.js";
 import { Runner } from "gallinago";
 import { fileURLToPath } from "node:url";
@@ -122,7 +122,7 @@ describe("Serve Greenwood With: ", function () {
       it("should have a bundled script for the footer component", function () {
         const footerScript = Array.from(
           dom.window.document.querySelectorAll("head > script[type]"),
-        ).filter((script) => /footer.*[a-z0-9].js/.test(script.src));
+        ).filter((script) => new RegExp(`footer\\.${HASH_REGEX}\\.js`).test(script.src));
 
         expect(footerScript.length).to.be.equal(1);
         expect(footerScript[0].type).to.be.equal("module");

--- a/yarn.lock
+++ b/yarn.lock
@@ -6244,10 +6244,10 @@ acorn@^8.11.0, acorn@^8.14.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
 
-acorn@^8.8.2:
-  version "8.11.2"
-  resolved "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz"
-  integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
+acorn@^8.15.0:
+  version "8.15.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
+  integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -19303,13 +19303,13 @@ terminal-link@3.0.0, terminal-link@^3.0.0:
     ansi-escapes "^5.0.0"
     supports-hyperlinks "^2.2.0"
 
-terser@^5.17.4:
-  version "5.25.0"
-  resolved "https://registry.npmjs.org/terser/-/terser-5.25.0.tgz"
-  integrity sha512-we0I9SIsfvNUMP77zC9HG+MylwYYsGFSBG8qm+13oud2Yh+O104y614FRbyjpxys16jZwot72Fpi827YvGzuqg==
+terser@^5.46.0:
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.46.0.tgz#1b81e560d584bbdd74a8ede87b4d9477b0ff9695"
+  integrity sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
-    acorn "^8.8.2"
+    acorn "^8.15.0"
     commander "^2.20.0"
     source-map-support "~0.5.20"
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1639 

> alternative version to https://github.com/ProjectEvergreen/greenwood/pull/1621 (I think I foo bar'd the lock file doing the terser upgrade?)

## Documentation 

N / A

## Summary of Changes

1. Configure Rollup to emit import attributes (`with`) as assertions (`assert`) [are the default](https://rollupjs.org/configuration-options/#output-importattributeskey)
1. Force bump terser for [import attributes support](https://github.com/terser/terser/blob/master/CHANGELOG.md#v5360)
1. Leverage our own custom Acorn parsing within Rollup bundling

## TODO
1. [x] intermittent Windows test case failures
1. [ ] retest Rollup upgrade (will likely need just rollback the Rollup upgrade for now) - https://github.com/ProjectEvergreen/greenwood/pull/1629#issuecomment-3764414850
    - maybe just try regenerating the entire lockfile 🤷‍♂️ 