### PR TITLE
fix(cli): #1715 split active content keys on first hyphen so hyphenated collections resolve

### DIFF
--- a/packages/cli/src/data/client.js
+++ b/packages/cli/src/data/client.js
@@ -18,7 +18,10 @@ async function getContentAsData(key = "") {
   } else if (CONTENT_STATE && !PRERENDER) {
     // if user is not prerendering, just fetch the entire graph but apply the same filtering
     const graph = await fetch("/graph.json").then((resp) => resp.json());
-    const value = key.split("-").pop();
+    // split on only the first "-" so hyphenated collection names / routes keep their hyphens
+    // https://github.com/ProjectEvergreen/greenwood/issues/1715
+    const delimiterIndex = key.indexOf("-");
+    const value = delimiterIndex === -1 ? "" : key.slice(delimiterIndex + 1);
 
     if (key === "graph") {
       return graph;

--- a/packages/cli/src/plugins/resource/plugin-active-content.js
+++ b/packages/cli/src/plugins/resource/plugin-active-content.js
@@ -32,7 +32,11 @@ class ContentAsDataResource {
   async serve(url, request) {
     const { graph } = this.compilation;
     const contentKey = request.headers.get("x-content-key") ?? "";
-    const keyPieces = contentKey.split("-");
+    // split on only the first "-" so hyphenated collection names / routes keep their hyphens
+    // https://github.com/ProjectEvergreen/greenwood/issues/1715
+    const delimiterIndex = contentKey.indexOf("-");
+    const type = delimiterIndex === -1 ? contentKey : contentKey.slice(0, delimiterIndex);
+    const value = delimiterIndex === -1 ? "" : contentKey.slice(delimiterIndex + 1);
     let status;
     let body;
 
@@ -44,10 +48,10 @@ class ContentAsDataResource {
 
       if (contentKey === "graph") {
         body = graph;
-      } else if (keyPieces[0] === "collection") {
-        body = filterContentByCollection(graph, keyPieces[1]);
-      } else if (keyPieces[0] === "route") {
-        body = filterContentByRoute(graph, keyPieces[1]);
+      } else if (type === "collection") {
+        body = filterContentByCollection(graph, value);
+      } else if (type === "route") {
+        body = filterContentByRoute(graph, value);
       }
 
       if (process.env.__GWD_COMMAND__ === "build") {

--- a/packages/cli/test/cases/build.config.prerender-collections-hyphen/build.config.prerender-collections-hyphen.spec.js
+++ b/packages/cli/test/cases/build.config.prerender-collections-hyphen/build.config.prerender-collections-hyphen.spec.js
@@ -1,0 +1,144 @@
+/*
+ * Use Case
+ * Run Greenwood build command with prerender and active content, using Content as Data APIs
+ * with a hyphenated collection name ("my-posts") and a hyphenated route ("/my-blog"), rendered
+ * through SSR'd custom elements.
+ *
+ * User Result
+ * Should generate a Greenwood build where the prerendered components list the pages of the
+ * hyphenated collection / route, and the emitted data-*.json query files contain those pages
+ * (regression for content keys being split on every hyphen).
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * {
+ *   activeContent: true,
+ *   prerender: true
+ * }
+ *
+ * User Workspace
+ * src/
+ *   components/
+ *     posts-list.js       (getContentByCollection("my-posts"))
+ *     routes-list.js      (getContentByRoute("/my-blog"))
+ *   pages/
+ *     my-blog/
+ *       first.html        (collection: my-posts)
+ *       second.html       (collection: my-posts)
+ *     index.html
+ */
+
+// https://github.com/ProjectEvergreen/greenwood/issues/1715
+import fs from "node:fs/promises";
+import { expect } from "chai";
+import { JSDOM } from "jsdom";
+import path from "node:path";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Build Greenwood With: ", function () {
+  const LABEL =
+    "Prerender Configuration turned on using Content as Data with a hyphenated collection";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+    });
+
+    runSmokeTest(["public", "index"], LABEL);
+
+    describe("Default output for index.html with hyphenated collection content", function () {
+      let dom;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./index.html"));
+      });
+
+      describe("post links from getContentByCollection('my-posts')", function () {
+        let postLinks;
+
+        before(function () {
+          postLinks = dom.window.document.querySelectorAll("ol li a");
+        });
+
+        it("should have the expected number of post links from all pages in the collection", function () {
+          expect(postLinks.length).to.equal(2);
+        });
+
+        it("should have the expected link content from all pages in the collection", function () {
+          expect(postLinks[0].getAttribute("href")).to.equal("/my-blog/first/");
+          expect(postLinks[0].getAttribute("title")).to.equal("First Post");
+          expect(postLinks[0].textContent).to.equal("First");
+
+          expect(postLinks[1].getAttribute("href")).to.equal("/my-blog/second/");
+          expect(postLinks[1].getAttribute("title")).to.equal("Second Post");
+          expect(postLinks[1].textContent).to.equal("Second");
+        });
+      });
+
+      describe("page links from getContentByRoute('/my-blog')", function () {
+        let pageLinks;
+
+        before(function () {
+          pageLinks = dom.window.document.querySelectorAll("ul li a");
+        });
+
+        it("should have the expected number of page links for the hyphenated route", function () {
+          expect(pageLinks.length).to.equal(2);
+        });
+
+        it("should have the expected link content for the hyphenated route", function () {
+          expect(pageLinks[0].getAttribute("href")).to.equal("/my-blog/first/");
+          expect(pageLinks[1].getAttribute("href")).to.equal("/my-blog/second/");
+        });
+      });
+    });
+
+    describe("Emitted data query files for the hyphenated content keys", function () {
+      it("should emit a collection query file with the pages of the hyphenated collection", async function () {
+        const collectionData = JSON.parse(
+          await fs.readFile(
+            path.resolve(this.context.publicDir, "./data-collection-my-posts.json"),
+            "utf-8",
+          ),
+        );
+        const routes = collectionData.map((page) => page.route).sort();
+
+        expect(collectionData.length).to.equal(2);
+        expect(routes).to.deep.equal(["/my-blog/first/", "/my-blog/second/"]);
+      });
+
+      it("should emit a route query file with the pages of the hyphenated route", async function () {
+        const routeData = JSON.parse(
+          await fs.readFile(
+            path.resolve(this.context.publicDir, "./data-route-_my-blog.json"),
+            "utf-8",
+          ),
+        );
+        const routes = routeData.map((page) => page.route).sort();
+
+        expect(routeData.length).to.equal(2);
+        expect(routes).to.deep.equal(["/my-blog/first/", "/my-blog/second/"]);
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/cli/test/cases/build.config.prerender-collections-hyphen/greenwood.config.js
+++ b/packages/cli/test/cases/build.config.prerender-collections-hyphen/greenwood.config.js
@@ -1,0 +1,4 @@
+export default {
+  activeContent: true,
+  prerender: true,
+};

--- a/packages/cli/test/cases/build.config.prerender-collections-hyphen/package.json
+++ b/packages/cli/test/cases/build.config.prerender-collections-hyphen/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/cli/test/cases/build.config.prerender-collections-hyphen/src/components/posts-list.js
+++ b/packages/cli/test/cases/build.config.prerender-collections-hyphen/src/components/posts-list.js
@@ -1,0 +1,25 @@
+import { getContentByCollection } from "@greenwood/cli/src/data/client.js";
+
+export default class MyPostsList extends HTMLElement {
+  async connectedCallback() {
+    const posts = (await getContentByCollection("my-posts")).sort((a, b) =>
+      a.data.order > b.data.order ? 1 : -1,
+    );
+
+    this.innerHTML = `
+      <ol>
+        ${posts
+          .map((post) => {
+            const { route, label, title } = post;
+
+            return `
+              <li><a href="${route}" title="${title}">${label}</a></li>
+            `;
+          })
+          .join("")}
+      </ol>
+    `;
+  }
+}
+
+customElements.define("x-my-posts-list", MyPostsList);

--- a/packages/cli/test/cases/build.config.prerender-collections-hyphen/src/components/routes-list.js
+++ b/packages/cli/test/cases/build.config.prerender-collections-hyphen/src/components/routes-list.js
@@ -1,0 +1,25 @@
+import { getContentByRoute } from "@greenwood/cli/src/data/client.js";
+
+export default class MyBlogRoutes extends HTMLElement {
+  async connectedCallback() {
+    const pages = (await getContentByRoute("/my-blog")).sort((a, b) =>
+      a.data.order > b.data.order ? 1 : -1,
+    );
+
+    this.innerHTML = `
+      <ul>
+        ${pages
+          .map((page) => {
+            const { route, label, title } = page;
+
+            return `
+              <li><a href="${route}" title="${title}">${label}</a></li>
+            `;
+          })
+          .join("")}
+      </ul>
+    `;
+  }
+}
+
+customElements.define("x-my-blog-routes", MyBlogRoutes);

--- a/packages/cli/test/cases/build.config.prerender-collections-hyphen/src/pages/index.html
+++ b/packages/cli/test/cases/build.config.prerender-collections-hyphen/src/pages/index.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <script type="module" src="../components/posts-list.js" data-gwd-opt="static"></script>
+    <script type="module" src="../components/routes-list.js" data-gwd-opt="static"></script>
+  </head>
+
+  <body>
+    <h1>Home Page</h1>
+    <x-my-posts-list></x-my-posts-list>
+    <x-my-blog-routes></x-my-blog-routes>
+  </body>
+</html>

--- a/packages/cli/test/cases/build.config.prerender-collections-hyphen/src/pages/my-blog/first.html
+++ b/packages/cli/test/cases/build.config.prerender-collections-hyphen/src/pages/my-blog/first.html
@@ -1,0 +1,11 @@
+---
+collection: my-posts
+title: First Post
+order: 1
+---
+
+<html>
+  <body>
+    <h1>First Post</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/build.config.prerender-collections-hyphen/src/pages/my-blog/second.html
+++ b/packages/cli/test/cases/build.config.prerender-collections-hyphen/src/pages/my-blog/second.html
@@ -1,0 +1,11 @@
+---
+collection: my-posts
+title: Second Post
+order: 2
+---
+
+<html>
+  <body>
+    <h1>Second Post</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/develop.config.active-content-collection-hyphen/develop.config.active-content-collection-hyphen.spec.js
+++ b/packages/cli/test/cases/develop.config.active-content-collection-hyphen/develop.config.active-content-collection-hyphen.spec.js
@@ -1,0 +1,134 @@
+/*
+ * Use Case
+ * Run Greenwood develop command with active content and a collection whose name
+ * contains a hyphen (e.g. "my-posts"), queried via the /___graph.json content key API.
+ *
+ * User Result
+ * Should start the dev server and return the pages belonging to a hyphenated collection
+ * when requested with X-CONTENT-KEY: collection-my-posts (regression for content keys
+ * being split on every hyphen).
+ *
+ * User Command
+ * greenwood develop
+ *
+ * User Config
+ * {
+ *   activeContent: true,
+ *   devServer: {
+ *     port: 1988
+ *   }
+ * }
+ *
+ * User Workspace
+ *  src/
+ *   pages/
+ *     my-blog/
+ *       first.html      (collection: my-posts)
+ *       second.html     (collection: [my-posts, nav])
+ *     about.html        (collection: nav)
+ *     index.html        (collection: nav)
+ */
+
+// https://github.com/ProjectEvergreen/greenwood/issues/1715
+import { expect } from "chai";
+import path from "node:path";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Develop Greenwood With: ", function () {
+  const LABEL = "Active Content with a hyphenated collection name";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  const hostname = "http://localhost";
+  const port = 1988;
+  let runner;
+
+  before(function () {
+    this.context = {
+      hostname: `${hostname}:${port}`,
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+
+      await new Promise((resolve, reject) => {
+        runner
+          .runCommand(cliPath, "develop", {
+            onStdOut: (message) => {
+              if (
+                message.includes(`Started local development server at http://localhost:${port}`)
+              ) {
+                resolve();
+              }
+            },
+          })
+          .catch(reject);
+      });
+    });
+
+    describe("Content Request Types", () => {
+      describe("Hyphenated Collection Request", () => {
+        let response;
+
+        before(async function () {
+          response = await fetch(`${hostname}:${port}/___graph.json`, {
+            headers: {
+              "x-content-key": "collection-my-posts",
+            },
+          });
+        });
+
+        it("should return the pages that belong to the hyphenated collection", async () => {
+          const data = await response.json();
+
+          expect(data.length).to.equal(2);
+        });
+      });
+
+      describe("Hyphen-free Collection Request", () => {
+        let response;
+
+        before(async function () {
+          response = await fetch(`${hostname}:${port}/___graph.json`, {
+            headers: {
+              "x-content-key": "collection-nav",
+            },
+          });
+        });
+
+        it("should still return the pages that belong to a hyphen-free collection", async () => {
+          const data = await response.json();
+
+          expect(data.length).to.equal(3);
+        });
+      });
+
+      describe("Route Request", () => {
+        let response;
+
+        before(async function () {
+          response = await fetch(`${hostname}:${port}/___graph.json`, {
+            headers: {
+              "x-content-key": "route-/my-blog",
+            },
+          });
+        });
+
+        it("should still return the pages under a hyphenated route", async () => {
+          const data = await response.json();
+
+          expect(data.length).to.equal(2);
+        });
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.stopCommand();
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/cli/test/cases/develop.config.active-content-collection-hyphen/greenwood.config.js
+++ b/packages/cli/test/cases/develop.config.active-content-collection-hyphen/greenwood.config.js
@@ -1,0 +1,6 @@
+export default {
+  activeContent: true,
+  devServer: {
+    port: 1988,
+  },
+};

--- a/packages/cli/test/cases/develop.config.active-content-collection-hyphen/package.json
+++ b/packages/cli/test/cases/develop.config.active-content-collection-hyphen/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/cli/test/cases/develop.config.active-content-collection-hyphen/src/pages/about.html
+++ b/packages/cli/test/cases/develop.config.active-content-collection-hyphen/src/pages/about.html
@@ -1,0 +1,12 @@
+---
+title: About
+collection: nav
+order: 2
+---
+
+<html>
+  <head></head>
+  <body>
+    <h1>About Page</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/develop.config.active-content-collection-hyphen/src/pages/index.html
+++ b/packages/cli/test/cases/develop.config.active-content-collection-hyphen/src/pages/index.html
@@ -1,0 +1,12 @@
+---
+title: Home
+collection: nav
+order: 1
+---
+
+<html>
+  <head></head>
+  <body>
+    <h1>Home Page</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/develop.config.active-content-collection-hyphen/src/pages/my-blog/first.html
+++ b/packages/cli/test/cases/develop.config.active-content-collection-hyphen/src/pages/my-blog/first.html
@@ -1,0 +1,11 @@
+---
+title: First Post
+collection: my-posts
+---
+
+<html>
+  <head></head>
+  <body>
+    <h1>First Post</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/develop.config.active-content-collection-hyphen/src/pages/my-blog/second.html
+++ b/packages/cli/test/cases/develop.config.active-content-collection-hyphen/src/pages/my-blog/second.html
@@ -1,0 +1,13 @@
+---
+title: Second Post
+collection:
+  - my-posts
+  - nav
+---
+
+<html>
+  <head></head>
+  <body>
+    <h1>Second Post</h1>
+  </body>
+</html>


### PR DESCRIPTION
## Related Issue

Resolves #1715

## Documentation

N/A — no user-facing documentation changes (bug fix only; the `collection-<name>` /
`route-<route>` content key format is unchanged).

## Summary of Changes

1. [x] Split active content content keys on only the **first** hyphen so the value keeps any
   remaining hyphens, in `packages/cli/src/plugins/resource/plugin-active-content.js`
   (server `/___graph.json` handler) and `packages/cli/src/data/client.js` (client-side
   `getContentByCollection` / `getContentByRoute` when not prerendering).
2. [x] Hyphenated collection names (e.g. `my-posts`) now resolve to their pages instead of `[]`;
   hyphenated routes (e.g. `/my-blog`) keep their full value instead of being truncated to a
   prefix that over-matches.
3. [x] Behavior for hyphen-free keys (`graph`, `collection-nav`, `route-/blog`) is unchanged.
4. [x] Added regression test
   `packages/cli/test/cases/develop.config.active-content-collection-hyphen/` that serves a
   collection named `my-posts` across two pages and asserts
   `X-CONTENT-KEY: collection-my-posts` returns those pages (fails with `[]` on unpatched source).
5. [x] No breaking changes.
