### PR TITLE
chore(workspace): #1614 update windows ci matrix to include node 26

### DIFF
--- a/.github/workflows/ci-win-loaders.yml
+++ b/.github/workflows/ci-win-loaders.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [24]
+        node: [24, 26]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [24]
+        node: [24, 26]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

https://github.com/ProjectEvergreen/greenwood/pull/1727

## Documentation 

<!-- if this issue has been labeled with documentation, please make sure submit a PR to our website repo and link it -->
<!-- https://github.com/ProjectEvergreen/www.greenwoodjs.dev -->

## Summary of Changes

1. Bump windows github actions to include Node 26