### PR TITLE
feature(plugins): #1752 add rss feed generation plugin

### DIFF
--- a/packages/plugin-rss/README.md
+++ b/packages/plugin-rss/README.md
@@ -1,0 +1,106 @@
+# @greenwood/plugin-rss
+
+## Overview
+
+A Greenwood plugin for generating an [RSS 2.0](https://www.rssboard.org/rss-specification) feed from the pages in your project.  At build time the feed is written to the output directory (_rss.xml_ by default), and during development it is served from the same route, so `greenwood develop`, `greenwood build`, and `greenwood serve` all expose your feed.  For more information and complete docs on Greenwood, please visit [our website](https://www.greenwoodjs.dev).
+
+> This package assumes you already have `@greenwood/cli` installed.
+
+## Installation
+
+You can use your favorite JavaScript package manager to install this package.
+
+```bash
+# npm
+$ npm i -D @greenwood/plugin-rss
+
+# yarn
+$ yarn add @greenwood/plugin-rss --dev
+
+# pnpm
+$ pnpm add -D @greenwood/plugin-rss
+```
+
+## Usage
+
+Use this plugin in your _greenwood.config.js_ and pass in the required channel information for your feed.
+
+```javascript
+import { greenwoodPluginRss } from '@greenwood/plugin-rss';
+
+export default {
+  // ...
+
+  plugins: [
+    greenwoodPluginRss({
+      title: 'My Blog',
+      link: 'https://www.myblog.dev',
+      description: 'Musings on web development'
+    })
+  ]
+}
+```
+
+This will generate a feed at `/rss.xml` with one `<item>` per page.  Each item is built from the page's [frontmatter](https://www.greenwoodjs.dev/docs/resources/markdown/#frontmatter):
+
+- `<title>` — the page's `title` (falling back to its inferred label)
+- `<link>` / `<guid>` — the `link` option joined with the page's route
+- `<description>` — the page's `description` frontmatter, when present
+- `<pubDate>` — the page's `published` (or `date`) frontmatter, when present
+
+Pages with a `published` / `date` are sorted newest first.
+
+To scope the feed to just your blog posts, group them into a [collection](https://www.greenwoodjs.dev/docs/content-as-data/collections/) and pass the collection name:
+
+```md
+---
+collection: blog
+title: My First Post
+published: 2026-01-15
+description: The one where it all began
+---
+
+# My First Post
+```
+
+```javascript
+import { greenwoodPluginRss } from '@greenwood/plugin-rss';
+
+export default {
+  plugins: [
+    greenwoodPluginRss({
+      title: 'My Blog',
+      link: 'https://www.myblog.dev',
+      description: 'Musings on web development',
+      collection: 'blog'
+    })
+  ]
+}
+```
+
+You can then advertise the feed from your pages' `<head>`:
+
+```html
+<link rel="alternate" type="application/rss+xml" title="My Blog" href="/rss.xml">
+```
+
+## Types
+
+Types should automatically be inferred through this package's exports map, but can be referenced explicitly in both JavaScript (JSDoc) and TypeScript files if needed.
+
+```js
+/** @type {import('@greenwood/plugin-rss').RssPlugin} */
+```
+
+```ts
+import type { RssPlugin } from '@greenwood/plugin-rss';
+```
+
+## Options
+
+- `title` (required) - The title of your feed
+- `link` (required) - The absolute URL of your site, used as the channel link and to build each item's link
+- `description` (required) - The description of your feed
+- `collection` (optional) - Only include pages from this [collection](https://www.greenwoodjs.dev/docs/content-as-data/collections/).  Default is all pages (excluding the 404 page)
+- `filename` (optional) - The output filename of the feed.  Default is `rss.xml`
+- `maxItems` (optional) - Cap the number of items in the feed.  Default is unlimited

--- a/packages/plugin-rss/package.json
+++ b/packages/plugin-rss/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@greenwood/plugin-rss",
+  "version": "0.34.0",
+  "description": "A Greenwood plugin for generating an RSS feed from your content.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-rss"
+  },
+  "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-rss",
+  "author": "Jonathan Stockdill",
+  "license": "MIT",
+  "keywords": [
+    "Greenwood",
+    "Static Site Generator",
+    "Server Side Rendering",
+    "Full Stack Web Development",
+    "Serverless",
+    "Web Components",
+    "RSS",
+    "Feed",
+    "Syndication"
+  ],
+  "type": "module",
+  "main": "./src/index.js",
+  "types": "./src/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/types/index.d.ts",
+      "import": "./src/index.js"
+    }
+  },
+  "files": [
+    "src/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@greenwood/cli": "^0.34.0"
+  },
+  "devDependencies": {
+    "@greenwood/cli": "^0.34.0"
+  }
+}

