### PR TITLE
fix(cli): #1711 strip only leading frontmatter block from html page bodies

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -5,6 +5,7 @@
  *
  */
 import fs from "node:fs/promises";
+import fm from "front-matter";
 import { getPageLayout, getAppLayout, getGreenwoodScripts } from "../../lib/layout-utils.js";
 import { requestAsObject } from "../../lib/resource-utils.js";
 import { getMatchingDynamicSsrRoute, getParamsFromSegment } from "../../lib/url-utils.js";
@@ -57,7 +58,10 @@ class StandardHtmlResource {
       // purge frontmatter data from HTML files that only have a `<body>` tag
       // frontmatter outside of an <html> tag will get ignored by node-html-parser
       if (body.trim().startsWith("---")) {
-        body = body.replace(/---(.*)---/s, "");
+        // strip only the leading frontmatter block via the same parser that reads its
+        // attributes, so a later `---` in the body isn't greedily matched and deleted
+        // https://github.com/ProjectEvergreen/greenwood/issues/1711
+        body = fm(body).body;
       }
     } else if (matchingRoute.servePage === "static") {
       const customStaticPageFormatPlugins = config.plugins

--- a/packages/cli/test/cases/build.default.frontmatter-body-dashes/build.default.frontmatter-body-dashes.spec.js
+++ b/packages/cli/test/cases/build.default.frontmatter-body-dashes/build.default.frontmatter-body-dashes.spec.js
@@ -1,0 +1,95 @@
+/*
+ * Use Case
+ * Run Greenwood build command with an HTML page that has frontmatter followed by
+ * body content which itself contains `---` sequences (inline dashes / dividers).
+ *
+ * User Result
+ * Should generate a bare bones Greenwood build where only the leading frontmatter
+ * block is removed and no body content is truncated at a later `---`.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * None
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     index.html
+ */
+import fs from "node:fs";
+import { JSDOM } from "jsdom";
+import path from "node:path";
+import { expect } from "chai";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+// https://github.com/ProjectEvergreen/greenwood/issues/1711
+describe("Build Greenwood With: ", function () {
+  const LABEL = "Frontmatter With `---` Sequences In The Page Body";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+    });
+
+    // only the "public" smoke tests here: the shared "index" suite asserts the body
+    // contains no `---`, but this fixture intentionally keeps inline `---` in the body
+    runSmokeTest(["public"], LABEL);
+
+    describe("Body content around inline `---` dashes", function () {
+      let dom;
+      let html;
+
+      before(async function () {
+        const htmlPath = path.resolve(this.context.publicDir, "./index.html");
+
+        dom = await JSDOM.fromFile(htmlPath);
+        html = await fs.promises.readFile(htmlPath, "utf-8");
+      });
+
+      it("should preserve the leading heading that comes before the inline dashes", function () {
+        const headings = dom.window.document.querySelectorAll("body h1");
+
+        expect(headings.length).to.be.equal(1);
+        expect(headings[0].textContent).to.be.equal("Before the dashes");
+      });
+
+      it("should preserve the full paragraph text containing the inline `---` dashes", function () {
+        const paragraphs = dom.window.document.querySelectorAll("body p");
+
+        expect(paragraphs.length).to.be.equal(1);
+        expect(paragraphs[0].textContent).to.be.equal("some --- inline --- dashes");
+      });
+
+      it("should preserve the trailing heading that comes after the inline dashes", function () {
+        const headings = dom.window.document.querySelectorAll("body h2");
+
+        expect(headings.length).to.be.equal(1);
+        expect(headings[0].textContent).to.be.equal("After the dashes");
+      });
+
+      it("should strip the leading frontmatter block from the rendered output", function () {
+        expect(html).to.not.contain('title: "Dashes Page"');
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/cli/test/cases/build.default.frontmatter-body-dashes/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.frontmatter-body-dashes/src/pages/index.html
@@ -1,0 +1,9 @@
+---
+title: "Dashes Page"
+---
+
+<body>
+  <h1>Before the dashes</h1>
+  <p>some --- inline --- dashes</p>
+  <h2>After the dashes</h2>
+</body>


### PR DESCRIPTION
## Related Issue

Resolves #1711

## Documentation

N/A — no user-facing documentation changes (bug fix only; the documented behavior, "the leading frontmatter block is removed", is unchanged and now correct).

## Summary of Changes

1. [x] Replaced the greedy frontmatter strip in `packages/cli/src/plugins/resource/plugin-standard-html.js` — `body.replace(/---(.*)---/s, "")` — which matched from the frontmatter's opening `---` to the **last** `---` anywhere in the document, silently deleting body content.
2. [x] The strip now reuses the `front-matter` (`fm`) parser's computed body (`fm(body).body`) — the same package/parser already used to read the frontmatter attributes in `lifecycles/graph.js`, so the removed block and the parsed attributes always agree and only the leading block is removed.
3. [x] Added regression test `packages/cli/test/cases/build.default.frontmatter-body-dashes/` — an HTML page whose body contains inline `---` sequences; asserts the build succeeds and the `<h1>`, full `<p>` text, and `<h2>` all survive while the frontmatter block is gone. (Fails on unpatched source; passes with the fix.)
4. [x] No breaking changes.

Note: the new spec uses only the `"public"` group of the shared smoke tests. The shared `"index"` group asserts the rendered body contains no `---`, which is deliberately false for this fixture (the whole point is that inline `---` in the body must be preserved).
