### PR TITLE
fix(cli): #1707 skip over unsupported api files instead of aborting the build

### DIFF
--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -105,7 +105,9 @@ const generateGraph = async (compilation) => {
         if (isApiRoute) {
           if (extension !== "js" && extension !== "ts" && !isCustom) {
             console.warn(`${filenameUrl} is not a supported API file extension, skipping...`);
-            return;
+            // skip this file but keep walking the directory instead of aborting the whole build
+            // https://github.com/ProjectEvergreen/greenwood/issues/1707
+            continue;
           }
 
           // is there a better way to detect for isolation export without having to actually import() the module?

--- a/packages/cli/test/cases/build.default.api-ignored-files/build.default.api-ignored-files.spec.js
+++ b/packages/cli/test/cases/build.default.api-ignored-files/build.default.api-ignored-files.spec.js
@@ -1,0 +1,77 @@
+/*
+ * Use Case
+ * Run Greenwood build command with no config and an unsupported (non-js/ts) file in the api directory.
+ *
+ * User Result
+ * Should generate a bare bones Greenwood build, skipping the unsupported api file while still
+ * emitting the valid API route and pages (instead of aborting the whole build).
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * None (Greenwood Default)
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     api/
+ *       greeting.js
+ *       notes.txt
+ *     index.html
+ */
+import { expect } from "chai";
+import glob from "glob-promise";
+import path from "node:path";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+
+// https://github.com/ProjectEvergreen/greenwood/issues/1707
+describe("Build Greenwood With: ", function () {
+  const LABEL = "Default Config and Unsupported File Extension in the API Directory";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+    });
+
+    runSmokeTest(["public"]);
+
+    describe("Default output", function () {
+      it("should emit the index page in the output directory", async function () {
+        expect(
+          await glob.promise(path.join(this.context.publicDir, "index.html")),
+        ).to.have.lengthOf(1);
+      });
+
+      it("should emit the one valid API route in the output directory", async function () {
+        expect(
+          await glob.promise(path.join(this.context.publicDir, "api/**/*.js")),
+        ).to.have.lengthOf(1);
+      });
+
+      it("should not emit the unsupported api file in the output directory", async function () {
+        expect(
+          await glob.promise(path.join(this.context.publicDir, "api/**/*.txt")),
+        ).to.have.lengthOf(0);
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/cli/test/cases/build.default.api-ignored-files/src/pages/api/greeting.js
+++ b/packages/cli/test/cases/build.default.api-ignored-files/src/pages/api/greeting.js
@@ -1,0 +1,3 @@
+export default function handler() {
+  return new Response("Hello World");
+}

--- a/packages/cli/test/cases/build.default.api-ignored-files/src/pages/api/notes.txt
+++ b/packages/cli/test/cases/build.default.api-ignored-files/src/pages/api/notes.txt
@@ -1,0 +1,1 @@
+just a stray text file a dev left in the api directory

--- a/packages/cli/test/cases/build.default.api-ignored-files/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.api-ignored-files/src/pages/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>Home</title>
+  </head>
+  <body>
+    <h1>Home Page</h1>
+  </body>
+</html>


### PR DESCRIPTION
## Related Issue

Resolves #1707

## Documentation

N / A — no user-facing documentation changes; this is a bug fix to build-time behavior.

## Summary of Changes

1. [x] Fixed `walkDirectoryForPages` in `packages/cli/src/lifecycles/graph.js` to `continue;` (skip the current file) instead of `return;` when an API-route file has an unsupported extension. The bare `return;` returned `undefined` out of the recursive page walk, causing the caller to throw `TypeError: Cannot read properties of undefined (reading 'pages')` and aborting the whole build.
2. [x] Added a regression test case `packages/cli/test/cases/build.default.api-ignored-files/` with a fixture containing a stray `src/pages/api/notes.txt` alongside a valid `src/pages/api/greeting.js` and `src/pages/index.html`. The spec asserts the build succeeds and emits both the index page and the valid API route while skipping the unsupported file.
3. [x] Verified the new spec fails on unpatched source (the `TypeError`) and passes with the fix.

No breaking changes.