--- a/packages/plugin-rss/src/index.js
+++ b/packages/plugin-rss/src/index.js
@@ -1,0 +1,156 @@
+import fs from "node:fs/promises";
+
+const DEFAULT_FILENAME = "rss.xml";
+
+function escapeEntities(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function getPageDate(page) {
+  const raw = page.data?.published ?? page.data?.date;
+  const date = raw ? new Date(raw) : null;
+
+  return date && !isNaN(date.valueOf()) ? date : null;
+}
+
+function getFeedPages(compilation, options) {
+  const { collection } = options;
+  const { basePath } = compilation.config;
+  const pages = collection
+    ? (compilation.collections?.[collection] ?? [])
+    : compilation.graph.filter((page) => page.route !== `${basePath}/404/`);
+
+  return [...pages].sort((pageA, pageB) => {
+    const dateA = getPageDate(pageA);
+    const dateB = getPageDate(pageB);
+
+    // newest first; undated pages keep their graph order at the end
+    if (!dateA && !dateB) {
+      return 0;
+    } else if (!dateA) {
+      return 1;
+    } else if (!dateB) {
+      return -1;
+    }
+
+    return dateB.valueOf() - dateA.valueOf();
+  });
+}
+
+function generateRssFeed(compilation, options) {
+  const { title, description, link, maxItems } = options;
+  const channelLink = link.replace(/\/$/, "");
+  let pages = getFeedPages(compilation, options);
+
+  if (maxItems) {
+    pages = pages.slice(0, maxItems);
+  }
+
+  const items = pages
+    .map((page) => {
+      const itemTitle = page.title ?? page.label;
+      const itemLink = `${channelLink}${page.route}`;
+      const itemDescription = page.data?.description;
+      const itemDate = getPageDate(page);
+
+      return [
+        "    <item>",
+        `      <title>${escapeEntities(itemTitle)}</title>`,
+        `      <link>${escapeEntities(itemLink)}</link>`,
+        `      <guid>${escapeEntities(itemLink)}</guid>`,
+        itemDescription
+          ? `      <description>${escapeEntities(itemDescription)}</description>`
+          : null,
+        itemDate ? `      <pubDate>${itemDate.toUTCString()}</pubDate>` : null,
+        "    </item>",
+      ]
+        .filter((line) => line !== null)
+        .join("\n");
+    })
+    .join("\n");
+
+  return [
+    `<?xml version="1.0" encoding="UTF-8"?>`,
+    `<rss version="2.0">`,
+    "  <channel>",
+    `    <title>${escapeEntities(title)}</title>`,
+    `    <link>${escapeEntities(channelLink)}</link>`,
+    `    <description>${escapeEntities(description)}</description>`,
+    items,
+    "  </channel>",
+    "</rss>",
+  ]
+    .filter((section) => section !== "")
+    .join("\n");
+}
+
+class RssFeedResource {
+  constructor(compilation, options = {}) {
+    this.compilation = compilation;
+    this.options = options;
+    this.contentType = "application/rss+xml";
+  }
+
+  async shouldServe(url) {
+    const { basePath } = this.compilation.config;
+    const filename = this.options.filename ?? DEFAULT_FILENAME;
+
+    return url.pathname === `${basePath}/${filename}`;
+  }
+
+  async serve() {
+    const feed = generateRssFeed(this.compilation, this.options);
+
+    return new Response(feed, {
+      headers: new Headers({
+        "Content-Type": this.contentType,
+      }),
+    });
+  }
+}
+
+/** @type {import('./types/index.d.ts').RssPlugin} */
+const greenwoodPluginRss = (options = {}) => {
+  // title, link, and description are the required channel elements of RSS 2.0
+  // https://www.rssboard.org/rss-specification#requiredChannelElements
+  ["title", "link", "description"].forEach((key) => {
+    if (!options[key] || typeof options[key] !== "string") {
+      throw new Error(
+        `Error: ${key} should be of type string.  got "${typeof options[key]}" instead.`,
+      );
+    }
+  });
+
+  return [
+    {
+      type: "copy",
+      name: "plugin-rss:copy",
+      provider: async (compilation) => {
+        const { outputDir, scratchDir } = compilation.context;
+        const filename = options.filename ?? DEFAULT_FILENAME;
+        const feedScratchUrl = new URL(`./${filename}`, scratchDir);
+
+        await fs.writeFile(feedScratchUrl, generateRssFeed(compilation, options));
+
+        return [
+          {
+            from: feedScratchUrl,
+            to: new URL(`./${filename}`, outputDir),
+          },
+        ];
+      },
+    },
+    {
+      type: "resource",
+      name: "plugin-rss:resource",
+      provider: (compilation) => new RssFeedResource(compilation, options),
+    },
+  ];
+};
+
+export { greenwoodPluginRss };

--- a/packages/plugin-rss/src/types/index.d.ts
+++ b/packages/plugin-rss/src/types/index.d.ts
@@ -1,0 +1,16 @@
+import type { CopyPlugin, ResourcePlugin } from "@greenwood/cli";
+
+export type RssPluginOptions = {
+  title: string;
+  link: string;
+  description: string;
+  collection?: string;
+  filename?: string;
+  maxItems?: number;
+};
+
+export type RssPlugin = (options: RssPluginOptions) => [CopyPlugin, ResourcePlugin];
+
+declare module "@greenwood/plugin-rss" {
+  export const greenwoodPluginRss: RssPlugin;
+}

--- a/packages/plugin-rss/test/cases/default/default.spec.js
+++ b/packages/plugin-rss/test/cases/default/default.spec.js
@@ -1,0 +1,133 @@
+/*
+ * Use Case
+ * Run Greenwood with RSS composite plugin with default options.
+ *
+ * User Result
+ * Should generate a bare bones Greenwood build with an RSS feed of all pages at rss.xml.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * import { greenwoodPluginRss } from '@greenwood/plugin-rss';
+ *
+ * {
+ *   plugins: [
+ *     greenwoodPluginRss({
+ *       title: 'My Blog',
+ *       link: 'https://www.myblog.dev',
+ *       description: 'Musings on web development'
+ *     })
+ *   ]
+ * }
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     blog/
+ *       first-post.html
+ *       second-post.html
+ *     404.html
+ *     index.html
+ */
+import fs from "node:fs/promises";
+import { expect } from "chai";
+import { JSDOM } from "jsdom";
+import path from "node:path";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Build Greenwood With: ", function () {
+  const LABEL = "RSS Plugin with default options and Default Workspace";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+    });
+
+    runSmokeTest(["public", "index"], LABEL);
+
+    describe("Default generated RSS feed", function () {
+      let channel;
+      let items;
+
+      before(async function () {
+        const feed = await fs.readFile(path.join(this.context.publicDir, "rss.xml"), "utf-8");
+        const dom = new JSDOM(feed, { contentType: "text/xml" });
+
+        channel = dom.window.document.querySelector("rss channel");
+        items = Array.from(channel.querySelectorAll("item"));
+      });
+
+      it("should generate an rss.xml file with a channel", function () {
+        expect(channel).to.not.equal(null);
+      });
+
+      it("should have the channel title, link, and description from the plugin options", function () {
+        expect(channel.querySelector("title").textContent).to.equal("My Blog");
+        expect(channel.querySelector("link").textContent).to.equal("https://www.myblog.dev");
+        expect(channel.querySelector("description").textContent).to.equal(
+          "Musings on web development",
+        );
+      });
+
+      it("should have an item for each page except the 404 page", function () {
+        const links = items.map((item) => item.querySelector("link").textContent);
+
+        expect(items.length).to.equal(3);
+        expect(links).to.not.include("https://www.myblog.dev/404/");
+      });
+
+      it("should order items by published frontmatter, newest first", function () {
+        const titles = items.map((item) => item.querySelector("title").textContent);
+
+        expect(titles).to.deep.equal(["My Second Post", "My First Post", "Home"]);
+      });
+
+      it("should build item links and guids from the link option and the page route", function () {
+        expect(items[0].querySelector("link").textContent).to.equal(
+          "https://www.myblog.dev/blog/second-post/",
+        );
+        expect(items[0].querySelector("guid").textContent).to.equal(
+          "https://www.myblog.dev/blog/second-post/",
+        );
+      });
+
+      it("should include an escaped description from frontmatter when present", function () {
+        expect(items[1].querySelector("description").textContent).to.equal(
+          "The one where it all began & more",
+        );
+      });
+
+      it("should include a pubDate from published frontmatter when present", function () {
+        expect(items[0].querySelector("pubDate").textContent).to.equal(
+          new Date("2026-02-20").toUTCString(),
+        );
+      });
+
+      it("should not include a description or pubDate for pages without frontmatter", function () {
+        const homeItem = items[2];
+
+        expect(homeItem.querySelector("description")).to.equal(null);
+        expect(homeItem.querySelector("pubDate")).to.equal(null);
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/plugin-rss/test/cases/default/greenwood.config.js
+++ b/packages/plugin-rss/test/cases/default/greenwood.config.js
@@ -1,0 +1,11 @@
+import { greenwoodPluginRss } from "../../../src/index.js";
+
+export default {
+  plugins: [
+    greenwoodPluginRss({
+      title: "My Blog",
+      link: "https://www.myblog.dev",
+      description: "Musings on web development",
+    }),
+  ],
+};

--- a/packages/plugin-rss/test/cases/default/src/pages/404.html
+++ b/packages/plugin-rss/test/cases/default/src/pages/404.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>Not Found</h1>
+  </body>
+</html>

--- a/packages/plugin-rss/test/cases/default/src/pages/blog/first-post.html
+++ b/packages/plugin-rss/test/cases/default/src/pages/blog/first-post.html
@@ -1,0 +1,11 @@
+---
+title: My First Post
+published: 2026-01-15
+description: The one where it all began & more
+---
+
+<html>
+  <body>
+    <h1>My First Post</h1>
+  </body>
+</html>

--- a/packages/plugin-rss/test/cases/default/src/pages/blog/second-post.html
+++ b/packages/plugin-rss/test/cases/default/src/pages/blog/second-post.html
@@ -1,0 +1,11 @@
+---
+title: My Second Post
+published: 2026-02-20
+description: The difficult second post
+---
+
+<html>
+  <body>
+    <h1>My Second Post</h1>
+  </body>
+</html>

--- a/packages/plugin-rss/test/cases/default/src/pages/index.html
+++ b/packages/plugin-rss/test/cases/default/src/pages/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>Home Page</h1>
+  </body>
+</html>

--- a/packages/plugin-rss/test/cases/develop.default/develop.default.spec.js
+++ b/packages/plugin-rss/test/cases/develop.default/develop.default.spec.js
@@ -1,0 +1,103 @@
+/*
+ * Use Case
+ * Run Greenwood develop command with RSS composite plugin.
+ *
+ * User Result
+ * Should start the development server and serve the generated RSS feed at rss.xml.
+ *
+ * User Command
+ * greenwood develop
+ *
+ * User Config
+ * import { greenwoodPluginRss } from '@greenwood/plugin-rss';
+ *
+ * {
+ *   plugins: [
+ *     greenwoodPluginRss({
+ *       title: 'My Blog',
+ *       link: 'https://www.myblog.dev',
+ *       description: 'Musings on web development'
+ *     })
+ *   ]
+ * }
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     blog/
+ *       first-post.html
+ *     index.html
+ */
+import { expect } from "chai";
+import { JSDOM } from "jsdom";
+import path from "node:path";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Develop Greenwood With: ", function () {
+  const LABEL = "RSS Plugin with default options and Default Workspace";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  const hostname = "http://localhost";
+  const port = 1984;
+  let runner;
+
+  before(function () {
+    this.context = {
+      hostname: `${hostname}:${port}`,
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+
+      await new Promise((resolve, reject) => {
+        runner
+          .runCommand(cliPath, "develop", {
+            onStdOut: (message) => {
+              if (message.includes(`Started local development server at http://localhost:1984`)) {
+                resolve();
+              }
+            },
+          })
+          .catch(reject);
+      });
+    });
+
+    describe("Develop command specific rss.xml behaviors", function () {
+      let response = {};
+      let items;
+
+      before(async function () {
+        response = await fetch(`${hostname}:${port}/rss.xml`);
+
+        const feed = await response.text();
+        const dom = new JSDOM(feed, { contentType: "text/xml" });
+
+        items = Array.from(dom.window.document.querySelectorAll("rss channel item"));
+      });
+
+      it("should return a 200", function () {
+        expect(response.status).to.equal(200);
+      });
+
+      it("should return the correct content type", function () {
+        expect(response.headers.get("content-type")).to.equal("application/rss+xml");
+      });
+
+      it("should return the generated RSS feed with an item for each page", function () {
+        const titles = items.map((item) => item.querySelector("title").textContent);
+
+        expect(items.length).to.equal(2);
+        expect(titles).to.deep.equal(["My First Post", "Home"]);
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.stopCommand();
+    await runner.teardown([path.join(outputPath, ".greenwood")]);
+  });
+});

--- a/packages/plugin-rss/test/cases/develop.default/greenwood.config.js
+++ b/packages/plugin-rss/test/cases/develop.default/greenwood.config.js
@@ -1,0 +1,11 @@
+import { greenwoodPluginRss } from "../../../src/index.js";
+
+export default {
+  plugins: [
+    greenwoodPluginRss({
+      title: "My Blog",
+      link: "https://www.myblog.dev",
+      description: "Musings on web development",
+    }),
+  ],
+};

--- a/packages/plugin-rss/test/cases/develop.default/src/pages/blog/first-post.html
+++ b/packages/plugin-rss/test/cases/develop.default/src/pages/blog/first-post.html
@@ -1,0 +1,10 @@
+---
+title: My First Post
+published: 2026-01-15
+---
+
+<html>
+  <body>
+    <h1>My First Post</h1>
+  </body>
+</html>

--- a/packages/plugin-rss/test/cases/develop.default/src/pages/index.html
+++ b/packages/plugin-rss/test/cases/develop.default/src/pages/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>Home Page</h1>
+  </body>
+</html>

--- a/packages/plugin-rss/test/cases/error-missing-options/error-missing-options.spec.js
+++ b/packages/plugin-rss/test/cases/error-missing-options/error-missing-options.spec.js
@@ -1,0 +1,55 @@
+/*
+ * Use Case
+ * Run Greenwood with RSS composite plugin.
+ *
+ * User Result
+ * Should generate an error when not passing in the required channel options.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * import { greenwoodPluginRss } from '@greenwood/plugin-rss';
+ *
+ * {
+ *   plugins: [greenwoodPluginRss()]
+ * }
+ *
+ * User Workspace
+ * N / A
+ */
+import * as chai from "chai";
+import { expect } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import path from "node:path";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+chai.use(chaiAsPromised);
+
+describe("Build Greenwood With: ", function () {
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe("RSS Plugin with missing required options", function () {
+    it("should throw an error that title must be a string", async function () {
+      await runner.setup(outputPath);
+
+      await expect(runner.runCommand(cliPath, "build")).to.be.rejectedWith(
+        `Error: title should be of type string.  got "undefined" instead.`,
+      );
+    });
+  });
+
+  after(async function () {
+    await runner.teardown();
+  });
+});

--- a/packages/plugin-rss/test/cases/error-missing-options/greenwood.config.js
+++ b/packages/plugin-rss/test/cases/error-missing-options/greenwood.config.js
@@ -1,0 +1,5 @@
+import { greenwoodPluginRss } from "../../../src/index.js";
+
+export default {
+  plugins: [greenwoodPluginRss()],
+};

--- a/packages/plugin-rss/test/cases/option-collection/greenwood.config.js
+++ b/packages/plugin-rss/test/cases/option-collection/greenwood.config.js
@@ -1,0 +1,13 @@
+import { greenwoodPluginRss } from "../../../src/index.js";
+
+export default {
+  plugins: [
+    greenwoodPluginRss({
+      title: "My Blog",
+      link: "https://www.myblog.dev",
+      description: "Musings on web development",
+      collection: "blog",
+      maxItems: 1,
+    }),
+  ],
+};

--- a/packages/plugin-rss/test/cases/option-collection/option-collection.spec.js
+++ b/packages/plugin-rss/test/cases/option-collection/option-collection.spec.js
@@ -1,0 +1,87 @@
+/*
+ * Use Case
+ * Run Greenwood with RSS composite plugin using the collection and maxItems options.
+ *
+ * User Result
+ * Should generate a bare bones Greenwood build with an RSS feed of only the newest page from the blog collection.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * import { greenwoodPluginRss } from '@greenwood/plugin-rss';
+ *
+ * {
+ *   plugins: [
+ *     greenwoodPluginRss({
+ *       title: 'My Blog',
+ *       link: 'https://www.myblog.dev',
+ *       description: 'Musings on web development',
+ *       collection: 'blog',
+ *       maxItems: 1
+ *     })
+ *   ]
+ * }
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     blog/
+ *       first-post.html
+ *       second-post.html
+ *     index.html
+ */
+import fs from "node:fs/promises";
+import { expect } from "chai";
+import { JSDOM } from "jsdom";
+import path from "node:path";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Build Greenwood With: ", function () {
+  const LABEL = "RSS Plugin with collection and maxItems options and Default Workspace";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+    });
+
+    runSmokeTest(["public", "index"], LABEL);
+
+    describe("Collection scoped RSS feed", function () {
+      let items;
+
+      before(async function () {
+        const feed = await fs.readFile(path.join(this.context.publicDir, "rss.xml"), "utf-8");
+        const dom = new JSDOM(feed, { contentType: "text/xml" });
+
+        items = Array.from(dom.window.document.querySelectorAll("rss channel item"));
+      });
+
+      it("should only include the newest item from the blog collection", function () {
+        expect(items.length).to.equal(1);
+        expect(items[0].querySelector("title").textContent).to.equal("My Second Post");
+        expect(items[0].querySelector("link").textContent).to.equal(
+          "https://www.myblog.dev/blog/second-post/",
+        );
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/plugin-rss/test/cases/option-collection/src/pages/blog/first-post.html
+++ b/packages/plugin-rss/test/cases/option-collection/src/pages/blog/first-post.html
@@ -1,0 +1,11 @@
+---
+collection: blog
+title: My First Post
+published: 2026-01-15
+---
+
+<html>
+  <body>
+    <h1>My First Post</h1>
+  </body>
+</html>

--- a/packages/plugin-rss/test/cases/option-collection/src/pages/blog/second-post.html
+++ b/packages/plugin-rss/test/cases/option-collection/src/pages/blog/second-post.html
@@ -1,0 +1,11 @@
+---
+collection: blog
+title: My Second Post
+published: 2026-02-20
+---
+
+<html>
+  <body>
+    <h1>My Second Post</h1>
+  </body>
+</html>

--- a/packages/plugin-rss/test/cases/option-collection/src/pages/index.html
+++ b/packages/plugin-rss/test/cases/option-collection/src/pages/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <h1>Home Page</h1>
+  </body>
+</html>


### PR DESCRIPTION
## Related Issue

Resolves #1752

## Documentation

Package README included in this PR. If this is accepted as first-party, I will open a follow-up PR to [www.greenwoodjs.dev](https://github.com/ProjectEvergreen/www.greenwoodjs.dev) adding a plugin docs page alongside the other first-party plugins.

## Summary of Changes

1. [x] new package `@greenwood/plugin-rss` following the existing plugin package conventions (`main` / `exports` map, hand-written `index.d.ts`, version + peer dependency at `^0.34.0`)
1. [x] composite plugin returning a `copy` plugin (build: renders RSS 2.0 XML from `compilation.graph` into `scratchDir`, copies to `outputDir`) and a `resource` plugin (develop: `shouldServe` / `serve` for `${basePath}/rss.xml` with `Content-Type: application/rss+xml`), mirroring the approach discussed for dynamic sitemaps in #1232
1. [x] options: required `title` / `link` / `description` (the RSS 2.0 required channel elements, validated with a descriptive error), optional `collection` (scope items via `compilation.collections`), `filename` (default `rss.xml`), and `maxItems`
1. [x] item mapping from page frontmatter: `title` (falls back to inferred label), `link`/`guid` from the `link` option + page route, optional `description`, optional `pubDate` from `published`/`date` (RFC 822 via `toUTCString()`), items sorted newest first; the 404 page is excluded; all text is XML-escaped
1. [x] four fixture-based test cases under `packages/plugin-rss/test/cases/`: `default` (channel + item shape, ordering, escaping, 404 exclusion), `option-collection` (collection + maxItems), `error-missing-options`, and `develop.default` (dev server serving + content type) — all passing locally
1. [x] `yarn lint` (ls-lint, eslint, tsc types) and `yarn format:check` clean

No breaking changes.
