### PR TITLE
fix(cli): #1585 copy css url() assets synchronously to avoid concurrent duplicate copies

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -136,12 +136,7 @@ function bundleCss(body, sourceUrl, compilation, workingUrl) {
 
             const destinationUrl = new URL(`.${finalValue}`, outputDir);
 
-            // copy synchronously, skipping destinations already written, since the same source
-            // can be referenced from multiple url()s (e.g. an eot ?#iefix fallback) and
-            // concurrent copies to the same destination intermittently fail on Windows with
-            // EBUSY, crashing the build as an unhandled rejection.  the destination name is
-            // content-hashed, so an existing file can safely be kept as is
-            // https://github.com/ProjectEvergreen/greenwood/issues/1585
+            // destination names are content-hashed, so an existing file is already correct
             if (!fs.existsSync(destinationUrl)) {
               fs.copyFileSync(resolvedUrl, destinationUrl);
             }

--- a/packages/cli/src/plugins/resource/plugin-standard-css.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-css.js
@@ -134,7 +134,17 @@ function bundleCss(body, sourceUrl, compilation, workingUrl) {
               recursive: true,
             });
 
-            fs.promises.copyFile(resolvedUrl, new URL(`.${finalValue}`, outputDir));
+            const destinationUrl = new URL(`.${finalValue}`, outputDir);
+
+            // copy synchronously, skipping destinations already written, since the same source
+            // can be referenced from multiple url()s (e.g. an eot ?#iefix fallback) and
+            // concurrent copies to the same destination intermittently fail on Windows with
+            // EBUSY, crashing the build as an unhandled rejection.  the destination name is
+            // content-hashed, so an existing file can safely be kept as is
+            // https://github.com/ProjectEvergreen/greenwood/issues/1585
+            if (!fs.existsSync(destinationUrl)) {
+              fs.copyFileSync(resolvedUrl, destinationUrl);
+            }
           }
 
           optimizedCss += `url('${basePath}${finalValue}')`;

