### PR TITLE
fix(cli): #1745 surface plugin config validation errors instead of unhandled rejection crash

### DIFF
--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -156,7 +156,10 @@ const readAndMergeConfig = async () => {
     if (plugins && plugins.length > 0) {
       const flattened = plugins.flat(PLUGINS_FLATTENED_DEPTH);
 
-      flattened.forEach((plugin) => {
+      // use for...of (not forEach) so these rejections actually return from readAndMergeConfig
+      // instead of surfacing as an UnhandledPromiseRejection crash
+      // https://github.com/ProjectEvergreen/greenwood/issues/1745
+      for (const plugin of flattened) {
         if (!plugin.type || pluginTypes.indexOf(plugin.type) < 0) {
           return Promise.reject(
             `Configuration error: plugins must be one of type "${pluginTypes.join(", ")}". got "${plugin.type}" instead.`,
@@ -178,7 +181,7 @@ const readAndMergeConfig = async () => {
             `Configuration error: plugins must have a name. got ${nameTypeof} instead.`,
           );
         }
-      });
+      }
 
       // if user provided a custom renderer, filter out Greenwood's default renderer
       const customRendererPlugins = flattened.filter((plugin) => plugin.type === "renderer").length;

--- a/packages/cli/test/cases/build.plugins.error-name/build.plugins.error-name.spec.js
+++ b/packages/cli/test/cases/build.plugins.error-name/build.plugins.error-name.spec.js
@@ -49,5 +49,15 @@ describe("Build Greenwood With: ", function () {
         "Configuration error: plugins must have a name. got undefined instead.",
       );
     });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/1745
+    it("should surface the configuration error directly instead of an unhandled promise rejection", async function () {
+      const stderr = await runner.runCommand(cliPath, "build").then(
+        () => "",
+        (err) => err,
+      );
+
+      expect(stderr).to.not.contain("UnhandledPromiseRejection");
+    });
   });
 });

--- a/packages/cli/test/cases/build.plugins.error-provider/build.plugins.error-provider.spec.js
+++ b/packages/cli/test/cases/build.plugins.error-provider/build.plugins.error-provider.spec.js
@@ -50,5 +50,15 @@ describe("Build Greenwood With: ", function () {
         `Configuration error: plugins provider must be a function. got object instead.`,
       );
     });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/1745
+    it("should surface the configuration error directly instead of an unhandled promise rejection", async function () {
+      const stderr = await runner.runCommand(cliPath, "build").then(
+        () => "",
+        (err) => err,
+      );
+
+      expect(stderr).to.not.contain("UnhandledPromiseRejection");
+    });
   });
 });

--- a/packages/cli/test/cases/build.plugins.error-type/build.plugins.error-type.spec.js
+++ b/packages/cli/test/cases/build.plugins.error-type/build.plugins.error-type.spec.js
@@ -61,5 +61,15 @@ describe("Build Greenwood With: ", function () {
         `Configuration error: plugins must be one of type "${pluginTypes.join(", ")}". got "indexxx" instead.`,
       );
     });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/1745
+    it("should surface the configuration error directly instead of an unhandled promise rejection", async function () {
+      const stderr = await runner.runCommand(cliPath, "build").then(
+        () => "",
+        (err) => err,
+      );
+
+      expect(stderr).to.not.contain("UnhandledPromiseRejection");
+    });
   });
 });


### PR DESCRIPTION
## Related Issue

Resolves #1745

## Documentation

N/A — no behavior change to document; the validation messages are unchanged, they just surface the way they were already written to.

## Summary of Changes

1. [x] `lifecycles/config.js` — iterate the flattened plugins with `for...of` instead of `forEach`, so the existing `return Promise.reject(...)` statements for the plugin `type` / `provider` / `name` checks actually return from `readAndMergeConfig` and reach the CLI's `try/catch`, instead of floating and crashing the process with an `UnhandledPromiseRejection` dump on a later tick.
2. [x] Extended the three existing cases `build.plugins.error-type`, `build.plugins.error-provider`, and `build.plugins.error-name` with a regression assertion that the build's stderr does not contain `UnhandledPromiseRejection` (the existing assertions passed either way, because the expected message was present as a substring inside Node's crash dump).

### Regression proof

The new assertions fail on unpatched `master` (all three validation branches):

```
  1) Build Greenwood With:
       Custom Configuration with a bad value for plugin type
         should surface the configuration error directly instead of an unhandled promise rejection:
     AssertionError: expected 'node:internal/process/promises:392\n …' to not include 'UnhandledPromiseRejection'

  2) Build Greenwood With:
       Custom Configuration with a bad provider value for a plugin
         should surface the configuration error directly instead of an unhandled promise rejection:
     AssertionError: expected 'node:internal/process/promises:392\n …' to not include 'UnhandledPromiseRejection'

  3) Build Greenwood With:
       Custom Configuration with a bad name value for a plugin
         should surface the configuration error directly instead of an unhandled promise rejection:
     AssertionError: expected 'node:internal/process/promises:392\n …' to not include 'UnhandledPromiseRejection'

  3 passing (5s)
  3 failing
```

With the fix:

```
  Build Greenwood With:
    Custom Configuration with a bad value for plugin type
      ✔ should throw an error that plugin.type is not a valid value
      ✔ should surface the configuration error directly instead of an unhandled promise rejection

  Build Greenwood With:
    Custom Configuration with a bad provider value for a plugin
      ✔ should throw an error that plugin.provider is not a function
      ✔ should surface the configuration error directly instead of an unhandled promise rejection

  Build Greenwood With:
    Custom Configuration with a bad name value for a plugin
      ✔ should throw an error that plugin.name is not a string
      ✔ should surface the configuration error directly instead of an unhandled promise rejection

  6 passing (3s)
```

`yarn lint` (ls-lint + eslint + tsc) and `yarn format:check` are clean.
