### PR TITLE
enhancement(cli): #1690 eliminate api route instantiation during greenwood lifecycles

### DIFF
--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -108,8 +108,10 @@ const generateGraph = async (compilation) => {
             return;
           }
 
-          // TODO should API routes be run in isolation mode like SSR pages?
-          const { isolation } = await import(filenameUrl).then((module) => module);
+          // TODO: should API routes be run in isolation mode like SSR pages?
+          // TODO: is there a better way to detect for isolation option?
+          const contents = await fs.readFile(filenameUrl, "utf8");
+          const isolation = contents.indexOf("export const isolation = true;") >= 0;
           const { segmentKey, dynamicRoute } = getDynamicSegmentsFromRoute({
             route,
             relativePagePath,

--- a/packages/cli/test/cases/build.default.api/build.default.api.spec.js
+++ b/packages/cli/test/cases/build.default.api/build.default.api.spec.js
@@ -3,7 +3,7 @@
  * Run Greenwood build command with no config.
  *
  * User Result
- * Should generate a bare bones Greenwood build.
+ * Should generate a bare bones Greenwood build and not error on generating API routes (that have side-effects).
  *
  * User Command
  * greenwood build
@@ -12,7 +12,10 @@
  * None (Greenwood Default)
  *
  * User Workspace
- * Empty
+ * src/
+ *   pages/
+ *     api/
+ *       greeting.js
  */
 import { expect } from "chai";
 import glob from "glob-promise";
@@ -23,7 +26,7 @@ import { fileURLToPath } from "node:url";
 import { runSmokeTest } from "../../../../../test/smoke-test.js";
 
 describe("Build Greenwood With: ", function () {
-  const LABEL = "Default (Empty) Greenwood Configuration and Workspace";
+  const LABEL = "Default Config and API Routes";
   const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   let runner;
@@ -49,7 +52,13 @@ describe("Build Greenwood With: ", function () {
       });
 
       it("should contain no JS files in the output directory", async function () {
-        expect(await glob.promise(path.join(this.context.publicDir, "*.js"))).to.have.lengthOf(0);
+        expect(await glob.promise(path.join(this.context.publicDir, "*.html"))).to.have.lengthOf(0);
+      });
+
+      it("should contain one API route in the output directory", async function () {
+        expect(
+          await glob.promise(path.join(this.context.publicDir, "api/**/*.js")),
+        ).to.have.lengthOf(1);
       });
     });
   });

--- a/packages/cli/test/cases/build.default.api/src/pages/api/greeting.js
+++ b/packages/cli/test/cases/build.default.api/src/pages/api/greeting.js
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+
+// tests that API routes don't execute at build time
+// https://github.com/ProjectEvergreen/greenwood/issues/1690
+assert(process.env.NODE_ENV);
+
+export default function handler() {
+  return new Response("Hello World");
+}


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1690 

## Documentation 

N / A

## Summary of Changes

1. Don't `import` API routes during graph lifecycle

## TODO
1.  [x] Track a better way to do this - put this into my personal backlog for now
    - for example, would this line with a comment still lead to a false positive? - `// export const isolation = true`