### PR TITLE
fix(plugins): #1633 lit css module scripts not emitting style tag content in ssr output

### DIFF
--- a/packages/plugin-renderer-lit/src/execute-route-module.js
+++ b/packages/plugin-renderer-lit/src/execute-route-module.js
@@ -1,8 +1,9 @@
-import { render, LitElementRenderer } from "@lit-labs/ssr";
+// order matters here - https://github.com/thescientist13/lit-ssr-css-modules/pull/3
+import "@lit-labs/ssr-dom-shim/register-css-hook.js";
+const { render, LitElementRenderer } = await import("@lit-labs/ssr");
 import { collectResult } from "@lit-labs/ssr/lib/render-result.js";
 import { html, literal, unsafeStatic } from "lit/static-html.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
-import "@lit-labs/ssr-dom-shim/register-css-hook.js";
 
 async function executeRouteModule({
   moduleUrl,

--- a/packages/plugin-renderer-lit/test/cases/loaders-build.prerender.import-attributes/loaders-build.prerender.import-attributes.spec.js
+++ b/packages/plugin-renderer-lit/test/cases/loaders-build.prerender.import-attributes/loaders-build.prerender.import-attributes.spec.js
@@ -89,6 +89,20 @@ describe("Build Greenwood With Custom Lit Renderer for SSG prerendering: ", func
         expect(nav[0].textContent).to.equal("Home");
         expect(nav[1].textContent).to.equal("About");
       });
+
+      // https://github.com/thescientist13/lit-ssr-css-modules/pull/3
+      it("should have the expected <style> tag output from SSR", function () {
+        const wrapper = new JSDOM(
+          dom.window.document.querySelectorAll('app-header template[shadowrootmode="open"]')[0]
+            .innerHTML,
+        );
+        const style = wrapper.window.document.querySelectorAll("style");
+
+        expect(style.length).to.equal(1);
+        expect(style[0].textContent.replace(/ /g, "").replace(/\n/g, "").trim()).to.equal(
+          "header{color:red;}",
+        );
+      });
     });
   });
 

--- a/packages/plugin-renderer-lit/test/cases/loaders-build.prerender.import-attributes/src/components/header/header.css
+++ b/packages/plugin-renderer-lit/test/cases/loaders-build.prerender.import-attributes/src/components/header/header.css
@@ -1,5 +1,3 @@
-:host {
-  header {
-    color: red;
-  }
+header {
+  color: red;
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #1633 

> See https://github.com/thescientist13/lit-ssr-css-modules/pull/3

## Documentation 

N / A

## Summary of Changes

1. Change ordering / import convention for Lit SSR imports for CSS Module Scripts `<style>` tag output