### PR TITLE
fix(cli): #1637 filter out frontmatter imports by content type

### DIFF
--- a/packages/cli/src/lib/layout-utils.js
+++ b/packages/cli/src/lib/layout-utils.js
@@ -157,12 +157,17 @@ async function mergeContentIntoLayout(
             return true;
           }
 
+          const contentType = "text/css";
           const resourceUrl = new URL(`file://${href}`);
-          const request = new Request(resourceUrl, { headers: { Accept: "text/css" } });
+          const request = new Request(resourceUrl, { headers: { Accept: contentType } });
           let isSupportedCustomFormat = false;
 
           for (const plugin of resourcePlugins) {
-            if (plugin.shouldServe && (await plugin.shouldServe(resourceUrl, request))) {
+            if (
+              plugin.contentType === contentType &&
+              plugin.shouldServe &&
+              (await plugin.shouldServe(resourceUrl, request))
+            ) {
               isSupportedCustomFormat = true;
               break;
             }
@@ -190,12 +195,17 @@ async function mergeContentIntoLayout(
             return true;
           }
 
+          const contentType = "text/javascript";
           const resourceUrl = new URL(`file://${src}`);
-          const request = new Request(resourceUrl, { headers: { Accept: "text/javascript" } });
+          const request = new Request(resourceUrl, { headers: { Accept: contentType } });
           let isSupportedCustomFormat = false;
 
           for (const plugin of resourcePlugins) {
-            if (plugin.shouldServe && (await plugin.shouldServe(resourceUrl, request))) {
+            if (
+              plugin.contentType === contentType &&
+              plugin.shouldServe &&
+              (await plugin.shouldServe(resourceUrl, request))
+            ) {
               isSupportedCustomFormat = true;
               break;
             }

--- a/packages/plugin-import-jsx/src/index.js
+++ b/packages/plugin-import-jsx/src/index.js
@@ -14,15 +14,11 @@ class ImportJsxResource {
     this.servePage = options.servePages ? "dynamic" : null;
   }
 
-  async shouldServe(url, request) {
+  async shouldServe(url) {
     const { pathname, protocol } = url;
     const ext = pathname.split(".").pop();
 
-    return (
-      protocol === "file:" &&
-      this.extensions.includes(ext) &&
-      request.headers?.get("Accept").indexOf(this.contentType) >= 0
-    );
+    return protocol === "file:" && this.extensions.includes(ext);
   }
 
   async serve(url) {

--- a/packages/plugin-import-jsx/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-import-jsx/test/cases/develop.default/develop.default.spec.js
@@ -1,0 +1,93 @@
+/*
+ * Use Case
+ * Run Greenwood develop command with parsing TSX content.
+ *
+ * User Result
+ * Should start the development server and render a bare bones Greenwood build.
+ *
+ * User Command
+ * greenwood develop
+ *
+ * User Config
+ * import { greenwoodPluginImportJsx } from '@greenwood/plugin-import-jsx';
+ *
+ * {
+ *   prerender: true,
+ *   plugins: [{
+ *     greenwoodPluginImportJsx()
+ *   }]
+ * }
+ *
+ * User Workspace
+ * src/
+ *   components/
+ *     greeting.tsx
+ *   pages/
+ *     index.html
+ */
+import chai from "chai";
+import path from "node:path";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+const expect = chai.expect;
+
+describe("Develop Greenwood With: ", function () {
+  const LABEL = "Default Greenwood Configuration and Workspace";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  const hostname = "http://localhost";
+  const port = 1984;
+  let runner;
+
+  before(function () {
+    this.context = {
+      hostname: `${hostname}:${port}`,
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+
+      await new Promise((resolve, reject) => {
+        runner
+          .runCommand(cliPath, "develop", {
+            onStdOut: (message) => {
+              if (message.includes(`Started local development server at http://localhost:1984`)) {
+                resolve();
+              }
+            },
+          })
+          .catch(reject);
+      });
+    });
+
+    runSmokeTest(["serve"], LABEL);
+
+    // extra testing for - https://github.com/ProjectEvergreen/greenwood/issues/1637
+    describe("Develop command with transforming TSX files", function () {
+      let contents;
+
+      before(async function () {
+        const response = await fetch(`http://127.0.0.1:${port}/components/greeting.tsx`);
+        contents = await response.text();
+      });
+
+      it("should return the correct content type", function (done) {
+        expect(contents.indexOf("this.innerHTML")).to.not.equal(-1);
+        done();
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.stopCommand();
+    await runner.teardown([
+      path.join(outputPath, ".greenwood"),
+      path.join(outputPath, "node_modules"),
+    ]);
+  });
+});

--- a/packages/plugin-import-jsx/test/cases/develop.default/greenwood.config.js
+++ b/packages/plugin-import-jsx/test/cases/develop.default/greenwood.config.js
@@ -1,0 +1,5 @@
+import { greenwoodPluginImportJsx } from "../../../src/index.js";
+
+export default {
+  plugins: [greenwoodPluginImportJsx()],
+};

--- a/packages/plugin-import-jsx/test/cases/develop.default/src/components/greeting.tsx
+++ b/packages/plugin-import-jsx/test/cases/develop.default/src/components/greeting.tsx
@@ -1,0 +1,13 @@
+export default class GreetingComponent extends HTMLElement {
+  connectedCallback() {
+    this.render();
+  }
+
+  render() {
+    const greeting = this.getAttribute("greeting") || "World";
+
+    return <span> Hello, {greeting}!</span>;
+  }
+}
+
+customElements.define("app-greeting", GreetingComponent);

--- a/packages/plugin-import-jsx/test/cases/develop.default/src/pages/index.html
+++ b/packages/plugin-import-jsx/test/cases/develop.default/src/pages/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <script type="module" src="../components/greeting.tsx"></script>
+  </head>
+
+  <body>
+    <app-greeting></app-greeting>
+  </body>
+</html>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1637 

> See https://github.com/ProjectEvergreen/greenwood/issues/1637#issuecomment-3829147938

## Documentation 

N / A

## Summary of Changes

1. Include content type when filtering frontmatter imports for CSS or JS