### PR TITLE
fix(cli): #1622 fix resource linking for pages when using get static paths

### DIFF
--- a/packages/cli/src/lib/graph-utils.js
+++ b/packages/cli/src/lib/graph-utils.js
@@ -28,28 +28,42 @@ function getStaticPages(compilation) {
 }
 
 // get a page by route; including getStaticPaths or dynamic SSR pages
+// not sure if there's a better way to filter through all the possible matches in one-shot?
 function getMatchingPageByRoute(compilation, route) {
   const { graph, config } = compilation;
 
-  return graph.find((page) => {
-    return (
-      // exact match
-      page.route === route ||
-      // dynamic route
-      (page.segment &&
-        new URLPattern({ pathname: `${config.basePath}${page.segment.pathname}` }).test(
-          `https://example.com${route}`,
-        )) ||
-      // getStaticPaths
-      (page.hasStaticParams &&
-        page.staticPaths.find((path) => {
-          const { segment } = page;
-          const staticRoute = route.replace(`[${segment.key}]`, path.params[segment.key]);
+  const exactMatch = graph.find((page) => page.route === route);
 
-          return `${config.basePath}${staticRoute}` === route;
-        }))
-    );
-  });
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  const dynamicMatch = graph.find(
+    (page) =>
+      page.segment &&
+      new URLPattern({ pathname: `${config.basePath}${page.segment.pathname}` }).test(
+        `https://example.com${route}`,
+      ),
+  );
+
+  if (dynamicMatch) {
+    return dynamicMatch;
+  }
+
+  const staticMatch = graph.find(
+    (page) =>
+      page.hasStaticParams &&
+      page.staticPaths.find((path) => {
+        const { segment } = page;
+        const staticRoute = route.replace(`[${segment.key}]`, path.params[segment.key]);
+
+        return `${config.basePath}${staticRoute}` === route;
+      }),
+  );
+
+  if (staticMatch) {
+    return staticMatch;
+  }
 }
 
 export { getDynamicPages, getStaticPages, getMatchingPageByRoute };

--- a/packages/cli/src/lib/graph-utils.js
+++ b/packages/cli/src/lib/graph-utils.js
@@ -38,19 +38,7 @@ function getMatchingPageByRoute(compilation, route) {
     return exactMatch;
   }
 
-  const dynamicMatch = graph.find(
-    (page) =>
-      page.segment &&
-      new URLPattern({ pathname: `${config.basePath}${page.segment.pathname}` }).test(
-        `https://example.com${route}`,
-      ),
-  );
-
-  if (dynamicMatch) {
-    return dynamicMatch;
-  }
-
-  const staticMatch = graph.find(
+  const staticParamsMatch = graph.find(
     (page) =>
       page.hasStaticParams &&
       page.staticPaths.find((path) => {
@@ -61,8 +49,20 @@ function getMatchingPageByRoute(compilation, route) {
       }),
   );
 
-  if (staticMatch) {
-    return staticMatch;
+  if (staticParamsMatch) {
+    return staticParamsMatch;
+  }
+
+  const dynamicMatch = graph.find(
+    (page) =>
+      page.segment &&
+      new URLPattern({ pathname: `${config.basePath}${page.segment.pathname}` }).test(
+        `https://example.com${route}`,
+      ),
+  );
+
+  if (dynamicMatch) {
+    return dynamicMatch;
   }
 }
 

--- a/packages/cli/src/lib/resource-utils.js
+++ b/packages/cli/src/lib/resource-utils.js
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import { hashString } from "./hashing-utils.js";
 import { getResolvedHrefFromPathnameShortcut } from "../lib/node-modules-utils.js";
+import { getMatchingPageByRoute } from "../lib/graph-utils.js";
 import { parse } from "node-html-parser";
 import { asyncMap } from "./async-utils.js";
 
@@ -208,9 +209,9 @@ async function trackResourcesForRoute(html, compilation, route) {
     });
   });
 
-  compilation.graph.find((page) => page.route === route).resources = resources.map(
-    (resource) => resource.sourcePathURL.pathname,
-  );
+  const matchingRoute = getMatchingPageByRoute(compilation, route);
+
+  matchingRoute.resources = resources.map((resource) => resource.sourcePathURL.pathname);
 
   return resources;
 }

