### PR TITLE
fix(cli): #1576 fix nested greenwood `type` imports from breaking the build

### DIFF
--- a/packages/cli/src/config/rollup.config.js
+++ b/packages/cli/src/config/rollup.config.js
@@ -28,6 +28,14 @@ function greenwoodResourceLoader(compilation, browser = false) {
   return {
     name: "greenwood-resource-loader",
     async resolveId(id, importer, options) {
+      // fix for nested type imports - https://github.com/ProjectEvergreen/greenwood/issues/1576
+      if (id.indexOf("@greenwood") >= 0) {
+        return {
+          id,
+          external: true,
+        };
+      }
+
       const { userWorkspace, scratchDir } = compilation.context;
       const normalizedId = cleanRollupId(id);
       const importerUrl = new URL(`file://${cleanRollupId(importer) ?? ""}`);

--- a/packages/cli/test/cases/build.typescript.default/build.typescript.default.spec.js
+++ b/packages/cli/test/cases/build.typescript.default/build.typescript.default.spec.js
@@ -168,7 +168,7 @@ describe("Build Greenwood With: ", function () {
 
         expect(jsFiles.length).to.equal(1);
         expect(javascript.replace(/\n/g, "")).to.contain(
-          'const o="Angela",l="Davis",s="Professor";console.log(`Hello ${s} ${o} ${l}!`);',
+          'const o="Angela",e="Davis",l="Professor";console.log(`Hello ${l} ${o} ${e}!`);',
         );
       });
     });

--- a/packages/cli/test/cases/build.typescript.default/src/scripts/main.ts
+++ b/packages/cli/test/cases/build.typescript.default/src/scripts/main.ts
@@ -1,3 +1,9 @@
+import { type Page } from "@greenwood/cli";
+
+const pages: Page[] = [];
+
+console.log({ pages });
+
 interface User {
   firstName: string;
   lastName: string;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1576

## Documentation 

(if we can't figure this out)
https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/262

## Summary of Changes

1. Have Rollup externalize any Greenwood specific packages

> See the patch here - https://github.com/thescientist13/greenwood-loops/pull/2

## TODO

1. [ ] Will need to refine this to make sure it doesn't catch legitimate use cases that are actually exposed through our exports, like the router or active content client
    <img width="798" height="234" alt="Screenshot 2026-01-23 at 8 49 57 PM" src="https://github.com/user-attachments/assets/aecb4905-b38e-472b-9add-db4325f4c602" />