### PR TITLE
docs(workspace): #978 for top level redirect for next directory

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,7 @@
   NODE_VERSION = "12.13.0"
 
 [[redirects]]
-  from = "/"
+  from = "/*"
   to = "https://www.greenwoodjs.dev"
   status = 301
   force = true


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #978

Seeing results from next.greenwoodjs.io in Google search results

<img width="921" height="247" alt="Screenshot 2026-02-07 at 1 49 20 PM" src="https://github.com/user-attachments/assets/7cef46f5-8f93-49a6-8475-a26a3149f486" />

```sh
➜  greenwood git:(master) ✗ curl -I https://next.greenwoodjs.io/about/
HTTP/2 200
accept-ranges: bytes
age: 0
cache-control: public,max-age=0,must-revalidate
cache-status: "Netlify Edge"; fwd=miss
content-type: text/html; charset=UTF-8
date: Sat, 07 Feb 2026 18:50:00 GMT
etag: "cff7983bb93a14bfc6f756dd4c4c5a69-ssl"
server: Netlify
strict-transport-security: max-age=31536000
x-nf-request-id: 01KGWQ0ZY2VS209GSH052BSQCT
content-length: 30900

➜  greenwood git:(chore/top-level-wildcard-redirect) ✗ curl -I https://next.greenwoodjs.io
HTTP/2 301
age: 578
cache-control: public,max-age=0,must-revalidate
cache-status: "Netlify Edge"; hit
content-type: text/plain; charset=utf-8
date: Sat, 07 Feb 2026 18:50:03 GMT
location: https://www.greenwoodjs.dev/
server: Netlify
strict-transport-security: max-age=31536000
x-nf-request-id: 01KGWQ136A62DZ28C0S203C1MN
content-length: 42
```

## Documentation 

N / A

## Summary of Changes

1. Just redirect everything