### PR TITLE
feature(init): #1702 upgrade ts-starter to typescript v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
     "mocha": "^9.1.3",
     "prettier": "^3.4.2",
     "rimraf": "^5.0.10",
-    "typescript": "^5.8.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
     "mocha": "^9.1.3",
     "prettier": "^3.4.2",
     "rimraf": "^5.0.10",
-    "typescript": "^5.8.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/init/src/template-base-ts/package.json
+++ b/packages/init/src/template-base-ts/package.json
@@ -7,6 +7,6 @@
     "check": "tsc"
   },
   "devDependencies": {
-    "typescript": "^5.8.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -35,7 +35,7 @@
     "@greenwood/cli": "^0.31.0"
   },
   "dependencies": {
-    "typescript": "^5.1.6"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.34.0"

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -35,7 +35,7 @@
     "@greenwood/cli": "^0.31.0"
   },
   "dependencies": {
-    "typescript": "^5.1.6"
+    "typescript": "^6.0.3"
   },
   "devDependencies": {
     "@greenwood/cli": "^0.34.0-alpha.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18229,10 +18229,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-"typescript@>=3 < 6", typescript@^5.0.0, typescript@^5.1.6, typescript@^5.4.4, typescript@^5.8.2:
+"typescript@>=3 < 6", typescript@^5.0.0, typescript@^5.4.4:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 uglify-js@^3.1.4:
   version "3.19.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18220,10 +18220,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-"typescript@>=3 < 6", typescript@^5.0.0, typescript@^5.1.6, typescript@^5.4.4, typescript@^5.8.2:
+"typescript@>=3 < 6", typescript@^5.0.0, typescript@^5.4.4:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 uglify-js@^3.1.4:
   version "3.19.3"


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #1702 

## Documentation 

1. [x] https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/288

## Summary of Changes
1. Upgrade init TypeScript starter to install TypeScript `6.x`

## TODO
1. [x] Confirm all default settings still work - https://greenwoodjs.dev/docs/resources/typescript/#setup
1. [x] merge docs PR