### PR TITLE
fix(cli): #1743 avoid interpolating active frontmatter values that contain replacement patterns

### DIFF
--- a/packages/cli/src/lib/layout-utils.js
+++ b/packages/cli/src/lib/layout-utils.js
@@ -110,7 +110,12 @@ async function mergeContentIntoLayout(
         childTitle && childTitle.rawText.indexOf(activeFrontmatterTitleKey) >= 0
           ? childTitle.rawText
           : parentTitle.rawText;
-      title = text.replace(activeFrontmatterTitleKey, matchingRoute.title || matchingRoute.label);
+      // function replacement so titles with $&, $`, $' or $n are inserted verbatim
+      // https://github.com/ProjectEvergreen/greenwood/issues/1743
+      title = text.replace(
+        activeFrontmatterTitleKey,
+        () => matchingRoute.title || matchingRoute.label,
+      );
     } else {
       // we favor frontmatter title for the page
       // otherwise we defer to page layouts and then ultimately the app layout

--- a/packages/cli/src/plugins/resource/plugin-active-content.js
+++ b/packages/cli/src/plugins/resource/plugin-active-content.js
@@ -16,6 +16,13 @@ const importMap = {
     "/node_modules/@greenwood/cli/src/lib/content-utils.js",
 };
 
+// escape regex metacharacters in user provided key / collection names
+// (RegExp.escape needs Node >= 24)
+// https://github.com/ProjectEvergreen/greenwood/issues/1743
+function escapeRegExpCharacters(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 class ContentAsDataResource {
   constructor(compilation) {
     this.compilation = compilation;
@@ -108,31 +115,35 @@ class ContentAsDataResource {
 
     // Greenwood active frontmatter keys
     for (const key of activeFrontmatterKeys) {
-      const interpolatedFrontmatter = "\\$\\{globalThis.page." + key + "\\}";
+      const interpolatedFrontmatter =
+        "\\$\\{globalThis.page." + escapeRegExpCharacters(key) + "\\}";
       const needle =
         key === "title" && !matchingRoute.title ? matchingRoute.label : matchingRoute[key];
 
-      newBody = newBody.replace(new RegExp(interpolatedFrontmatter, "g"), needle);
+      // function replacement so values with $&, $`, $' or $n are inserted verbatim
+      // https://github.com/ProjectEvergreen/greenwood/issues/1743
+      newBody = newBody.replace(new RegExp(interpolatedFrontmatter, "g"), () => needle);
     }
 
     // custom user frontmatter data
     for (const fm in matchingRoute.data) {
-      const interpolatedFrontmatter = "\\$\\{globalThis.page.data." + fm + "\\}";
+      const interpolatedFrontmatter =
+        "\\$\\{globalThis.page.data." + escapeRegExpCharacters(fm) + "\\}";
       const needle =
         typeof matchingRoute.data[fm] === "string"
           ? matchingRoute.data[fm]
           : JSON.stringify(matchingRoute.data[fm]).replace(/"/g, "&quot;");
 
-      newBody = newBody.replace(new RegExp(interpolatedFrontmatter, "g"), needle);
+      newBody = newBody.replace(new RegExp(interpolatedFrontmatter, "g"), () => needle);
     }
 
     // collections
     for (const collection in this.compilation.collections) {
-      const interpolatedFrontmatter = "\\$\\{globalThis.collection." + collection + "\\}";
+      const interpolatedFrontmatter =
+        "\\$\\{globalThis.collection." + escapeRegExpCharacters(collection) + "\\}";
       const cleanedCollections = cleanContentCollection(this.compilation.collections[collection]);
 
-      newBody = newBody.replace(
-        new RegExp(interpolatedFrontmatter, "g"),
+      newBody = newBody.replace(new RegExp(interpolatedFrontmatter, "g"), () =>
         JSON.stringify(cleanedCollections).replace(/"/g, "&quot;"),
       );
     }

--- a/packages/cli/test/cases/build.config.active-frontmatter-dollar/build.config.active-frontmatter-dollar.spec.js
+++ b/packages/cli/test/cases/build.config.active-frontmatter-dollar/build.config.active-frontmatter-dollar.spec.js
@@ -1,0 +1,96 @@
+/*
+ * Use Case
+ * Run Greenwood with activeContent configuration enabled for validating active frontmatter
+ * values that contain regex replacement patterns ($&, $`, $1).
+ *
+ * User Result
+ * Should generate a bare bones Greenwood build with frontmatter values interpolated verbatim,
+ * with no replacement pattern expansion or page duplication.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * {
+ *   activeContent: true
+ * }
+ *
+ * User Workspace
+ * Greenwood default
+ *  src/
+ *   pages/
+ *     index.html
+ */
+// https://github.com/ProjectEvergreen/greenwood/issues/1743
+import { JSDOM } from "jsdom";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { expect } from "chai";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Build Greenwood With: ", function () {
+  const LABEL = "Active Frontmatter with Dollar Sign Replacement Patterns";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+    });
+
+    runSmokeTest(["public", "index"], LABEL);
+
+    describe("Frontmatter values containing replacement patterns for the home page", function () {
+      let dom;
+      let html;
+
+      before(async function () {
+        const htmlPath = path.resolve(this.context.publicDir, "./index.html");
+
+        dom = await JSDOM.fromFile(htmlPath);
+        html = await fs.readFile(htmlPath, "utf-8");
+      });
+
+      it("should interpolate a custom data frontmatter value with $&, $` and $1 verbatim", function () {
+        const money = dom.window.document.querySelector("body p.money").textContent;
+
+        expect(money).to.be.equal("pay $& now $` later and $1 tomorrow");
+      });
+
+      it("should interpolate an active frontmatter title value with $& verbatim in the <head>", function () {
+        const title = dom.window.document.querySelector("head title").textContent;
+
+        expect(title).to.be.equal("costs $& per month");
+      });
+
+      it("should interpolate an active frontmatter title value with $& verbatim in the <body>", function () {
+        const heading = dom.window.document.querySelector("body h1").textContent;
+
+        expect(heading).to.be.equal("costs $& per month");
+      });
+
+      it("should not duplicate the page inside itself", function () {
+        const headings = dom.window.document.querySelectorAll("h1");
+
+        expect(headings.length).to.be.equal(1);
+        expect(html.match(/<p class="money">/g).length).to.be.equal(1);
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/cli/test/cases/build.config.active-frontmatter-dollar/greenwood.config.js
+++ b/packages/cli/test/cases/build.config.active-frontmatter-dollar/greenwood.config.js
@@ -1,0 +1,3 @@
+export default {
+  activeContent: true,
+};

--- a/packages/cli/test/cases/build.config.active-frontmatter-dollar/src/pages/index.html
+++ b/packages/cli/test/cases/build.config.active-frontmatter-dollar/src/pages/index.html
@@ -1,0 +1,15 @@
+---
+title: costs $& per month
+money: "pay $& now $` later and $1 tomorrow"
+---
+
+<html lang="en">
+  <head>
+    <title>${globalThis.page.title}</title>
+  </head>
+
+  <body>
+    <h1>${globalThis.page.title}</h1>
+    <p class="money">${globalThis.page.data.money}</p>
+  </body>
+</html>

--- a/packages/cli/test/cases/develop.config.active-content/develop.config.active-content.spec.js
+++ b/packages/cli/test/cases/develop.config.active-content/develop.config.active-content.spec.js
@@ -26,6 +26,7 @@
  *       index.html
  *     contact.html
  *     index.html
+ *     pricing.html
  *     toc.html
  */
 
@@ -109,7 +110,7 @@ describe("Develop Greenwood With: ", function () {
         it("should have the expected content response data", async () => {
           const data = await response.json();
 
-          expect(data.length).to.equal(6);
+          expect(data.length).to.equal(7);
         });
       });
 
@@ -147,6 +148,44 @@ describe("Develop Greenwood With: ", function () {
 
           expect(data.length).to.equal(4);
         });
+      });
+    });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/1743
+    describe("Active Frontmatter values containing replacement patterns", () => {
+      let dom;
+      let html;
+
+      before(async function () {
+        const response = await fetch(`${hostname}:${port}/pricing/`);
+
+        html = await response.text();
+        dom = new JSDOM(html);
+      });
+
+      it("should interpolate a custom data frontmatter value with $&, $` and $1 verbatim", function () {
+        const money = dom.window.document.querySelector("body p.money").textContent;
+
+        expect(money).to.be.equal("pay $& now $` later and $1 tomorrow");
+      });
+
+      it("should interpolate an active frontmatter title value with $& verbatim in the <head>", function () {
+        const title = dom.window.document.querySelector("head title").textContent;
+
+        expect(title).to.be.equal("costs $& per month");
+      });
+
+      it("should interpolate an active frontmatter title value with $& verbatim in the <body>", function () {
+        const heading = dom.window.document.querySelector("body h1").textContent;
+
+        expect(heading).to.be.equal("costs $& per month");
+      });
+
+      it("should not duplicate the page inside itself", function () {
+        const headings = dom.window.document.querySelectorAll("h1");
+
+        expect(headings.length).to.be.equal(1);
+        expect(html.match(/<p class="money">/g).length).to.be.equal(1);
       });
     });
   });

--- a/packages/cli/test/cases/develop.config.active-content/src/pages/pricing.html
+++ b/packages/cli/test/cases/develop.config.active-content/src/pages/pricing.html
@@ -1,0 +1,15 @@
+---
+title: costs $& per month
+money: "pay $& now $` later and $1 tomorrow"
+---
+
+<html lang="en">
+  <head>
+    <title>${globalThis.page.title}</title>
+  </head>
+
+  <body>
+    <h1>${globalThis.page.title}</h1>
+    <p class="money">${globalThis.page.data.money}</p>
+  </body>
+</html>

--- a/packages/cli/test/cases/serve.config.active-content/greenwood.config.js
+++ b/packages/cli/test/cases/serve.config.active-content/greenwood.config.js
@@ -1,0 +1,4 @@
+export default {
+  activeContent: true,
+  prerender: true,
+};

--- a/packages/cli/test/cases/serve.config.active-content/package.json
+++ b/packages/cli/test/cases/serve.config.active-content/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/cli/test/cases/serve.config.active-content/serve.config.active-content.spec.js
+++ b/packages/cli/test/cases/serve.config.active-content/serve.config.active-content.spec.js
@@ -1,0 +1,213 @@
+/*
+ * Use Case
+ * Run Greenwood serve command for a production build using various content as data APIs.
+ *
+ * User Result
+ * Should start the production server with the expected prerendered output using custom elements.
+ *
+ * User Command
+ * greenwood serve
+ *
+ * User Config
+ * {
+ *   activeContent: true,
+ *   prerender: true
+ * }
+ *
+ * User Workspace
+ *  src/
+ *   components/
+ *    blog-posts-lists.js
+ *    header.js
+ *    toc.js
+ *   pages/
+ *     blog/
+ *       first-post.html
+ *       second-post.html
+ *       index.html
+ *     contact.html
+ *     index.html
+ *     pricing.html
+ *     toc.html
+ */
+
+import { expect } from "chai";
+import { JSDOM } from "jsdom";
+import path from "node:path";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Serve Greenwood With: ", function () {
+  const LABEL = "Active Content";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  const hostname = "http://localhost:8080";
+  let runner;
+
+  before(function () {
+    this.context = {
+      hostname,
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+
+      await new Promise((resolve, reject) => {
+        runner
+          .runCommand(cliPath, "serve", {
+            onStdOut: (message) => {
+              if (message.includes(`Started server at ${hostname}`)) {
+                resolve();
+              }
+            },
+          })
+          .catch(reject);
+      });
+    });
+
+    runSmokeTest(["serve"], LABEL);
+
+    describe("Default output for index.html with header nav collection content", function () {
+      let dom;
+
+      before(async function () {
+        const response = await fetch(`${hostname}/`);
+
+        dom = new JSDOM(await response.text());
+      });
+
+      it("should not have a <script> tag of type importmap", function () {
+        const map = dom.window.document.querySelectorAll('script[type="importmap"]');
+
+        expect(map.length).to.equal(0);
+      });
+
+      it("should have a <script> tag that confirms content as data is set", function () {
+        const stateScripts = dom.window.document.querySelectorAll("script#content-as-data-state");
+
+        expect(stateScripts.length).to.equal(1);
+      });
+
+      it("should have a <script> tag that captures content as data related options", function () {
+        const optionsScript = dom.window.document.querySelectorAll("script#data-client-options");
+
+        expect(optionsScript.length).to.equal(1);
+      });
+
+      it("should have the expected number of prerendered nav links from all pages in the collection", function () {
+        const navLinks = dom.window.document.querySelectorAll("x-header nav ul li a");
+
+        expect(navLinks.length).to.equal(4);
+      });
+    });
+
+    describe("Default output for blog/index.html with routes based collection content", function () {
+      let dom;
+
+      before(async function () {
+        const response = await fetch(`${hostname}/blog/`);
+
+        dom = new JSDOM(await response.text());
+      });
+
+      it("should have the expected number of prerendered post links from all blog pages in the collection (minus the index route)", function () {
+        const postLinks = dom.window.document.querySelectorAll("x-posts-list ol li a");
+
+        expect(postLinks.length).to.equal(2);
+      });
+    });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/1743
+    describe("Active Frontmatter values containing replacement patterns", function () {
+      let dom;
+      let html;
+
+      before(async function () {
+        const response = await fetch(`${hostname}/pricing/`);
+
+        html = await response.text();
+        dom = new JSDOM(html);
+      });
+
+      it("should interpolate a custom data frontmatter value with $&, $` and $1 verbatim", function () {
+        const money = dom.window.document.querySelector("body p.money").textContent;
+
+        expect(money).to.be.equal("pay $& now $` later and $1 tomorrow");
+      });
+
+      it("should interpolate an active frontmatter title value with $& verbatim in the <head>", function () {
+        const title = dom.window.document.querySelector("head title").textContent;
+
+        expect(title).to.be.equal("costs $& per month");
+      });
+
+      it("should interpolate an active frontmatter title value with $& verbatim in the <body>", function () {
+        const heading = dom.window.document.querySelector("body h1").textContent;
+
+        expect(heading).to.be.equal("costs $& per month");
+      });
+
+      it("should not duplicate the page inside itself", function () {
+        const headings = dom.window.document.querySelectorAll("h1");
+
+        expect(headings.length).to.be.equal(1);
+        expect(html.match(/<p class="money">/g).length).to.be.equal(1);
+      });
+    });
+
+    describe("Prerendered content as data cache files", function () {
+      describe("Graph Data", function () {
+        let response;
+
+        before(async function () {
+          response = await fetch(`${hostname}/data-graph.json`);
+        });
+
+        it("should have the expected content response data", async function () {
+          const data = await response.json();
+
+          expect(data.length).to.equal(7);
+        });
+      });
+
+      describe("Route Data", function () {
+        let response;
+
+        before(async function () {
+          response = await fetch(`${hostname}/data-route-_blog.json`);
+        });
+
+        it("should have the expected content response data", async function () {
+          const data = await response.json();
+
+          expect(data.length).to.equal(3);
+        });
+      });
+
+      describe("Collections Data", function () {
+        let response;
+
+        before(async function () {
+          response = await fetch(`${hostname}/data-collection-nav.json`);
+        });
+
+        it("should have the expected content response data", async function () {
+          const data = await response.json();
+
+          expect(data.length).to.equal(4);
+        });
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+    await runner.stopCommand();
+  });
+});

--- a/packages/cli/test/cases/serve.config.active-content/src/components/blog-posts-list.js
+++ b/packages/cli/test/cases/serve.config.active-content/src/components/blog-posts-list.js
@@ -1,0 +1,27 @@
+import { getContentByRoute } from "@greenwood/cli/src/data/client.js";
+
+export default class BlogPostsList extends HTMLElement {
+  async connectedCallback() {
+    const posts = (await getContentByRoute("/blog")).filter(
+      (page) => page.label !== "Index" && page.label !== "Blog",
+    );
+
+    this.innerHTML = `
+      <ol>
+        ${posts
+          .map((post) => {
+            const { label, route, title } = post;
+
+            return `
+              <li>
+                <a href='${route}' title="${title}">${label}</a>
+              </li>
+            `;
+          })
+          .join("")}
+      </ol>
+    `;
+  }
+}
+
+customElements.define("x-posts-list", BlogPostsList);

--- a/packages/cli/test/cases/serve.config.active-content/src/components/header.js
+++ b/packages/cli/test/cases/serve.config.active-content/src/components/header.js
@@ -1,0 +1,29 @@
+import { getContentByCollection } from "@greenwood/cli/src/data/client.js";
+
+export default class Header extends HTMLElement {
+  async connectedCallback() {
+    const navItems = (await getContentByCollection("nav")).sort((a, b) =>
+      a.data.order > b.data.order ? 1 : -1,
+    );
+
+    this.innerHTML = `
+      <header>
+        <nav>
+          <ul>
+            ${navItems
+              .map((item) => {
+                const { route, label, title } = item;
+
+                return `
+                  <li><a href="${route}" title="${title}">${label}</a></li>
+                `;
+              })
+              .join("")}
+          </ul>
+        </nav>
+      </header>
+    `;
+  }
+}
+
+customElements.define("x-header", Header);

--- a/packages/cli/test/cases/serve.config.active-content/src/components/toc.js
+++ b/packages/cli/test/cases/serve.config.active-content/src/components/toc.js
@@ -1,0 +1,24 @@
+import { getContent } from "@greenwood/cli/src/data/client.js";
+
+export default class ToC extends HTMLElement {
+  async connectedCallback() {
+    const pages = await getContent();
+
+    this.innerHTML = `
+      <ol>
+        ${pages
+          .map((page) => {
+            const { label, route, title } = page;
+            return `
+              <li>
+                <a href="${route}" title="${title}">${label}</a>
+              </li>
+            `;
+          })
+          .join("")}
+      </ol>
+    `;
+  }
+}
+
+customElements.define("x-toc", ToC);

--- a/packages/cli/test/cases/serve.config.active-content/src/pages/blog/first-post.html
+++ b/packages/cli/test/cases/serve.config.active-content/src/pages/blog/first-post.html
@@ -1,0 +1,4 @@
+<body>
+  <h1>First Post</h1>
+  <p>Lorum Ipsum</p>
+</body>

--- a/packages/cli/test/cases/serve.config.active-content/src/pages/blog/index.html
+++ b/packages/cli/test/cases/serve.config.active-content/src/pages/blog/index.html
@@ -1,0 +1,15 @@
+---
+collection: nav
+order: 2
+---
+
+<html>
+  <head>
+    <script type="module" src="../components/blog-posts-list.js" data-gwd-opt="static"></script>
+  </head>
+
+  <body>
+    <h1>Blog Posts</h1>
+    <x-posts-list></x-posts-list>
+  </body>
+</html>

--- a/packages/cli/test/cases/serve.config.active-content/src/pages/blog/second-post.html
+++ b/packages/cli/test/cases/serve.config.active-content/src/pages/blog/second-post.html
@@ -1,0 +1,4 @@
+<body>
+  <h1>Second Post</h1>
+  <p>Lorum Ipsum</p>
+</body>

--- a/packages/cli/test/cases/serve.config.active-content/src/pages/contact.html
+++ b/packages/cli/test/cases/serve.config.active-content/src/pages/contact.html
@@ -1,0 +1,11 @@
+---
+collection: nav
+order: 4
+label: Contact
+---
+
+<html>
+  <body>
+    <h1>Contact Page</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/serve.config.active-content/src/pages/index.html
+++ b/packages/cli/test/cases/serve.config.active-content/src/pages/index.html
@@ -1,0 +1,16 @@
+---
+collection: nav
+order: 1
+---
+
+<html>
+  <head>
+    <script type="module" src="../components/header.js" data-gwd-opt="static"></script>
+  </head>
+
+  <body>
+    <x-header></x-header>
+    <span>${globalThis.collection.nav}</span>
+    <h1>Home Page</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/serve.config.active-content/src/pages/pricing.html
+++ b/packages/cli/test/cases/serve.config.active-content/src/pages/pricing.html
@@ -1,0 +1,15 @@
+---
+title: costs $& per month
+money: "pay $& now $` later and $1 tomorrow"
+---
+
+<html lang="en">
+  <head>
+    <title>${globalThis.page.title}</title>
+  </head>
+
+  <body>
+    <h1>${globalThis.page.title}</h1>
+    <p class="money">${globalThis.page.data.money}</p>
+  </body>
+</html>

--- a/packages/cli/test/cases/serve.config.active-content/src/pages/toc.html
+++ b/packages/cli/test/cases/serve.config.active-content/src/pages/toc.html
@@ -1,0 +1,16 @@
+---
+collection: nav
+order: 3
+label: Table of Contents
+---
+
+<html>
+  <head>
+    <script type="module" src="../components/toc.js" data-gwd-opt="static"></script>
+  </head>
+
+  <body>
+    <h1>Table of Contents Page</h1>
+    <x-toc></x-toc>
+  </body>
+</html>


### PR DESCRIPTION
## Related Issue

Resolves #1743

## Documentation

N/A — no user-facing documentation changes (bug fix only).

## Summary of Changes

1. [x] Used the function form of `String.prototype.replace` in all three active
   content interpolation loops in
   `packages/cli/src/plugins/resource/plugin-active-content.js` (active
   frontmatter keys, custom `data.*` frontmatter, collections), so a frontmatter
   value containing `$&`, `` $` ``, `$'`, `$$` or `$n` is inserted verbatim
   instead of being expanded as a replacement pattern (which could silently
   duplicate the whole page inside itself).
1. [x] Applied the same function-form fix to the page `<title>` interpolation in
   `packages/cli/src/lib/layout-utils.js`, which had the identical defect on the
   layout-merge path.
1. [x] Added a small `escapeRegExpCharacters` helper (local, since
   `RegExp.escape` requires Node >= 24 and CI also runs Node 22) and used it on
   the interpolated key / collection names when building the search pattern, so
   a data key or collection name containing a regex metacharacter no longer
   builds a wrong `RegExp`.
1. [x] Added a regression test case
   `packages/cli/test/cases/build.config.active-frontmatter-dollar/` with a
   fixture page whose frontmatter `title` and custom `money` values contain
   `$&`, `` $` `` and `$1`, asserting they render verbatim in the built HTML and
   that the page is not duplicated inside itself. Verified the spec fails on the
   unpatched source and passes with the fix.
1. [x] No breaking changes — values without `$` patterns and keys without regex
   metacharacters interpolate exactly as before (the existing
   `build.config.active-frontmatter` case still passes).