--- a/packages/cli/src/plugins/resource/plugin-active-content.js
+++ b/packages/cli/src/plugins/resource/plugin-active-content.js
@@ -7,6 +7,7 @@ import {
   filterContentByCollection,
   filterContentByRoute,
 } from "../../lib/content-utils.js";
+import { getMatchingPageByRoute } from "../../lib/graph-utils.js";
 import fs from "node:fs/promises";
 
 const importMap = {
@@ -78,7 +79,7 @@ class ContentAsDataResource {
 
   async intercept(url, request, response) {
     const { polyfills, devServer } = this.compilation.config;
-    const matchingRoute = this.compilation.graph.find((page) => page.route === url.pathname);
+    const matchingRoute = getMatchingPageByRoute(this.compilation, url.pathname);
     const body = await response.text();
     let newBody = body;
 

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -8,7 +8,7 @@ import fs from "node:fs/promises";
 import { getPageLayout, getAppLayout, getGreenwoodScripts } from "../../lib/layout-utils.js";
 import { requestAsObject } from "../../lib/resource-utils.js";
 import { getMatchingDynamicSsrRoute, getParamsFromSegment } from "../../lib/url-utils.js";
-import { getMatchingPageByRoute } from "@greenwood/cli/src/lib/graph-utils.js";
+import { getMatchingPageByRoute } from "../../lib/graph-utils.js";
 import { Worker } from "node:worker_threads";
 import { parse } from "node-html-parser";
 

--- a/packages/cli/test/cases/serve.dynamic-routing-static-paths/serve.dynamic-routing-static-paths.spec.js
+++ b/packages/cli/test/cases/serve.dynamic-routing-static-paths/serve.dynamic-routing-static-paths.spec.js
@@ -13,6 +13,11 @@
  *
  * User Workspace
  *  src/
+ *   components/
+ *     greeting.js
+ *     header.js
+ *   layouts/
+ *     app.html
  *   pages/
  *     blog/
  *       [slug].ts
@@ -20,6 +25,7 @@
  *       [title].js
  *     product/
  *       [name].js
+ *     index.html
  *   services/
  *     blog-posts.ts
  */
@@ -70,7 +76,53 @@ describe("Serve Greenwood With: ", function () {
           fs.glob("*.js", { cwd: new URL("./public", import.meta.url) }),
         );
 
-        expect(files.length).to.equal(2);
+        expect(files.length).to.equal(4);
+      });
+    });
+
+    describe("A static HTML page with correctly synced page resources", function () {
+      let response;
+      let dom;
+      let body;
+
+      before(async function () {
+        response = await fetch(`${hostname}/`);
+        body = await response.clone().text();
+        dom = new JSDOM(body);
+      });
+
+      it("should have the expected output for the page in the h1 tag", function () {
+        const headings = dom.window.document.querySelectorAll("body > h1");
+
+        expect(headings.length).to.equal(1);
+        expect(headings[0].textContent).to.equal("This is my site");
+      });
+
+      it("should have the expected output for the page in the h2 tag", function () {
+        const headings = dom.window.document.querySelectorAll("body > h2");
+
+        expect(headings.length).to.equal(1);
+        expect(headings[0].textContent).to.equal("Home Page");
+      });
+
+      it("should have the expected bundled script tag for the header component", function () {
+        const scripts = dom.window.document.querySelectorAll("head > script");
+        const headingScript = Array.from(scripts).filter(
+          (script) => script.getAttribute("src")?.indexOf("header") > 0,
+        );
+
+        expect(headingScript.length).to.equal(1);
+        expect(headingScript[0].getAttribute("src").startsWith("/header.")).to.equal(true);
+      });
+
+      it("should have the expected bundled script tag for the greeting component", function () {
+        const scripts = dom.window.document.querySelectorAll("head > script");
+        const greetingScript = Array.from(scripts).filter(
+          (script) => script.getAttribute("src")?.indexOf("greeting") > 0,
+        );
+
+        expect(greetingScript.length).to.equal(1);
+        expect(greetingScript[0].getAttribute("src").startsWith("/greeting.")).to.equal(true);
       });
     });
 
@@ -86,8 +138,25 @@ describe("Serve Greenwood With: ", function () {
         dom = new JSDOM(body);
       });
 
