### PR TITLE
fix(cli): #1622 fix get static params types

### DIFF
--- a/packages/cli/src/types/ssr.d.ts
+++ b/packages/cli/src/types/ssr.d.ts
@@ -37,7 +37,9 @@ export type StaticPath = { params: object };
 export type StaticParam = Record<string, unknown>;
 
 export type GetStaticPaths = () => Promise<StaticPath[]>;
-export type GetStaticParams = ({ params }) => Promise<StaticParam>;
+export type GetStaticParams = ({
+  params,
+}: InferGetStaticParamsType<StaticPath>) => Promise<StaticParam>;
 
 export type InferGetStaticParamsType<T> = T extends () => Promise<Array<{ params: infer P }>>
   ? P

--- a/packages/plugin-graphql/src/core/client.d.ts
+++ b/packages/plugin-graphql/src/core/client.d.ts
@@ -1,6 +1,6 @@
 declare module "@greenwood/plugin-graphql/src/core/client.js" {
   const Client: {
-    query: (params: string) => Promise;
+    query: (params: string) => Promise<Response>;
   };
 
   export default Client;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

relates to #1622 

Was seeing [this error](https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/112#issuecomment-4822948240) in this project
```sh
➜  www.analogstudios.net git:(v2) ✗ npm run lint

> www.analogstudios.net@2.0.0 lint
> eslint && ls-lint "./src/**/*.js" && stylelint "./src/**/*.css" && tsc

node_modules/@greenwood/cli/src/types/ssr.d.ts:40:34 - error TS7031: Binding element 'params' implicitly has an 'any' type.

40 export type GetStaticParams = ({ params }) => Promise<StaticParam>;
                                    ~~~~~~


Found 1 error in node_modules/@greenwood/cli/src/types/ssr.d.ts:40
```

## Documentation 

N / A

## Summary of Changes

1. Fix up `GetStaticParams` types
1. Fix GraphQL client types