### PR TITLE
docs(workspace): #978 fix old website getting started redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -63,7 +63,7 @@
   force = true
 
 [[redirects]]
-  from = "/getting-started/"
+  from = "/getting-started/*"
   to = "https://www.greenwoodjs.dev/guides/getting-started/"
   status = 301
   force = true


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

#978 

Seeing the old getting started docs link is in google search results that aren't redirecting to the new site
<img width="845" height="218" alt="Screenshot 2026-02-07 at 1 29 50 PM" src="https://github.com/user-attachments/assets/4da685bc-47b2-49f5-8a93-10523adb751d" />


But does not redirect as expected for sub pages (top level `/getting-started/` works fine though)
```sh
➜  ✗ curl -I https://www.greenwoodjs.io/getting-started/quick-start/
HTTP/2 200 
accept-ranges: bytes
age: 60
cache-control: public,max-age=0,must-revalidate
cache-status: "Netlify Edge"; hit
content-type: text/html; charset=UTF-8
date: Sat, 07 Feb 2026 18:31:02 GMT
etag: "589e13b5b3ed6362fe87b25a8ca2d364-ssl"
server: Netlify
strict-transport-security: max-age=31536000
x-nf-request-id: 01KGWNY8RAQ6FRJDYD807QKETS
content-length: 84267
```

## Documentation 

N / A

## Summary of Changes

1. Expand capturing for all `/getting-started/*` routes in _netlify.toml_