--- a/packages/cli/test/cases/build.default.css-duplicate-asset-references/build.default.css-duplicate-asset-references.spec.js
+++ b/packages/cli/test/cases/build.default.css-duplicate-asset-references/build.default.css-duplicate-asset-references.spec.js
@@ -1,0 +1,113 @@
+/*
+ * Use Case
+ * Run Greenwood build command with no config and a stylesheet that references the same
+ * asset from more than one url(), e.g. the classic eot ?#iefix @font-face fallback.
+ * Each url() fires its own copy of the same source file to the same hashed destination,
+ * which intermittently fails on Windows with EBUSY (destination locked by the concurrent
+ * copy) and crashes the build as an unhandled rejection.  The Windows locking behavior
+ * is emulated deterministically via windows-copyfile-emulation.js, loaded into the CLI
+ * process through NODE_OPTIONS --import.
+ * https://github.com/ProjectEvergreen/greenwood/issues/1585
+ *
+ * User Result
+ * Should generate a bare bones Greenwood build with the referenced font copied once.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * None (Greenwood Default)
+ *
+ * User Workspace
+ *  src/
+ *   fonts/
+ *     example.woff
+ *   pages/
+ *     index.html
+ *   styles/
+ *     main.css
+ */
+import { expect } from "chai";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+describe("Build Greenwood With: ", function () {
+  const LABEL = "Default Greenwood Configuration and duplicate CSS asset references";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      const shimUrl = pathToFileURL(path.join(outputPath, "windows-copyfile-emulation.js"));
+      const previousNodeOptions = process.env.NODE_OPTIONS;
+
+      process.env.NODE_OPTIONS = `--import=${shimUrl.href}`;
+
+      try {
+        await runner.setup(outputPath);
+        await runner.runCommand(cliPath, "build");
+      } finally {
+        if (previousNodeOptions === undefined) {
+          delete process.env.NODE_OPTIONS;
+        } else {
+          process.env.NODE_OPTIONS = previousNodeOptions;
+        }
+      }
+    });
+
+    runSmokeTest(["public"], LABEL);
+
+    describe("Bundled CSS with duplicate references to the same font file", function () {
+      let styles;
+      let fonts;
+
+      before(async function () {
+        styles = await Array.fromAsync(
+          fs.glob("main.*.css", { cwd: new URL("./public/styles/", import.meta.url) }),
+        );
+        fonts = await Array.fromAsync(
+          fs.glob("example.*.woff", { cwd: new URL("./public/fonts/", import.meta.url) }),
+        );
+      });
+
+      it("should reference the hashed font file from the bundled stylesheet", async function () {
+        const stylesContents = await fs.readFile(
+          new URL(`./public/styles/${styles[0]}`, import.meta.url),
+          "utf-8",
+        );
+
+        expect(stylesContents).to.contain(`/fonts/${fonts[0]}`);
+      });
+
+      it("should copy the referenced font file once with its original contents", async function () {
+        const sourceContents = await fs.readFile(
+          new URL("./src/fonts/example.woff", import.meta.url),
+          "utf-8",
+        );
+        const copiedContents = await fs.readFile(
+          new URL(`./public/fonts/${fonts[0]}`, import.meta.url),
+          "utf-8",
+        );
+
+        expect(fonts.length).to.equal(1);
+        expect(copiedContents).to.equal(sourceContents);
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/cli/test/cases/build.default.css-duplicate-asset-references/src/fonts/example.woff
+++ b/packages/cli/test/cases/build.default.css-duplicate-asset-references/src/fonts/example.woff
@@ -1,0 +1,1 @@
+not-a-real-font-just-fixture-bytes-for-copy-testing

--- a/packages/cli/test/cases/build.default.css-duplicate-asset-references/src/pages/index.html
+++ b/packages/cli/test/cases/build.default.css-duplicate-asset-references/src/pages/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Duplicate CSS Asset References</title>
+    <link rel="stylesheet" href="/styles/main.css" />
+  </head>
+
+  <body>
+    <h1>Duplicate CSS Asset References</h1>
+  </body>
+</html>

--- a/packages/cli/test/cases/build.default.css-duplicate-asset-references/src/styles/main.css
+++ b/packages/cli/test/cases/build.default.css-duplicate-asset-references/src/styles/main.css
@@ -1,0 +1,11 @@
+@font-face {
+  font-family: "Example";
+  src: url("../fonts/example.woff?v=1.0");
+  src:
+    url("../fonts/example.woff?#iefix&v=1.0") format("woff"),
+    url("../fonts/example.woff?v=1.0") format("woff");
+}
+
+body {
+  font-family: "Example", sans-serif;
+}

--- a/packages/cli/test/cases/build.default.css-duplicate-asset-references/windows-copyfile-emulation.js
+++ b/packages/cli/test/cases/build.default.css-duplicate-asset-references/windows-copyfile-emulation.js
@@ -1,0 +1,31 @@
+/*
+ * Emulates the destination file locking behavior of copyFile on Windows, where a copy
+ * to a destination that already has another copy in flight fails with EBUSY.  Loaded
+ * into the CLI process via NODE_OPTIONS --import by the accompanying spec, so the
+ * intermittent Windows-only CI failure can be reproduced deterministically on any OS.
+ * https://github.com/ProjectEvergreen/greenwood/issues/1585
+ */
+import fs from "node:fs";
+
+const originalCopyFile = fs.promises.copyFile;
+const inFlightDestinations = new Set();
+
+fs.promises.copyFile = function copyFile(src, dest, ...args) {
+  const key = dest.toString();
+
+  if (inFlightDestinations.has(key)) {
+    const error = new Error(`EBUSY: resource busy or locked, copyfile '${src}' -> '${dest}'`);
+
+    error.code = "EBUSY";
+    error.errno = -4082;
+    error.syscall = "copyfile";
+
+    return Promise.reject(error);
+  }
+
+  inFlightDestinations.add(key);
+
+  return originalCopyFile.call(fs.promises, src, dest, ...args).finally(() => {
+    inFlightDestinations.delete(key);
+  });
+};


### PR DESCRIPTION
## Related Issue

Resolves #1585

Most recently observed instance: the Windows `build (22)` job on #1747's CI run ([job link](https://github.com/ProjectEvergreen/greenwood/actions/runs/30770248106/job/91556054517)), failing in `build.default.import-node-modules` on `fontawesome-webfont.eot`.

## Summary of Changes

**Root cause.** `bundleCss` fires an unawaited `fs.promises.copyFile` for every `url()` reference it walks ([plugin-standard-css.js#L137](https://github.com/ProjectEvergreen/greenwood/blob/598ec15618871580e83a37f00cc27173dcf9e2e5/packages/cli/src/plugins/resource/plugin-standard-css.js#L137)). When the same source file is referenced from more than one `url()` — e.g. font-awesome's `fontawesome-webfont.eot?v=4.7.0` plus its `?#iefix` IE fallback on the very next line, or any asset shared across stylesheets — two copies to the same content-hashed destination start in the same synchronous tick of the CSS AST walk. On Windows, `copyfile` takes an exclusive handle on the destination, so the second copy intermittently fails with `EBUSY`; because the promise is fire-and-forget, that error surfaces as an unhandled rejection that crashes the entire build. Linux and macOS tolerate concurrent writes to the same path, which is why only the Windows CI jobs ever see it.

**Fix.** Copy synchronously, skipping destinations that already exist — the destination name is content-hashed, so an existing file already has the right contents. Synchronous copies cannot interleave (eliminating the race by construction), a genuine copy failure now throws catchably instead of killing the process, and sync `fs` matches the surrounding code, which already uses `readFileSync` on the same asset for hashing. Awaiting the promises instead was considered, but `bundleCss` is synchronous and recursive, so that would have meant refactoring its whole call chain.

**Regression test.** `build.default.css-duplicate-asset-references` builds a workspace whose stylesheet references the same font from multiple `url()`s (the `?#iefix` pattern). Since the race is benign on Linux, the Windows destination-locking semantics are emulated deterministically by `windows-copyfile-emulation.js`, loaded into the spawned CLI process via `NODE_OPTIONS --import`: it rejects with `EBUSY` when a `fs.promises.copyFile` targets a destination that already has a copy in flight, exactly as win32 does. Happy to drop or rework the shim if you'd prefer a different approach.

Proven to fail on pristine `master` with the same signature as the CI flake:

```
1) Build Greenwood With:
     Default Greenwood Configuration and duplicate CSS asset references
       "before all" hook ...:
   Error: the string "...
   Error: EBUSY: resource busy or locked, copyfile '.../src/fonts/example.woff?v=1.0' -> '.../public/fonts/example.JMHWbgbO.woff?v=1.0'
       at Object.copyFile (.../windows-copyfile-emulation.js:17:19)
       at Object.enter (.../packages/cli/src/plugins/resource/plugin-standard-css.js:137:25)
       at walkNode (.../css-tree/lib/walker/create.js:169:36)
   ...
   Node.js v22.20.0
   " was thrown, throw an Error :)
```

and to pass with the fix (`5 passing`), alongside `build.default.import-node-modules` (`14 passing`) and `build.config.optimization-default` (`16 passing`). Lint, type check, and format check all clean.
