### PR TITLE
fix(cli): #1572 refactor serve lifecycle for response body consumed error

### DIFF
--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -106,16 +106,14 @@ async function getDevServer(compilation) {
       // when looping through and sharing responses between plugins
       const response = await resourcePlugins.reduce(async (responsePromise, plugin) => {
         const intermediateResponse = await responsePromise;
+        // Create a single snapshot to avoid multiple clone() calls failing on exhausted bodies
+        const responseSnapshot = intermediateResponse.clone();
         if (
           plugin.shouldPreIntercept &&
-          (await plugin.shouldPreIntercept(url, request, intermediateResponse.clone()))
+          (await plugin.shouldPreIntercept(url, request, responseSnapshot.clone()))
         ) {
-          const current = await plugin.preIntercept(
-            url,
-            request,
-            await intermediateResponse.clone(),
-          );
-          const merged = mergeResponse(intermediateResponse.clone(), current);
+          const current = await plugin.preIntercept(url, request, await responseSnapshot.clone());
+          const merged = mergeResponse(responseSnapshot, current);
 
           return Promise.resolve(merged);
         } else {
@@ -152,12 +150,14 @@ async function getDevServer(compilation) {
       // when looping through and sharing responses between plugins
       const response = await resourcePlugins.reduce(async (responsePromise, plugin) => {
         const intermediateResponse = await responsePromise;
+        // Create a single "snapshot" to avoid multiple clone() calls failing on exhausted bodies
+        const responseSnapshot = intermediateResponse.clone();
         if (
           plugin.shouldIntercept &&
-          (await plugin.shouldIntercept(url, request, intermediateResponse.clone()))
+          (await plugin.shouldIntercept(url, request, responseSnapshot.clone()))
         ) {
-          const current = await plugin.intercept(url, request, await intermediateResponse.clone());
-          const merged = mergeResponse(intermediateResponse.clone(), current);
+          const current = await plugin.intercept(url, request, await responseSnapshot.clone());
+          const merged = mergeResponse(responseSnapshot, current);
 
           return Promise.resolve(merged);
         } else {


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1572 

> Specifically in reference to reproduction / resolution found here - https://github.com/ProjectEvergreen/playground.wcc.dev/issues/9#issuecomment-3948473121

## Documentation 

N / A

## Summary of Changes

1. Refactor `shouldPreIntercept` / `shouldIntercept` response cloning (per [this patch](https://github.com/ProjectEvergreen/playground.wcc.dev/pull/18/changes#diff-0580326cb53e180b3b4ea72100199290a52621a039139c827f629841c0890ad8))

## TODO
1. [x] ~~pull in `shouldServe` change? (if not, then not sure if we should still keep this issue open as part of the 1.0 milestone just to make sure, since original issue seemed to be at this point in _serve.js_)~~ - our patch downstream seems to match here and is working well, so let's consider this "done"