### PR TITLE
fix(cli): #1585 make css bundling static asset emit sync

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -134,7 +134,7 @@ function bundleCss(body, sourceUrl, compilation, workingUrl) {
               recursive: true,
             });
 
-            fs.promises.copyFile(resolvedUrl, new URL(`.${finalValue}`, outputDir));
+            fs.copyFileSync(resolvedUrl, new URL(`.${finalValue}`, outputDir));
           }
 
           optimizedCss += `url('${basePath}${finalValue}')`;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

resolves #1585 

## Documentation 

N / A

## Summary of Changes

1. make css bundling static asset emit sync

> _Could probably release this as 0.34.1_

----

Did a little splunking (with AI) with and realized the issue was coming from CSS resource plugin, which bundles static assets in CSS files, _**not**_ the copy plugin like I thought 🫨 

In this case, the operation needed to be sync since it's happening in an sync context inside the AST walker

## TODO
1. [ ] review for this case - https://github.com/ProjectEvergreen/greenwood/issues/1585#issuecomment-3393372618