### PR TITLE
fix(plugins): #1667 scope jsx import plugin intercepting to pages

### DIFF
--- a/packages/plugin-import-jsx/src/index.js
+++ b/packages/plugin-import-jsx/src/index.js
@@ -6,6 +6,7 @@
 import { generate } from "astring";
 import { parseJsx } from "wc-compiler/jsx-loader";
 import { mergeImportMap } from "@greenwood/cli/src/lib/node-modules-utils.js";
+import { getMatchingPageByRoute } from "@greenwood/cli/src/lib/graph-utils.js";
 import { parse } from "node-html-parser";
 
 const importMap = {
@@ -43,8 +44,12 @@ class ImportJsxResource {
   }
 
   async shouldIntercept(url, request, response) {
+    const matchingRoute = getMatchingPageByRoute(this.compilation, url.pathname);
+
     return (
-      this.inferredObservability && response.headers.get("Content-Type")?.indexOf("text/html") >= 0
+      this.inferredObservability &&
+      matchingRoute &&
+      response.headers.get("Content-Type")?.indexOf("text/html") >= 0
     );
   }
 


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to https://github.com/ProjectEvergreen/greenwood/pull/1667

> _Found an issue where the JSX import plugin was trying to [intercept API routes that were returning HTML](https://github.com/thescientist13/greenwood-jsx/pull/14#issuecomment-4826876063)_

## Documentation 

N / A

## Summary of Changes

1. Scope JSX import plugin intercepting to only page routes