### PR TITLE
fix(cli): #1709 guard frontmatter title/label/id decode so a literal % cannot crash the build

### DIFF
--- a/packages/cli/src/lib/url-utils.js
+++ b/packages/cli/src/lib/url-utils.js
@@ -49,10 +49,23 @@ function getStaticRouteFromDynamicRoute(dynamicStaticPath, segment, route) {
   return `${route.replace(`[${segment.key}]`, dynamicStaticPath.params[segment.key])}`;
 }
 
+// decodeURIComponent throws URIError on a "%" that does not start a valid escape
+// sequence (e.g. a frontmatter title like "100% Complete"), so fall back to
+// returning the value untouched instead of aborting the whole build
+// https://github.com/ProjectEvergreen/greenwood/issues/1709
+function safeDecodeURIComponent(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 export {
   getDynamicSegmentsFromRoute,
   getMatchingDynamicApiRoute,
   getParamsFromSegment,
   getMatchingDynamicSsrRoute,
   getStaticRouteFromDynamicRoute,
+  safeDecodeURIComponent,
 };

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -26,6 +26,18 @@ function getLabelFromRoute(_route) {
     .join(" ");
 }
 
+// decodeURIComponent is only meant to normalize percent-encoded filenames; raw
+// frontmatter values (e.g. "100% Complete") can contain a bare "%" that throws
+// URIError and aborts the whole build, so fall back to the original string
+// https://github.com/ProjectEvergreen/greenwood/issues/1709
+function safeDecodeURIComponent(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 function getIdFromRelativePathPath(relativePathPath, extension) {
   return relativePathPath
     .replace(`.${extension}`, "")
@@ -284,9 +296,9 @@ const generateGraph = async (compilation) => {
           });
 
           const page = {
-            id: decodeURIComponent(getIdFromRelativePathPath(relativePagePath, extension)),
-            label: decodeURIComponent(label),
-            title: title ? decodeURIComponent(title) : title,
+            id: safeDecodeURIComponent(getIdFromRelativePathPath(relativePagePath, extension)),
+            label: safeDecodeURIComponent(label),
+            title: title ? safeDecodeURIComponent(title) : title,
             route: `${basePath}${route}`,
             layout,
             data: customData || {},

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import fm from "front-matter";
 import { checkResourceExists, requestAsObject } from "../lib/resource-utils.js";
 import { activeFrontmatterKeys } from "../lib/content-utils.js";
-import { getDynamicSegmentsFromRoute } from "../lib/url-utils.js";
+import { getDynamicSegmentsFromRoute, safeDecodeURIComponent } from "../lib/url-utils.js";
 import { Worker } from "node:worker_threads";
 
 function getLabelFromRoute(_route) {
@@ -24,18 +24,6 @@ function getLabelFromRoute(_route) {
       return `${routePart.charAt(0).toUpperCase()}${routePart.substring(1)}`;
     })
     .join(" ");
-}
-
-// decodeURIComponent is only meant to normalize percent-encoded filenames; raw
-// frontmatter values (e.g. "100% Complete") can contain a bare "%" that throws
-// URIError and aborts the whole build, so fall back to the original string
-// https://github.com/ProjectEvergreen/greenwood/issues/1709
-function safeDecodeURIComponent(value) {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
 }
 
 function getIdFromRelativePathPath(relativePathPath, extension) {

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -26,6 +26,18 @@ function getLabelFromRoute(_route) {
     .join(" ");
 }
 
+// decodeURIComponent is only meant to normalize percent-encoded filenames; raw
+// frontmatter values (e.g. "100% Complete") can contain a bare "%" that throws
+// URIError and aborts the whole build, so fall back to the original string
+// https://github.com/ProjectEvergreen/greenwood/issues/1709
+function safeDecodeURIComponent(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 function getIdFromRelativePathPath(relativePathPath, extension) {
   return relativePathPath
     .replace(`.${extension}`, "")
@@ -286,9 +298,9 @@ const generateGraph = async (compilation) => {
           });
 
           const page = {
-            id: decodeURIComponent(getIdFromRelativePathPath(relativePagePath, extension)),
-            label: decodeURIComponent(label),
-            title: title ? decodeURIComponent(title) : title,
+            id: safeDecodeURIComponent(getIdFromRelativePathPath(relativePagePath, extension)),
+            label: safeDecodeURIComponent(label),
+            title: title ? safeDecodeURIComponent(title) : title,
             route: `${basePath}${route}`,
             layout,
             data: customData || {},

--- a/packages/cli/src/lifecycles/graph.js
+++ b/packages/cli/src/lifecycles/graph.js
@@ -390,6 +390,11 @@ const generateGraph = async (compilation) => {
           resources: [],
           outputHref: new URL(`.${route}index.html`, outputDir).href,
           ...node,
+          // normalize the same fields as filesystem pages so both content APIs
+          // treat percent-encoded (and literal "%") values identically
+          id: node.id ? safeDecodeURIComponent(node.id) : node.id,
+          label: node.label ? safeDecodeURIComponent(node.label) : node.label,
+          title: node.title ? safeDecodeURIComponent(node.title) : node.title,
           route: encodeURIComponent(route).replace(/%2F/g, "/"),
           data: {
             ...node.data,

--- a/packages/cli/test/cases/build.default.frontmatter-percent/build.default.frontmatter-percent.spec.js
+++ b/packages/cli/test/cases/build.default.frontmatter-percent/build.default.frontmatter-percent.spec.js
@@ -1,0 +1,77 @@
+/*
+ * Use Case
+ * Run Greenwood build with a page whose frontmatter title/label contain a literal
+ * "%" that is not part of a valid percent-encoding sequence (e.g. "100% Complete").
+ *
+ * User Result
+ * Should generate a bare bones Greenwood build without crashing, with the "%"
+ * containing title reaching the output verbatim.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * None
+ *
+ * User Workspace
+ * Greenwood default
+ *  src/
+ *   layouts/
+ *     page.html
+ *   pages/
+ *     index.html   (frontmatter: title "100% Complete", label "Save 20%")
+ */
+// https://github.com/ProjectEvergreen/greenwood/issues/1709
+import fs from "node:fs";
+import { JSDOM } from "jsdom";
+import path from "node:path";
+import { expect } from "chai";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Build Greenwood With: ", function () {
+  const LABEL = "Frontmatter title and label containing a literal percent sign";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+    });
+
+    runSmokeTest(["public", "index"], LABEL);
+
+    describe("Percent-containing Frontmatter Title", function () {
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./index.html"));
+      });
+
+      it("should output an index.html file", function () {
+        expect(fs.existsSync(path.join(this.context.publicDir, "./index.html"))).to.be.true;
+      });
+
+      it("should keep the literal '%' in the frontmatter <title> verbatim", function () {
+        const title = dom.window.document.querySelector("head title").textContent;
+
+        expect(title).to.be.equal("100% Complete");
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/cli/test/cases/build.default.frontmatter-percent/src/layouts/page.html
+++ b/packages/cli/test/cases/build.default.frontmatter-percent/src/layouts/page.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>Placeholder Title</title>
+  </head>
+  <body>
+    <content-outlet></content-outlet>
+  </body>
+</html>

--- a/packages/cli/test/cases/build.default.frontmatter-percent/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.frontmatter-percent/src/pages/index.html
@@ -1,0 +1,8 @@
+---
+title: 100% Complete
+label: Save 20%
+---
+
+<body>
+  <h1>Percent</h1>
+</body>

--- a/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
+++ b/packages/cli/test/cases/build.plugins.source/build.plugins-source.spec.js
@@ -171,6 +171,46 @@ describe("Build Greenwood With: ", function () {
       });
     });
 
+    describe("Default output for a page with a literal percent sign in its title and label", function () {
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./promo/index.html"));
+      });
+
+      it("should have the expected heading text", function () {
+        const heading = dom.window.document.querySelector("body h1").textContent;
+
+        expect(heading).to.be.equal("100% Complete Page");
+      });
+
+      it("should keep the literal '%' in the <title> verbatim", function () {
+        const title = dom.window.document.querySelector("head title").textContent;
+
+        expect(title).to.be.equal("100% Complete");
+      });
+    });
+
+    describe("Default output for a page with a percent-encoded title and label", function () {
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./cafe/index.html"));
+      });
+
+      it("should have the expected heading text", function () {
+        const heading = dom.window.document.querySelector("body h1").textContent;
+
+        expect(heading).to.be.equal("Cafe Page");
+      });
+
+      it("should decode the percent-encoded <title>", function () {
+        const title = dom.window.document.querySelector("head title").textContent;
+
+        expect(title).to.be.equal("Café");
+      });
+    });
+
     describe("Sitemap Page", function () {
       let dom;
 

--- a/packages/cli/test/cases/build.plugins.source/greenwood.config.js
+++ b/packages/cli/test/cases/build.plugins.source/greenwood.config.js
@@ -42,6 +42,20 @@ const customExternalSourcesPlugin = {
           body: `<h1>First Post Page</h1>`,
         },
         {
+          title: "100% Complete",
+          id: "promo",
+          label: "Save 20%",
+          route: "/promo/",
+          body: `<h1>100% Complete Page</h1>`,
+        },
+        {
+          title: "Caf%C3%A9",
+          id: "cafe",
+          label: "Caf%C3%A9",
+          route: "/cafe/",
+          body: `<h1>Cafe Page</h1>`,
+        },
+        {
           title: "Sitemap",
           body: `
             <ul>


### PR DESCRIPTION
## Related Issue

Resolves #1709

## Documentation

N/A — no user-facing documentation changes (bug fix only).

## Summary of Changes

1. [x] Added a small `safeDecodeURIComponent` helper in
   `packages/cli/src/lifecycles/graph.js` that wraps `decodeURIComponent` in a
   try/catch and returns the original string on `URIError`.
1. [x] Used it for the page `id`, `label`, and `title` decodes so valid
   percent-encoded filenames still decode, but a literal `%` in frontmatter
   (e.g. `100% Complete`, `Save 20%`) can no longer crash the build.
1. [x] Added a regression test case
   `packages/cli/test/cases/build.default.frontmatter-percent/` with a fixture
   page whose frontmatter title/label contain `%`, asserting the build succeeds
   and the title reaches the output verbatim.
1. [x] No breaking changes — valid percent-encoded filenames decode exactly as
   before; only the previously-fatal malformed-input path now falls back to the
   raw string.
