### PR TITLE
fix(cli): #1748 reject prod server requests that resolve outside the output directory

### DIFF
--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -232,8 +232,11 @@ async function getStaticServer(compilation, composable) {
   app.use(async (ctx, next) => {
     try {
       const url = new URL(`.${ctx.url.replace(basePath, "")}`, outputDir.href);
+      // reject paths that resolve outside the output directory (e.g. `../` traversal);
+      // outputDir.href ends in `/`, so this boundary also excludes sibling-prefix paths
+      const isWithinOutputDir = url.href.startsWith(outputDir.href);
 
-      if (await checkResourceExists(url)) {
+      if (isWithinOutputDir && (await checkResourceExists(url))) {
         const resourcePlugins = standardResourcePlugins
           .filter((plugin) => plugin.isStandardStaticResource)
           .map((plugin) => {

--- a/packages/cli/test/cases/serve.default.path-traversal/greenwood.config.js
+++ b/packages/cli/test/cases/serve.default.path-traversal/greenwood.config.js
@@ -1,0 +1,3 @@
+export default {
+  port: 8182,
+};

--- a/packages/cli/test/cases/serve.default.path-traversal/secret-outside-webroot.json
+++ b/packages/cli/test/cases/serve.default.path-traversal/secret-outside-webroot.json
@@ -1,0 +1,1 @@
+{ "canary": "THIS_FILE_IS_OUTSIDE_THE_WEB_ROOT" }

--- a/packages/cli/test/cases/serve.default.path-traversal/serve.default.path-traversal.spec.js
+++ b/packages/cli/test/cases/serve.default.path-traversal/serve.default.path-traversal.spec.js
@@ -1,0 +1,139 @@
+/*
+ * Use Case
+ * Run Greenwood serve command and make sure the static file handler cannot be
+ * tricked into reading files outside the output directory via `../` traversal.
+ *
+ * User Result
+ * Should return the requested in-root asset, but 404 for any path that resolves
+ * outside the output directory.
+ *
+ * User Command
+ * greenwood serve
+ *
+ * User Config
+ * {
+ *   port: 8182
+ * }
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     index.html
+ *   assets/
+ *     data.json
+ * secret-outside-webroot.json  (sibling of the build output, must never be served)
+ *
+ * https://github.com/ProjectEvergreen/greenwood/issues/1748
+ */
+import { expect } from "chai";
+import net from "node:net";
+import path from "node:path";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+// fetch()/WHATWG URL normalize `..` client-side, so use a raw socket to send the
+// literal request target an attacker would send (e.g. curl --path-as-is).
+function rawRequest(port, requestTarget) {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(port, "127.0.0.1", () => {
+      socket.write(`GET ${requestTarget} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
+    });
+    let raw = "";
+    socket.on("data", (chunk) => (raw += chunk));
+    socket.on("error", reject);
+    socket.on("end", () => {
+      const [head, body = ""] = raw.split("\r\n\r\n");
+      const status = Number(head.split("\r\n")[0].split(" ")[1]);
+      resolve({ status, body });
+    });
+  });
+}
+
+describe("Serve Greenwood With: ", function () {
+  const LABEL = "Path traversal protection for the static file handler";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  const hostname = "http://localhost:8182";
+  const port = 8182;
+  let runner;
+
+  before(function () {
+    this.context = {
+      hostname,
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+
+      await new Promise((resolve, reject) => {
+        runner
+          .runCommand(cliPath, "serve", {
+            onStdOut: (message) => {
+              if (message.includes(`Started server at ${hostname}`)) {
+                resolve();
+              }
+            },
+          })
+          .catch(reject);
+      });
+    });
+
+    describe("a legitimate in-root static asset", function () {
+      let response;
+
+      before(async function () {
+        response = await rawRequest(port, "/assets/data.json");
+      });
+
+      it("should return a 200 status", function () {
+        expect(response.status).to.equal(200);
+      });
+
+      it("should return the asset contents", function () {
+        expect(response.body).to.contain("world-in-root-asset");
+      });
+    });
+
+    describe("a `../` traversal to a file outside the output directory", function () {
+      let response;
+
+      before(async function () {
+        response = await rawRequest(port, "/../secret-outside-webroot.json");
+      });
+
+      it("should return a 404 status", function () {
+        expect(response.status).to.equal(404);
+      });
+
+      it("should not leak the out-of-root file contents", function () {
+        expect(response.body).to.not.contain("THIS_FILE_IS_OUTSIDE_THE_WEB_ROOT");
+      });
+    });
+
+    describe("a percent-encoded `..` traversal", function () {
+      let response;
+
+      before(async function () {
+        response = await rawRequest(port, "/%2e%2e/secret-outside-webroot.json");
+      });
+
+      it("should return a 404 status", function () {
+        expect(response.status).to.equal(404);
+      });
+
+      it("should not leak the out-of-root file contents", function () {
+        expect(response.body).to.not.contain("THIS_FILE_IS_OUTSIDE_THE_WEB_ROOT");
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+    await runner.stopCommand();
+  });
+});

--- a/packages/cli/test/cases/serve.default.path-traversal/src/assets/data.json
+++ b/packages/cli/test/cases/serve.default.path-traversal/src/assets/data.json
@@ -1,0 +1,1 @@
+{ "hello": "world-in-root-asset" }

--- a/packages/cli/test/cases/serve.default.path-traversal/src/pages/index.html
+++ b/packages/cli/test/cases/serve.default.path-traversal/src/pages/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>Path Traversal Test</title>

--- a/packages/cli/test/cases/serve.default.path-traversal/src/pages/index.html
+++ b/packages/cli/test/cases/serve.default.path-traversal/src/pages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Path Traversal Test</title>
+  </head>
+  <body>
+    <h1>Path Traversal Test</h1>
+  </body>
+</html>


### PR DESCRIPTION
### Related Issue

Closes #1748

### Summary of Changes

The static-asset middleware in `getStaticServer` (`packages/cli/src/lifecycles/serve.js`) built a `file://` URL directly from the request path and passed it to `checkResourceExists`/the resource plugins without checking that it stayed inside the output directory. Because the base is a `file://` URL — which has no origin for the URL parser to clamp against — a request path containing `../` resolved outside the web root, so `greenwood serve` returned the contents of arbitrary files with a served extension (`.js`, `.css`, `.json`, `.map`, images, fonts, `.wasm`, media) and an existence oracle for everything else. Node and Koa pass `../` through untouched, so any client that does not pre-normalize the path (e.g. `curl --path-as-is`, a raw socket) could reach it.

This adds a containment check: the resolved URL must fall within `outputDir` before the filesystem is touched, otherwise the request falls through to the existing 404 path. Because `outputDir.href` ends in `/`, the `startsWith` boundary also rejects sibling-prefix paths (e.g. `.../public-evil/`), and the URL parser has already collapsed percent-encoded `..` by the time the check runs.

The two sibling page-resolution middlewares in the same file are unaffected — they build `http://` URLs, which clamp `../` to the origin, so they were never able to escape.

```diff
  const url = new URL(`.${ctx.url.replace(basePath, "")}`, outputDir.href);
+ // reject paths that resolve outside the output directory (e.g. `../` traversal);
+ // outputDir.href ends in `/`, so this boundary also excludes sibling-prefix paths
+ const isWithinOutputDir = url.href.startsWith(outputDir.href);

- if (await checkResourceExists(url)) {
+ if (isWithinOutputDir && (await checkResourceExists(url))) {
```

### Testing

New case `serve.default.path-traversal` with a canary file placed one level above the output directory:

- a legitimate in-root asset (`/assets/data.json`) still returns `200` with its contents
- a raw `../` traversal (`/../secret-outside-webroot.json`) returns `404` and does not leak the file
- a percent-encoded traversal (`/%2e%2e/secret-outside-webroot.json`) returns `404` and does not leak the file

Verified the test fails against `master` (both traversal cases return `200` with the canary body) and passes with the fix. The existing `serve.default` suite still passes (49 passing together), confirming normal static serving is unaffected.