-      it("should have the expected output for the page in the title", function () {
+      it("should have the expected bundled script tag for the header component", function () {
+        const scripts = dom.window.document.querySelectorAll("head > script");
+        const headingScript = Array.from(scripts).filter(
+          (script) => script.getAttribute("src")?.indexOf("header") > 0,
+        );
+
+        expect(headingScript.length).to.equal(1);
+        expect(headingScript[0].getAttribute("src").startsWith("/header.")).to.equal(true);
+      });
+
+      it("should have the expected output for the page in the h1 tag", function () {
         const headings = dom.window.document.querySelectorAll("body > h1");
+
+        expect(headings.length).to.equal(1);
+        expect(headings[0].textContent).to.equal("This is my site");
+      });
+
+      it("should have the expected output for the page in the h2 tag", function () {
+        const headings = dom.window.document.querySelectorAll("body > h2");
 
         expect(headings.length).to.equal(1);
         expect(headings[0].textContent).to.equal("First Post");
@@ -113,8 +182,25 @@ describe("Serve Greenwood With: ", function () {
         dom = new JSDOM(body);
       });
 
-      it("should have the expected output for the page", function () {
-        const headings = dom.window.document.querySelectorAll("h1");
+      it("should have the expected bundled script tag for the header component", function () {
+        const scripts = dom.window.document.querySelectorAll("head > script");
+        const headingScript = Array.from(scripts).filter(
+          (script) => script.getAttribute("src")?.indexOf("header") > 0,
+        );
+
+        expect(headingScript.length).to.equal(1);
+        expect(headingScript[0].getAttribute("src").startsWith("/header.")).to.equal(true);
+      });
+
+      it("should have the expected output for the page in the h1 tag", function () {
+        const headings = dom.window.document.querySelectorAll("body > h1");
+
+        expect(headings.length).to.equal(1);
+        expect(headings[0].textContent).to.equal("This is my site");
+      });
+
+      it("should have the expected output for the page in the h2 tag", function () {
+        const headings = dom.window.document.querySelectorAll("body > h2");
 
         expect(headings.length).to.equal(1);
         expect(headings[0].textContent).to.equal(name);
@@ -133,11 +219,28 @@ describe("Serve Greenwood With: ", function () {
         dom = new JSDOM(body);
       });
 
-      it("should have the expected output for the page", function () {
-        const headings = dom.window.document.querySelectorAll("h1");
+      it("should have the expected bundled script tag for the header component", function () {
+        const scripts = dom.window.document.querySelectorAll("head > script");
+        const headingScript = Array.from(scripts).filter(
+          (script) => script.getAttribute("src")?.indexOf("header") > 0,
+        );
+
+        expect(headingScript.length).to.equal(1);
+        expect(headingScript[0].getAttribute("src").startsWith("/header.")).to.equal(true);
+      });
+
+      it("should have the expected output for the page in the h1 tag", function () {
+        const headings = dom.window.document.querySelectorAll("body > h1");
 
         expect(headings.length).to.equal(1);
-        expect(headings[0].textContent).to.equal(title.toUpperCase().replace(/-/g, " "));
+        expect(headings[0].textContent).to.equal("This is my site");
+      });
+
+      it("should have the expected output for the page in the h2 tag", function () {
+        const headings = dom.window.document.querySelectorAll("body > h2");
+
+        expect(headings.length).to.equal(1);
+        expect(headings[0].textContent).to.equal(title.toUpperCase());
       });
     });
   });

--- a/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/components/greeting.js
+++ b/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/components/greeting.js
@@ -1,0 +1,13 @@
+export default class Greeting extends HTMLElement {
+  connectedCallback() {
+    const user = {
+      name: this.getAttribute("name") || "World",
+    };
+
+    this.innerHTML = `
+      <h3>Hello ${user.name}!</h3>
+    `;
+  }
+}
+
+customElements.define("x-greeting", Greeting);

--- a/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/components/header.js
+++ b/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/components/header.js
@@ -1,0 +1,18 @@
+export default class Header extends HTMLElement {
+  connectedCallback() {
+    if (!this.shadowRoot) {
+      const template = document.createElement("template");
+
+      template.innerHTML = `
+        <header>
+          <span>Welcome to my site</span>
+        </header>
+      `;
+
+      this.attachShadow({ mode: "open" });
+      this.shadowRoot.appendChild(template.content.cloneNode(true));
+    }
+  }
+}
+
+customElements.define("x-header", Header);

--- a/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/layouts/app.html
+++ b/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/layouts/app.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <script type="module" src="../components/header.js"></script>
+  </head>
+  <body>
+    <x-header></x-header>
+    <h1>This is my site</h1>
+    <output for="page"></output>
+  </body>
+</html>

--- a/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/pages/blog/[slug].ts
+++ b/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/pages/blog/[slug].ts
@@ -39,7 +39,7 @@ export default class BlogPostPage extends HTMLElement {
   connectedCallback() {
     this.innerHTML = `
       <body>
-        <h1>${this.#post.title}</h1>
+        <h2>${this.#post.title}</h2>
         <p>${this.#post.content}</p>
       </body>
     `;

--- a/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/pages/events/[title].js
+++ b/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/pages/events/[title].js
@@ -8,7 +8,7 @@ export default class EventDetailPage extends HTMLElement {
 
   async connectedCallback() {
     this.innerHTML = `
-      <h1>${this.#title.toUpperCase().replace(/-/g, " ")}</h1>
+      <h2>${this.#title.toUpperCase().replace(/-/g, " ")}</h2>
     `;
   }
 }

--- a/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/pages/index.html
+++ b/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/pages/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <script type="module" src="../components/greeting.js"></script>
+  </head>
+  <body>
+    <h2>Home Page</h2>
+    <x-greeting></x-greeting>
+  </body>
+</html>

--- a/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/pages/product/[name].js
+++ b/packages/cli/test/cases/serve.dynamic-routing-static-paths/src/pages/product/[name].js
@@ -27,5 +27,5 @@ export async function getStaticParams({ params }) {
 }
 
 export async function getBody(compilation, request, page, params) {
-  return `<h1>${params.product.name}</h1>`;
+  return `<h2>${params.product.name}</h2>`;
 }

--- a/packages/plugin-import-raw/src/index.js
+++ b/packages/plugin-import-raw/src/index.js
@@ -5,6 +5,7 @@
  */
 import { IMPORT_MAP_RESOLVED_PREFIX } from "@greenwood/cli/src/lib/walker-package-ranger.js";
 import { mergeImportMap } from "@greenwood/cli/src/lib/node-modules-utils.js";
+import { getMatchingPageByRoute } from "@greenwood/cli/src/lib/graph-utils.js";
 import { parse } from "node-html-parser";
 
 function generateImportMapExtensionsMap(body = "", extensions = []) {
@@ -35,7 +36,7 @@ class ImportMapExtensionsResourcePlugin {
 
   async shouldIntercept(url, request, response) {
     const { protocol, pathname } = url;
-    const hasMatchingPageRoute = this.compilation.graph.find((node) => node.route === pathname);
+    const hasMatchingPageRoute = getMatchingPageByRoute(this.compilation, pathname);
 
     return (
       this.options?.importMapExtensions?.length > 0 &&

--- a/packages/plugin-markdown/src/index.js
+++ b/packages/plugin-markdown/src/index.js
@@ -109,6 +109,7 @@ class MarkdownResource {
 
   async shouldServe(url) {
     const { pathname } = url;
+    // we only want exact matches, since markdown pages cannot be dynamic
     const hasMatchingPageRoute = this.compilation.graph.find((node) => node.route === pathname);
 
     return hasMatchingPageRoute?.pageHref?.endsWith(`.${PLUGIN_EXTENSION}`);


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #1622 

Noticed in [this project](https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/112#pullrequestreview-4585963456) that page specific resources were missing when building
<img width="1889" height="921" alt="image" src="https://github.com/user-attachments/assets/17d567dc-d51f-4bb4-9244-196bc6e28a27" />
<img width="1911" height="932" alt="image" src="https://github.com/user-attachments/assets/b9bda41c-571d-4c6f-a655-de6c965e3df3" />

## Documentation 

N / A

## Summary of Changes

1. Refactor page matching in `getMatchingPageByRoute` to have more explicit matching by "specificity"
1. Update `trackResourceForRoute` to leverage `getMatchingPageByRoute`
1. Misc refactoring
1. Update test case to reproduce / validate