### PR TITLE
feature(plugins): #1633 lit ssr and css module scripts support

### DIFF
--- a/packages/plugin-renderer-lit/README.md
+++ b/packages/plugin-renderer-lit/README.md
@@ -78,7 +78,6 @@ import type { LitRendererPlugin } from '@greenwood/plugin-renderer-lit';
     - Lit SSR [**only** renders into declarative shadow roots](https://github.com/lit/lit/issues/3080#issuecomment-1165158794), so you will have to keep browser support (and polyfill usage) in mind.
     - At this time, `LitElement` does not support `async` work (e.g. for `connectedCallback`).  You can follow along with [this issue](https://github.com/lit/lit/issues/2469) and [this issue](https://github.com/lit/lit/issues/4866) from the Lit repo.
 1. For constructor props support, you will have to [map attributes to properties](https://greenwoodjs.dev/docs/plugins/lit-ssr/#usage)
-1. Lit does not support [`CSSStyleSheet` (aka CSS Modules) in their SSR DOM shim](https://github.com/lit/lit/issues/4862).  As an alternative, you may consider using Greenwood's [**Raw adapter**](https://greenwoodjs.dev/docs/plugins/raw/) to inline CSS in `<style>` tags into your custom elements.
 1. Full hydration support is not available yet.  See [this Greenwood issue](https://github.com/ProjectEvergreen/greenwood/issues/880) to follow along with when it will land.
 
 _**Note**: As `LitElement` [only renders into Shadow Roots](https://github.com/lit/lit/issues/3080#issuecomment-1165158794), for pages and layouts this plugin will extract the HTML contents of the SSR'd `<template>` tag and output those content into the **Light DOM** of your page._

--- a/packages/plugin-renderer-lit/src/execute-route-module.js
+++ b/packages/plugin-renderer-lit/src/execute-route-module.js
@@ -2,6 +2,7 @@ import { render, LitElementRenderer } from "@lit-labs/ssr";
 import { collectResult } from "@lit-labs/ssr/lib/render-result.js";
 import { html, literal, unsafeStatic } from "lit/static-html.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import "@lit-labs/ssr-dom-shim/register-css-hook.js";
 
 async function executeRouteModule({
   moduleUrl,

--- a/packages/plugin-renderer-lit/test/cases/loaders-build.prerender.import-attributes/src/components/header/header.js
+++ b/packages/plugin-renderer-lit/test/cases/loaders-build.prerender.import-attributes/src/components/header/header.js
@@ -1,13 +1,10 @@
 import { html, LitElement } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import nav from "./nav.json" with { type: "json" };
-
-// CSSStyleSheet is not supported by Lit
-// https://github.com/lit/lit/issues/2631#issuecomment-1065400805
-// import sheet from './header.css' with { type: 'css' };
+import sheet from "./header.css" with { type: "css" };
 
 class HeaderComponent extends LitElement {
-  // static styles = [sheet];
+  static styles = [sheet];
 
   render() {
     return html`


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1633 

## Documentation 

N / A

## Summary of Changes

1. Update latest Lit SSR packages for CSS Module Scripts support

> See minimal working reproduction here - https://github.com/thescientist13/lit-ssr-css-modules/pull/2

## TODO
1. [x] Waiting on a new Lit release for https://github.com/lit/lit/pull/5240
1. [x] can we remove the need for the `resolution`?  See https://github.com/ProjectEvergreen/greenwood/pull/1647/changes#r3253292087

----

Could Greenwood also self load its own custom loaders script too?  🤔 