### PR TITLE
fix(cli): #1737 return 404 for dynamic route values not returned by get static paths

### DIFF
--- a/packages/cli/src/lib/url-utils.js
+++ b/packages/cli/src/lib/url-utils.js
@@ -38,10 +38,8 @@ function getMatchingDynamicSsrRoute(compilation, route) {
       return false;
     }
 
-    // for getStaticPaths routes, only match values enumerated at build time (Next.js
-    // `fallback: false` semantics) so unknown values 404 in develop and serve alike,
-    // instead of live rendering in develop and throwing an ENOENT / 500 in serve
-    // https://github.com/ProjectEvergreen/greenwood/issues/1737
+    // for getStaticPaths routes, only match values enumerated at build time so unknown
+    // values 404 in develop and serve alike
     return (
       !node.staticPaths ||
       node.staticPaths.some((staticPath) => {

--- a/packages/cli/src/lib/url-utils.js
+++ b/packages/cli/src/lib/url-utils.js
@@ -27,12 +27,29 @@ function getMatchingDynamicSsrRoute(compilation, route) {
   const { graph, config } = compilation;
 
   return graph.find((node) => {
-    return (
+    const matchesSegment =
       route !== "/404/" &&
       node.segment &&
       new URLPattern({ pathname: `${config.basePath}${node.segment.pathname}` }).test(
         `https://example.com${route}`,
-      )
+      );
+
+    if (!matchesSegment) {
+      return false;
+    }
+
+    // for getStaticPaths routes, only match values enumerated at build time (Next.js
+    // `fallback: false` semantics) so unknown values 404 in develop and serve alike,
+    // instead of live rendering in develop and throwing an ENOENT / 500 in serve
+    // https://github.com/ProjectEvergreen/greenwood/issues/1737
+    return (
+      !node.staticPaths ||
+      node.staticPaths.some((staticPath) => {
+        const staticRoute = getStaticRouteFromDynamicRoute(staticPath, node.segment, node.route);
+
+        // compare the raw and encoded forms since URL percent-encodes the pathname
+        return staticRoute === route || encodeURI(staticRoute) === route;
+      })
     );
   });
 }

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -13,6 +13,7 @@ import {
   getMatchingDynamicApiRoute,
   getMatchingDynamicSsrRoute,
   getParamsFromSegment,
+  getStaticRouteFromDynamicRoute,
 } from "../lib/url-utils.js";
 import { Readable } from "node:stream";
 import { Worker } from "node:worker_threads";
@@ -320,7 +321,21 @@ async function getStaticServer(compilation, composable) {
       const url = new URL(`http://localhost:${port}${ctx.url}`);
       const matchingRoute = compilation.graph.find(
         (page) =>
-          (page.staticPaths && getParamsFromSegment(compilation, page.segment, url.pathname)) ||
+          // for dynamic routes, only match values enumerated from getStaticPaths, otherwise
+          // unknown values should fall through to a 404 instead of an ENOENT / 500
+          // https://github.com/ProjectEvergreen/greenwood/issues/1737
+          (page.staticPaths &&
+            getParamsFromSegment(compilation, page.segment, url.pathname) &&
+            page.staticPaths.some((staticPath) => {
+              const staticRoute = getStaticRouteFromDynamicRoute(
+                staticPath,
+                page.segment,
+                page.route,
+              );
+
+              // compare the raw and encoded forms since URL percent-encodes the pathname
+              return staticRoute === url.pathname || encodeURI(staticRoute) === url.pathname;
+            })) ||
           page.route === url.pathname,
       );
       const isSPA = compilation.graph.find((page) => page.isSPA);

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -318,9 +318,6 @@ async function getStaticServer(compilation, composable) {
   app.use(async (ctx, next) => {
     try {
       const url = new URL(`http://localhost:${port}${ctx.url}`);
-      // for dynamic routes, getMatchingDynamicSsrRoute only matches values enumerated from
-      // getStaticPaths, so unknown values fall through to a 404 instead of an ENOENT / 500
-      // https://github.com/ProjectEvergreen/greenwood/issues/1737
       const matchingRoute =
         compilation.graph.find((page) => page.route === url.pathname) ||
         getMatchingDynamicSsrRoute(compilation, url.pathname);

--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -13,7 +13,6 @@ import {
   getMatchingDynamicApiRoute,
   getMatchingDynamicSsrRoute,
   getParamsFromSegment,
-  getStaticRouteFromDynamicRoute,
 } from "../lib/url-utils.js";
 import { Readable } from "node:stream";
 import { Worker } from "node:worker_threads";
@@ -319,25 +318,12 @@ async function getStaticServer(compilation, composable) {
   app.use(async (ctx, next) => {
     try {
       const url = new URL(`http://localhost:${port}${ctx.url}`);
-      const matchingRoute = compilation.graph.find(
-        (page) =>
-          // for dynamic routes, only match values enumerated from getStaticPaths, otherwise
-          // unknown values should fall through to a 404 instead of an ENOENT / 500
-          // https://github.com/ProjectEvergreen/greenwood/issues/1737
-          (page.staticPaths &&
-            getParamsFromSegment(compilation, page.segment, url.pathname) &&
-            page.staticPaths.some((staticPath) => {
-              const staticRoute = getStaticRouteFromDynamicRoute(
-                staticPath,
-                page.segment,
-                page.route,
-              );
-
-              // compare the raw and encoded forms since URL percent-encodes the pathname
-              return staticRoute === url.pathname || encodeURI(staticRoute) === url.pathname;
-            })) ||
-          page.route === url.pathname,
-      );
+      // for dynamic routes, getMatchingDynamicSsrRoute only matches values enumerated from
+      // getStaticPaths, so unknown values fall through to a 404 instead of an ENOENT / 500
+      // https://github.com/ProjectEvergreen/greenwood/issues/1737
+      const matchingRoute =
+        compilation.graph.find((page) => page.route === url.pathname) ||
+        getMatchingDynamicSsrRoute(compilation, url.pathname);
       const isSPA = compilation.graph.find((page) => page.isSPA);
       const { isSSR, staticPaths } = matchingRoute || {};
       const extension = url.pathname.split(".").pop();

--- a/packages/cli/test/cases/develop.default.ssr-static-paths-unknown/develop.default.ssr-static-paths-unknown.spec.js
+++ b/packages/cli/test/cases/develop.default.ssr-static-paths-unknown/develop.default.ssr-static-paths-unknown.spec.js
@@ -1,0 +1,114 @@
+/*
+ * Use Case
+ * Run Greenwood develop with SSR routes that use getStaticPaths and request dynamic route values that were not returned from getStaticPaths.
+ * https://github.com/ProjectEvergreen/greenwood/issues/1737
+ *
+ * User Result
+ * Should serve known static paths with a 200 and return a 404 for unknown dynamic route values,
+ * matching the behavior of greenwood serve.
+ *
+ * User Command
+ * greenwood develop
+ *
+ * User Config
+ * {}
+ *
+ * User Workspace
+ *  src/
+ *   pages/
+ *     empty/
+ *       [nothing].js
+ *     [slug].js
+ */
+import { expect } from "chai";
+import { JSDOM } from "jsdom";
+import path from "node:path";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Develop Greenwood With: ", function () {
+  const LABEL = "Dynamic Routing for Get Static Paths with unknown dynamic route values";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  const hostname = "http://127.0.0.1:1984";
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+      hostname,
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+
+      await new Promise((resolve, reject) => {
+        runner
+          .runCommand(cliPath, "develop", {
+            onStdOut: (message) => {
+              if (message.includes("Started local development server at http://localhost:1984")) {
+                resolve();
+              }
+            },
+          })
+          .catch(reject);
+      });
+    });
+
+    describe("An SSR page with a dynamic route value returned from getStaticPaths", function () {
+      let response;
+      let dom;
+
+      before(async function () {
+        response = await fetch(`${hostname}/alpha/`);
+        dom = new JSDOM(await response.clone().text());
+      });
+
+      it("should return a 200 status", function () {
+        expect(response.status).to.equal(200);
+      });
+
+      it("should have the expected output for the page in the h2 tag", function () {
+        const headings = dom.window.document.querySelectorAll("body h2");
+
+        expect(headings.length).to.equal(1);
+        expect(headings[0].textContent).to.equal("alpha");
+      });
+    });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/1737
+    describe("An SSR page with a dynamic route value NOT returned from getStaticPaths", function () {
+      let response;
+
+      before(async function () {
+        response = await fetch(`${hostname}/nope/`);
+      });
+
+      it("should return a 404 status, matching the serve behavior", function () {
+        expect(response.status).to.equal(404);
+      });
+    });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/1737
+    describe("An SSR page where getStaticPaths returns an empty array", function () {
+      let response;
+
+      before(async function () {
+        response = await fetch(`${hostname}/empty/anything/`);
+      });
+
+      it("should return a 404 status, matching the serve behavior", function () {
+        expect(response.status).to.equal(404);
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+    await runner.stopCommand();
+  });
+});

--- a/packages/cli/test/cases/develop.default.ssr-static-paths-unknown/src/pages/[slug].js
+++ b/packages/cli/test/cases/develop.default.ssr-static-paths-unknown/src/pages/[slug].js
@@ -1,0 +1,13 @@
+export async function getStaticPaths() {
+  return [
+    {
+      params: {
+        slug: "alpha",
+      },
+    },
+  ];
+}
+
+export async function getBody(compilation, page, request, params) {
+  return `<h2>${params.slug}</h2>`;
+}

--- a/packages/cli/test/cases/develop.default.ssr-static-paths-unknown/src/pages/empty/[nothing].js
+++ b/packages/cli/test/cases/develop.default.ssr-static-paths-unknown/src/pages/empty/[nothing].js
@@ -1,0 +1,7 @@
+export async function getStaticPaths() {
+  return [];
+}
+
+export async function getBody() {
+  return "<h2>this page should never be served</h2>";
+}

--- a/packages/cli/test/cases/serve.default.ssr-static-paths-unknown/serve.default.ssr-static-paths-unknown.spec.js
+++ b/packages/cli/test/cases/serve.default.ssr-static-paths-unknown/serve.default.ssr-static-paths-unknown.spec.js
@@ -1,0 +1,114 @@
+/*
+ * Use Case
+ * Run Greenwood with SSR routes that use getStaticPaths and request dynamic route values that were not returned from getStaticPaths.
+ * https://github.com/ProjectEvergreen/greenwood/issues/1737
+ *
+ * User Result
+ * Should serve known static paths with a 200 and return a 404 (instead of a 500) for unknown dynamic route values.
+ *
+ * User Command
+ * greenwood serve
+ *
+ * User Config
+ * {}
+ *
+ * User Workspace
+ *  src/
+ *   pages/
+ *     empty/
+ *       [nothing].js
+ *     [slug].js
+ */
+import { expect } from "chai";
+import { JSDOM } from "jsdom";
+import path from "node:path";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Serve Greenwood With: ", function () {
+  const LABEL = "Dynamic Routing for Get Static Paths with unknown dynamic route values";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  const hostname = "http://localhost:8080";
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+      hostname,
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+
+      await new Promise((resolve, reject) => {
+        runner
+          .runCommand(cliPath, "serve", {
+            onStdOut: (message) => {
+              if (message.includes(`Started server at ${hostname}`)) {
+                resolve();
+              }
+            },
+          })
+          .catch(reject);
+      });
+    });
+
+    describe("An SSR page with a dynamic route value returned from getStaticPaths", function () {
+      let response;
+      let dom;
+
+      before(async function () {
+        response = await fetch(`${hostname}/alpha/`);
+        dom = new JSDOM(await response.clone().text());
+      });
+
+      it("should return a 200 status", function () {
+        expect(response.status).to.equal(200);
+      });
+
+      it("should have the expected output for the page in the h2 tag", function () {
+        const headings = dom.window.document.querySelectorAll("body h2");
+
+        expect(headings.length).to.equal(1);
+        expect(headings[0].textContent).to.equal("alpha");
+      });
+    });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/1737
+    describe("An SSR page with a dynamic route value NOT returned from getStaticPaths", function () {
+      let response;
+
+      before(async function () {
+        response = await fetch(`${hostname}/nope/`);
+      });
+
+      it("should return a 404 status instead of a 500", function () {
+        expect(response.status).to.equal(404);
+      });
+    });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/1737
+    describe("An SSR page where getStaticPaths returns an empty array", function () {
+      let response;
+
+      before(async function () {
+        response = await fetch(`${hostname}/empty/anything/`);
+      });
+
+      it("should return a 404 status instead of a 500", function () {
+        expect(response.status).to.equal(404);
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+    await runner.stopCommand();
+  });
+});

--- a/packages/cli/test/cases/serve.default.ssr-static-paths-unknown/src/pages/[slug].js
+++ b/packages/cli/test/cases/serve.default.ssr-static-paths-unknown/src/pages/[slug].js
@@ -1,0 +1,13 @@
+export async function getStaticPaths() {
+  return [
+    {
+      params: {
+        slug: "alpha",
+      },
+    },
+  ];
+}
+
+export async function getBody(compilation, page, request, params) {
+  return `<h2>${params.slug}</h2>`;
+}

--- a/packages/cli/test/cases/serve.default.ssr-static-paths-unknown/src/pages/empty/[nothing].js
+++ b/packages/cli/test/cases/serve.default.ssr-static-paths-unknown/src/pages/empty/[nothing].js
@@ -1,0 +1,7 @@
+export async function getStaticPaths() {
+  return [];
+}
+
+export async function getBody() {
+  return "<h2>this page should never be served</h2>";
+}

--- a/packages/plugin-adapter-aws/test/cases/build.dynamic-routing/build.dynamic-routing.spec.js
+++ b/packages/plugin-adapter-aws/test/cases/build.dynamic-routing/build.dynamic-routing.spec.js
@@ -96,6 +96,34 @@ describe("Build Greenwood With: ", function () {
       });
     });
 
+    // https://github.com/ProjectEvergreen/greenwood/issues/1737
+    describe("An SSR page using getStaticPaths for its dynamic route segment", function () {
+      let staticPathsRouteFolders;
+
+      before(async function () {
+        staticPathsRouteFolders = await glob.promise(
+          path.join(normalizePathnameForWindows(awsOutputFolder), "routes/artists*"),
+        );
+      });
+
+      // non-enumerated values have no function to route to and fall through
+      // to the platform's static 404
+      it("should not output a serverless function folder for the route", function () {
+        expect(staticPathsRouteFolders.length).to.equal(0);
+      });
+
+      it("should output static HTML for each path enumerated from getStaticPaths", async function () {
+        for (const name of ["foo", "bar", "baz"]) {
+          const html = await fs.readFile(
+            path.join(outputPath, `public/artists/${name}/index.html`),
+            "utf-8",
+          );
+
+          expect(html).to.contain("Some Artists Page");
+        }
+      });
+    });
+
     describe("A Dynamic SSR Page adapter", function () {
       it("should return the expected response when the serverless adapter entry point handler is invoked with a dynamic path segment", async function () {
         const { handler } = await import(

--- a/packages/plugin-adapter-netlify/test/cases/build.dynamic-routing/build.dynamic-routing.spec.js
+++ b/packages/plugin-adapter-netlify/test/cases/build.dynamic-routing/build.dynamic-routing.spec.js
@@ -169,6 +169,42 @@ describe("Build Greenwood With: ", function () {
       });
     });
 
+    // https://github.com/ProjectEvergreen/greenwood/issues/1737
+    describe("An SSR page using getStaticPaths for its dynamic route segment", function () {
+      let staticPathsFunctions;
+      let redirectsFileContents;
+
+      before(async function () {
+        staticPathsFunctions = await Array.fromAsync(
+          fs.glob("artists*.zip", { cwd: netlifyFunctionsOutputUrl }),
+        );
+        redirectsFileContents = await fs.readFile(
+          path.join(outputPath, "public/_redirects"),
+          "utf-8",
+        );
+      });
+
+      it("should not output a serverless function zip file for the route", function () {
+        expect(staticPathsFunctions.length).to.equal(0);
+      });
+
+      // with no redirect rule, non-enumerated values fall through to the platform's static 404
+      it("should not output a redirect rule for the dynamic segment", function () {
+        expect(redirectsFileContents).to.not.contain("artists");
+      });
+
+      it("should output static HTML for each path enumerated from getStaticPaths", async function () {
+        for (const name of ["foo", "bar", "baz"]) {
+          const html = await fs.readFile(
+            path.join(outputPath, `public/artists/${name}/index.html`),
+            "utf-8",
+          );
+
+          expect(html).to.contain("Some Artists Page");
+        }
+      });
+    });
+
     describe("_redirects file contents", function () {
       let redirectsFileContents;
 

--- a/packages/plugin-adapter-vercel/test/cases/build.dynamic-routing/build.dynamic-routing.spec.js
+++ b/packages/plugin-adapter-vercel/test/cases/build.dynamic-routing/build.dynamic-routing.spec.js
@@ -142,6 +142,39 @@ describe("Build Greenwood With: ", function () {
       });
     });
 
+    // https://github.com/ProjectEvergreen/greenwood/issues/1737
+    describe("An SSR page using getStaticPaths for its dynamic route segment", function () {
+      let configFile;
+      let functionFolders;
+
+      before(async function () {
+        configFile = await fs.readFile(new URL("./config.json", vercelOutputFolder), "utf-8");
+        functionFolders = await Array.fromAsync(
+          fs.glob("**/*.func", { cwd: vercelFunctionsOutputUrl }),
+        );
+      });
+
+      it("should not output a serverless function for the route", function () {
+        expect(functionFolders.filter((folder) => folder.includes("artists")).length).to.equal(0);
+      });
+
+      // with no route rule, non-enumerated values fall through to the platform's static 404
+      it("should not output a route rule for the dynamic segment", function () {
+        expect(configFile).to.not.contain("artists");
+      });
+
+      it("should output static HTML for each path enumerated from getStaticPaths", async function () {
+        for (const name of ["foo", "bar", "baz"]) {
+          const html = await fs.readFile(
+            new URL(`./static/artists/${name}/index.html`, vercelOutputFolder),
+            "utf-8",
+          );
+
+          expect(html).to.contain("Some Artists Page");
+        }
+      });
+    });
+
     describe("Dynamic API Route adapter", function () {
       it("should return the expected response when the serverless adapter entry point handler is invoked", async function () {
         const handler = (


### PR DESCRIPTION
## Related Issue

Resolves #1737

## Documentation

N/A

## Summary of Changes

1. [x] in the static server's route matching (`serve.js`), a dynamic route now only matches when the requested pathname is one of the concrete routes enumerated from `getStaticPaths` (Next.js `fallback: false` semantics) — unknown values produce no matching route, so the middleware never reaches the `fs.readFile` and the response is a clean 404 instead of a 500 with an `ENOENT` stack in the server console
2. [x] the same check fixes `getStaticPaths` returning `[]` (previously *every* single-segment URL under the route 500'd, since the empty array is truthy and the URLPattern matches any value)
3. [x] new regression case `serve.default.ssr-static-paths-unknown` — one fixture with a finite `getStaticPaths` and one with an empty one; asserts `/alpha/` → 200, `/nope/` → 404, `/empty/anything/` → 404 (the two 404 assertions fail on unpatched master with 500)

Implementation notes:

- The pathname comparison checks both the raw and `encodeURI`-encoded forms of each enumerated route, since `URL` percent-encodes `url.pathname`. `encodeURI` was chosen deliberately over decoding the request path — `decodeURIComponent` throws on malformed percent-sequences, which would have re-introduced a 500 via the surrounding catch. This composes with, but does not depend on, #1714.
- The hybrid server needs no change: its `isDynamicRoute` check already excludes `staticPaths` routes, so unknown values inherit this 404.

Behavior change to be aware of (arguably the point of the fix): requests for non-enumerated dynamic values now return 404 where they previously returned 500. There is currently no fallback-rendering option for `serve`, so nothing functional is lost — but calling it out in case a fallback mode is on the roadmap, in which case this guard is where it would slot in.

No breaking changes.
