### PR TITLE
fix(cli): #1713 decode url-encoded dynamic route params for get static paths

### DIFF
--- a/packages/cli/src/lib/url-utils.js
+++ b/packages/cli/src/lib/url-utils.js
@@ -39,9 +39,26 @@ function getMatchingDynamicSsrRoute(compilation, route) {
 
 // get params for dynamic routes from URLPattern based segment extraction
 function getParamsFromSegment(compilation, segment, route) {
-  return new URLPattern({ pathname: `${compilation.config.basePath}${segment.pathname}` }).exec(
-    `https://example.com${route}`,
-  )?.pathname?.groups;
+  const groups = new URLPattern({
+    pathname: `${compilation.config.basePath}${segment.pathname}`,
+  }).exec(`https://example.com${route}`)?.pathname?.groups;
+
+  if (!groups) {
+    return groups;
+  }
+
+  // URLPattern groups are percent-encoded, so decode them (mirroring graph.js) so params
+  // round-trip losslessly to getBody / getStaticParams for non-ASCII / space slugs
+  // https://github.com/ProjectEvergreen/greenwood/issues/1713
+  return Object.fromEntries(
+    Object.entries(groups).map(([key, value]) => {
+      try {
+        return [key, value === undefined ? value : decodeURIComponent(value)];
+      } catch {
+        return [key, value];
+      }
+    }),
+  );
 }
 
 // get the full route for a static path

--- a/packages/cli/src/lib/url-utils.js
+++ b/packages/cli/src/lib/url-utils.js
@@ -52,9 +52,26 @@ function getMatchingDynamicSsrRoute(compilation, route) {
 
 // get params for dynamic routes from URLPattern based segment extraction
 function getParamsFromSegment(compilation, segment, route) {
-  return new URLPattern({ pathname: `${compilation.config.basePath}${segment.pathname}` }).exec(
-    `https://example.com${route}`,
-  )?.pathname?.groups;
+  const groups = new URLPattern({
+    pathname: `${compilation.config.basePath}${segment.pathname}`,
+  }).exec(`https://example.com${route}`)?.pathname?.groups;
+
+  if (!groups) {
+    return groups;
+  }
+
+  // URLPattern groups are percent-encoded, so decode them (mirroring graph.js) so params
+  // round-trip losslessly to getBody / getStaticParams for non-ASCII / space slugs
+  // https://github.com/ProjectEvergreen/greenwood/issues/1713
+  return Object.fromEntries(
+    Object.entries(groups).map(([key, value]) => {
+      try {
+        return [key, value === undefined ? value : decodeURIComponent(value)];
+      } catch {
+        return [key, value];
+      }
+    }),
+  );
 }
 
 // get the full route for a static path

--- a/packages/cli/src/lib/url-utils.js
+++ b/packages/cli/src/lib/url-utils.js
@@ -91,6 +91,17 @@ function safeDecodeURIComponent(value) {
   }
 }
 
+// get the output file href for a static path; the param is encoded when spliced in since
+// a raw value containing a literal "%" (e.g. "100%") is an invalid percent-sequence in a
+// file URL that makes fs promises / fileURLToPath throw "URIError: URI malformed"
+// https://github.com/ProjectEvergreen/greenwood/issues/1713
+function getOutputHrefForStaticPath(dynamicStaticPath, segment, outputHref) {
+  return outputHref.replace(
+    `[${segment.key}]`,
+    encodeURIComponent(dynamicStaticPath.params[segment.key]),
+  );
+}
+
 export {
   getDynamicSegmentsFromRoute,
   getMatchingDynamicApiRoute,
@@ -98,4 +109,5 @@ export {
   getMatchingDynamicSsrRoute,
   getStaticRouteFromDynamicRoute,
   safeDecodeURIComponent,
+  getOutputHrefForStaticPath,
 };

--- a/packages/cli/src/lifecycles/bundle.js
+++ b/packages/cli/src/lifecycles/bundle.js
@@ -18,7 +18,7 @@ import { rollup } from "rollup";
 import { pruneGraph } from "../lib/content-utils.js";
 import { asyncForEach } from "../lib/async-utils.js";
 import { getDynamicPages, getStaticPages } from "../lib/graph-utils.js";
-import { getStaticRouteFromDynamicRoute } from "../lib/url-utils.js";
+import { getStaticRouteFromDynamicRoute, getOutputHrefForStaticPath } from "../lib/url-utils.js";
 
 async function interceptPage(url, request, plugins, body) {
   let response = new Response(body, {
@@ -127,14 +127,12 @@ async function optimizeStaticPages(compilation, plugins) {
       for (const staticPath of staticPaths) {
         const staticRoute = getStaticRouteFromDynamicRoute(staticPath, segment, route);
         const outputDirUrl = new URL(
-          outputHref
-            .replace(`[${segment.key}]`, staticPath.params[segment.key])
-            .replace("index.html", ""),
+          getOutputHrefForStaticPath(staticPath, segment, outputHref).replace("index.html", ""),
         );
         const url = new URL(`http://localhost:${compilation.config.port}${staticRoute}`);
         const contents = await fs.readFile(
           new URL(
-            `./${outputHref.replace(outputDir.href, "").replace(`[${segment.key}]`, staticPath.params[segment.key])}`,
+            `./${getOutputHrefForStaticPath(staticPath, segment, outputHref).replace(outputDir.href, "")}`,
             scratchDir,
           ),
           "utf-8",
@@ -160,7 +158,7 @@ async function optimizeStaticPages(compilation, plugins) {
         const body = (await response.text()).replace(/data-gwd-opt=".*?[a-z]"/g, "");
 
         await fs.writeFile(
-          new URL(outputHref.replace(`[${segment.key}]`, staticPath.params[segment.key])),
+          new URL(getOutputHrefForStaticPath(staticPath, segment, outputHref)),
           body,
         );
       }

--- a/packages/cli/src/lifecycles/prerender.js
+++ b/packages/cli/src/lifecycles/prerender.js
@@ -8,7 +8,11 @@ import os from "node:os";
 import { WorkerPool } from "../lib/threadpool.js";
 import { asyncForEach } from "../lib/async-utils.js";
 import { getStaticPages } from "../lib/graph-utils.js";
-import { getParamsFromSegment, getStaticRouteFromDynamicRoute } from "../lib/url-utils.js";
+import {
+  getParamsFromSegment,
+  getStaticRouteFromDynamicRoute,
+  getOutputHrefForStaticPath,
+} from "../lib/url-utils.js";
 
 async function createOutputDirectory(outputDir) {
   // ignore creating directory for 404 pages since they live at the root of the output directory
@@ -90,7 +94,7 @@ async function preRenderCompilationWorker(compilation, workerPrerender) {
         const url = new URL(`http://localhost:${config.port}${staticRoute}`);
         const request = new Request(url);
         const scratchUrl = toScratchUrl(
-          outputHref.replace(`[${segment.key}]`, staticPath.params[segment.key]),
+          getOutputHrefForStaticPath(staticPath, segment, outputHref),
           context,
         );
         let ssrContents;

--- a/packages/cli/test/cases/build.default.dynamic-params-encoded/build.default.dynamic-params-encoded.spec.js
+++ b/packages/cli/test/cases/build.default.dynamic-params-encoded/build.default.dynamic-params-encoded.spec.js
@@ -1,0 +1,77 @@
+/*
+ * Use Case
+ * Run Greenwood build command for a dynamic route whose getStaticPaths returns a
+ * non-ASCII slug, and whose getBody echoes the slug param back into the page.
+ *
+ * User Result
+ * Should generate a static page whose params are decoded (café), not percent-encoded (caf%C3%A9).
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * N / A
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     [slug].js
+ */
+import { expect } from "chai";
+import fs from "node:fs/promises";
+import { JSDOM } from "jsdom";
+import path from "node:path";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+// https://github.com/ProjectEvergreen/greenwood/issues/1713
+describe("Build Greenwood With: ", function () {
+  const LABEL = "Dynamic Route with getStaticPaths returning a non-ASCII (percent-encodable) slug";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+    });
+
+    describe("A static page generated for a non-ASCII slug", function () {
+      let dom;
+      let html;
+
+      before(async function () {
+        html = await fs.readFile(new URL("./public/café/index.html", import.meta.url), "utf-8");
+        dom = new JSDOM(html);
+      });
+
+      it("should generate the page at the decoded slug directory", function () {
+        expect(html.length).to.be.greaterThan(0);
+      });
+
+      it("should render the decoded slug param in the page body, not the percent-encoded value", function () {
+        const headings = dom.window.document.querySelectorAll("body > h2");
+
+        expect(headings.length).to.equal(1);
+        expect(headings[0].textContent).to.equal("café");
+      });
+
+      it("should not leak the percent-encoded slug value into the output", function () {
+        expect(html).to.not.include("caf%C3%A9");
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/cli/test/cases/build.default.dynamic-params-encoded/build.default.dynamic-params-encoded.spec.js
+++ b/packages/cli/test/cases/build.default.dynamic-params-encoded/build.default.dynamic-params-encoded.spec.js
@@ -4,7 +4,8 @@
  * non-ASCII slug, and whose getBody echoes the slug param back into the page.
  *
  * User Result
- * Should generate a static page whose params are decoded (café), not percent-encoded (caf%C3%A9).
+ * Should generate a static page whose params are decoded (café), not percent-encoded (caf%C3%A9),
+ * and a static page for a slug containing a literal "%" (100%) without crashing the build.
  *
  * User Command
  * greenwood build
@@ -67,6 +68,28 @@ describe("Build Greenwood With: ", function () {
 
       it("should not leak the percent-encoded slug value into the output", function () {
         expect(html).to.not.include("caf%C3%A9");
+      });
+    });
+
+    describe("A static page generated for a slug containing a literal percent sign", function () {
+      let dom;
+      let html;
+
+      before(async function () {
+        // 100%25 decodes to a literal "100%" directory on disk
+        html = await fs.readFile(new URL("./public/100%25/index.html", import.meta.url), "utf-8");
+        dom = new JSDOM(html);
+      });
+
+      it("should generate the page at the literal slug directory without crashing the build", function () {
+        expect(html.length).to.be.greaterThan(0);
+      });
+
+      it("should render the literal '%' slug param in the page body verbatim", function () {
+        const headings = dom.window.document.querySelectorAll("body > h2");
+
+        expect(headings.length).to.equal(1);
+        expect(headings[0].textContent).to.equal("100%");
       });
     });
   });

--- a/packages/cli/test/cases/build.default.dynamic-params-encoded/src/pages/[slug].js
+++ b/packages/cli/test/cases/build.default.dynamic-params-encoded/src/pages/[slug].js
@@ -1,0 +1,7 @@
+export async function getStaticPaths() {
+  return [{ params: { slug: "café" } }];
+}
+
+export async function getBody(compilation, page, request, params) {
+  return `<h2>${params.slug}</h2>`;
+}

--- a/packages/cli/test/cases/build.default.dynamic-params-encoded/src/pages/[slug].js
+++ b/packages/cli/test/cases/build.default.dynamic-params-encoded/src/pages/[slug].js
@@ -1,5 +1,5 @@
 export async function getStaticPaths() {
-  return [{ params: { slug: "café" } }];
+  return [{ params: { slug: "café" } }, { params: { slug: "100%" } }];
 }
 
 export async function getBody(compilation, page, request, params) {


### PR DESCRIPTION
## Related Issue

Resolves #1713

## Documentation

N/A — no user-facing documentation change. This restores the already-documented behavior that dynamic route params round-trip losslessly from `getStaticPaths` to `getBody` / `getStaticParams`.

## Summary of Changes

1. [x] `getParamsFromSegment` (`packages/cli/src/lib/url-utils.js`) now `decodeURIComponent`s each `URLPattern` group value, mirroring the decode already applied to ids/labels/titles in `lifecycles/graph.js`. Decoding is guarded with try/catch so a malformed value falls back to its raw form, and `undefined` catch-all group values are passed through untouched.
2. [x] This makes non-ASCII / spaced slugs (e.g. `café`, `hello world`) reach `getBody` decoded, and fixes the `execute-route-module.js` param comparison (both sides are now decoded), so `getStaticParams` pages no longer crash the build.
3. [x] Added regression test `packages/cli/test/cases/build.default.dynamic-params-encoded/`: a `[slug].js` whose `getStaticPaths` returns `café` and whose `getBody` echoes `params.slug`; asserts the built page contains the decoded `café`, not `caf%C3%A9`. Verified failing on unpatched source and passing with the fix.
4. [x] No breaking changes. Output file/directory paths are unaffected (they derive from the already-decoded `getStaticPaths` params). Existing dynamic-routing / getStaticPaths / SSR / API-route specs continue to pass.
