### PR TITLE
feature(plugins): #357 add html minification plugin

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,4 +7,5 @@ packages/cli/test/cases/develop.default.hud/src/pages/index.html
 packages/cli/test/cases/develop.config.polyfills-import-attributes/src/components/hero.js
 packages/cli/test/cases/develop.plugins.context/fixtures/my-layouts/app.html
 packages/cli/test/cases/**/wasm_hello_world.js
+packages/plugin-minify-html/test/cases/default/src/pages/index.html
 /.nx/workspace-data

--- a/packages/plugin-minify-html/README.md
+++ b/packages/plugin-minify-html/README.md
@@ -1,0 +1,75 @@
+# @greenwood/plugin-minify-html
+
+## Overview
+
+A Greenwood plugin for minifying your HTML output at build time.  It deliberately sticks to the two transforms that are safe by construction:
+
+- **Strips HTML comments**, preserving comments that frameworks rely on (Lit SSR hydration markers like `<!--lit-part ...-->`) and license style `<!--! ... -->` comments
+- **Collapses whitespace runs to a single space** — the same collapsing browsers already perform when rendering — leaving `<pre>`, `<textarea>`, `<script>`, `<style>`, and `<noscript>` content untouched
+
+It does not remove attribute quotes, omit optional tags, or minify inline JavaScript / CSS (Greenwood's bundler already runs [terser](https://github.com/terser/terser) over your scripts).  For more information and complete docs on Greenwood, please visit [our website](https://www.greenwoodjs.dev).
+
+> This package assumes you already have `@greenwood/cli` installed.
+
+## Installation
+
+You can use your favorite JavaScript package manager to install this package.
+
+```bash
+# npm
+$ npm i -D @greenwood/plugin-minify-html
+
+# yarn
+$ yarn add @greenwood/plugin-minify-html --dev
+
+# pnpm
+$ pnpm add -D @greenwood/plugin-minify-html
+```
+
+## Usage
+
+Add this plugin to your _greenwood.config.js_.
+
+```javascript
+import { greenwoodPluginMinifyHtml } from '@greenwood/plugin-minify-html';
+
+export default {
+  // ...
+
+  plugins: [
+    greenwoodPluginMinifyHtml()
+  ]
+}
+```
+
+All pages in your build output will then have comments stripped and whitespace collapsed.  Minification only runs as part of `greenwood build` optimizations; `greenwood develop` output is left as authored.
+
+## Types
+
+Types should automatically be inferred through this package's exports map, but can be referenced explicitly in both JavaScript (JSDoc) and TypeScript files if needed.
+
+```js
+/** @type {import('@greenwood/plugin-minify-html').MinifyHtmlPlugin} */
+```
+
+```ts
+import type { MinifyHtmlPlugin } from '@greenwood/plugin-minify-html';
+```
+
+## Options
+
+- `ignoreCustomComments` (optional) - An array of `RegExp` patterns tested against each comment's (trimmed) contents; matching comments are kept.  Default is `[/^!/, /^\/?lit-/]`.  Passing your own array replaces the default, so include those patterns if you still want them.
+
+```javascript
+import { greenwoodPluginMinifyHtml } from '@greenwood/plugin-minify-html';
+
+export default {
+  // ...
+
+  plugins: [
+    greenwoodPluginMinifyHtml({
+      ignoreCustomComments: [/^!/, /^\/?lit-/, /^KEEP/]
+    })
+  ]
+}
+```

--- a/packages/plugin-minify-html/package.json
+++ b/packages/plugin-minify-html/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@greenwood/plugin-minify-html",
+  "version": "0.34.0",
+  "description": "A Greenwood plugin for minifying HTML output by stripping comments and collapsing whitespace.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ProjectEvergreen/greenwood.git",
+    "directory": "packages/plugin-minify-html"
+  },
+  "homepage": "https://github.com/ProjectEvergreen/greenwood/tree/master/packages/plugin-minify-html",
+  "author": "Jonathan Stockdill",
+  "license": "MIT",
+  "keywords": [
+    "Greenwood",
+    "Static Site Generator",
+    "Server Side Rendering",
+    "Full Stack Web Development",
+    "Serverless",
+    "Web Components",
+    "HTML",
+    "Minification",
+    "Optimization"
+  ],
+  "type": "module",
+  "main": "./src/index.js",
+  "types": "./src/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/types/index.d.ts",
+      "import": "./src/index.js"
+    }
+  },
+  "files": [
+    "src/"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "node-html-parser": "^7.0.1"
+  },
+  "peerDependencies": {
+    "@greenwood/cli": "^0.34.0"
+  },
+  "devDependencies": {
+    "@greenwood/cli": "^0.34.0"
+  }
+}

--- a/packages/plugin-minify-html/src/index.js
+++ b/packages/plugin-minify-html/src/index.js
@@ -1,0 +1,74 @@
+import { parse, NodeType } from "node-html-parser";
+
+// whitespace inside these elements is significant, or is already handled by the bundler
+const PRESERVED_TAGS = ["pre", "textarea", "script", "style", "noscript"];
+
+// Lit SSR hydration markers (<!--lit-part ...--> / <!--/lit-part-->) and license style
+// comments (<!--! ... -->) must survive minification
+// https://github.com/ProjectEvergreen/greenwood/issues/357
+const DEFAULT_IGNORED_COMMENTS = [/^!/, /^\/?lit-/];
+
+function minifyNode(node, ignoredComments) {
+  for (const childNode of [...node.childNodes]) {
+    if (childNode.nodeType === NodeType.COMMENT_NODE) {
+      const contents = childNode.rawText.trim();
+
+      if (!ignoredComments.some((pattern) => pattern.test(contents))) {
+        node.removeChild(childNode);
+      }
+    } else if (childNode.nodeType === NodeType.TEXT_NODE) {
+      childNode.rawText = childNode.rawText.replace(/[ \t\r\n\f]+/g, " ");
+    } else if (
+      childNode.nodeType === NodeType.ELEMENT_NODE &&
+      !PRESERVED_TAGS.includes(childNode.rawTagName?.toLowerCase())
+    ) {
+      minifyNode(childNode, ignoredComments);
+    }
+  }
+}
+
+class MinifyHtmlResource {
+  constructor(compilation, options = {}) {
+    this.compilation = compilation;
+    this.options = options;
+    this.contentType = "text/html";
+  }
+
+  async shouldOptimize(url, response) {
+    return response.headers.get("Content-Type")?.indexOf(this.contentType) >= 0;
+  }
+
+  async optimize(url, response) {
+    const ignoredComments = this.options.ignoreCustomComments ?? DEFAULT_IGNORED_COMMENTS;
+    const body = await response.text();
+    const root = parse(body, {
+      comment: true,
+      blockTextElements: {
+        script: true,
+        style: true,
+        noscript: true,
+        pre: true,
+        textarea: true,
+      },
+    });
+
+    minifyNode(root, ignoredComments);
+
+    return new Response(root.toString(), {
+      headers: response.headers,
+    });
+  }
+}
+
+/** @type {import('./types/index.d.ts').MinifyHtmlPlugin} */
+const greenwoodPluginMinifyHtml = (options = {}) => {
+  return [
+    {
+      type: "resource",
+      name: "plugin-minify-html",
+      provider: (compilation) => new MinifyHtmlResource(compilation, options),
+    },
+  ];
+};
+
+export { greenwoodPluginMinifyHtml };

--- a/packages/plugin-minify-html/src/types/index.d.ts
+++ b/packages/plugin-minify-html/src/types/index.d.ts
@@ -1,0 +1,11 @@
+import type { ResourcePlugin } from "@greenwood/cli";
+
+export type MinifyHtmlPluginOptions = {
+  ignoreCustomComments?: RegExp[];
+};
+
+export type MinifyHtmlPlugin = (options?: MinifyHtmlPluginOptions) => [ResourcePlugin];
+
+declare module "@greenwood/plugin-minify-html" {
+  export const greenwoodPluginMinifyHtml: MinifyHtmlPlugin;
+}

--- a/packages/plugin-minify-html/test/cases/default/default.spec.js
+++ b/packages/plugin-minify-html/test/cases/default/default.spec.js
@@ -1,0 +1,87 @@
+/*
+ * Use Case
+ * Run Greenwood with Minify HTML composite plugin with default options.
+ *
+ * User Result
+ * Should generate a bare bones Greenwood build with minified HTML output.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * import { greenwoodPluginMinifyHtml } from '@greenwood/plugin-minify-html';
+ *
+ * {
+ *   plugins: [greenwoodPluginMinifyHtml()]
+ * }
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     index.html
+ */
+import fs from "node:fs/promises";
+import { expect } from "chai";
+import path from "node:path";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Build Greenwood With: ", function () {
+  const LABEL = "Minify HTML Plugin with default options and Default Workspace";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    let html;
+
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+
+      html = await fs.readFile(path.join(this.context.publicDir, "index.html"), "utf-8");
+    });
+
+    runSmokeTest(["public", "index"], LABEL);
+
+    describe("Minified HTML output", function () {
+      it("should strip authoring comments", function () {
+        expect(html).to.not.include("authoring comment that should be removed");
+      });
+
+      it("should keep license style comments", function () {
+        expect(html).to.include("<!--! legalese that should be kept -->");
+      });
+
+      it("should keep Lit SSR hydration marker comments", function () {
+        expect(html).to.include("<!--lit-part abc123=-->");
+        expect(html).to.include("<!--/lit-part-->");
+      });
+
+      it("should collapse indentation whitespace between tags", function () {
+        expect(html).to.not.match(/\n\s+</);
+      });
+
+      it("should keep a single space between adjacent inline elements", function () {
+        expect(html).to.include("<span>inline</span> <span>gap</span>");
+      });
+
+      it("should leave <pre> content untouched", function () {
+        expect(html).to.include("<pre>keep\n  these lines</pre>");
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/plugin-minify-html/test/cases/default/greenwood.config.js
+++ b/packages/plugin-minify-html/test/cases/default/greenwood.config.js
@@ -1,0 +1,5 @@
+import { greenwoodPluginMinifyHtml } from "../../../src/index.js";
+
+export default {
+  plugins: [greenwoodPluginMinifyHtml()],
+};

--- a/packages/plugin-minify-html/test/cases/default/src/pages/index.html
+++ b/packages/plugin-minify-html/test/cases/default/src/pages/index.html
@@ -1,0 +1,16 @@
+<html>
+  <head>
+    <title>Home</title>
+  </head>
+  <body>
+    <!-- authoring comment that should be removed -->
+    <!--! legalese that should be kept -->
+    <h1>Home Page</h1>
+    <!--lit-part abc123=-->
+    <p>hydratable content</p>
+    <!--/lit-part-->
+    <span>inline</span> <span>gap</span>
+    <pre>keep
+  these lines</pre>
+  </body>
+</html>

--- a/packages/plugin-minify-html/test/cases/option-ignore-custom-comments/greenwood.config.js
+++ b/packages/plugin-minify-html/test/cases/option-ignore-custom-comments/greenwood.config.js
@@ -1,0 +1,9 @@
+import { greenwoodPluginMinifyHtml } from "../../../src/index.js";
+
+export default {
+  plugins: [
+    greenwoodPluginMinifyHtml({
+      ignoreCustomComments: [/^KEEP/],
+    }),
+  ],
+};

--- a/packages/plugin-minify-html/test/cases/option-ignore-custom-comments/option-ignore-custom-comments.spec.js
+++ b/packages/plugin-minify-html/test/cases/option-ignore-custom-comments/option-ignore-custom-comments.spec.js
@@ -1,0 +1,79 @@
+/*
+ * Use Case
+ * Run Greenwood with Minify HTML composite plugin using the ignoreCustomComments option.
+ *
+ * User Result
+ * Should generate a bare bones Greenwood build with minified HTML output where only comments
+ * matching the user provided patterns are kept.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * import { greenwoodPluginMinifyHtml } from '@greenwood/plugin-minify-html';
+ *
+ * {
+ *   plugins: [
+ *     greenwoodPluginMinifyHtml({
+ *       ignoreCustomComments: [/^KEEP/]
+ *     })
+ *   ]
+ * }
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     index.html
+ */
+import fs from "node:fs/promises";
+import { expect } from "chai";
+import path from "node:path";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Build Greenwood With: ", function () {
+  const LABEL = "Minify HTML Plugin with ignoreCustomComments option and Default Workspace";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    let html;
+
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build");
+
+      html = await fs.readFile(path.join(this.context.publicDir, "index.html"), "utf-8");
+    });
+
+    runSmokeTest(["public", "index"], LABEL);
+
+    describe("Minified HTML output with custom comment patterns", function () {
+      it("should keep comments matching the user provided patterns", function () {
+        expect(html).to.include("<!-- KEEP: banner -->");
+      });
+
+      it("should strip comments not matching the user provided patterns", function () {
+        expect(html).to.not.include("a normal comment");
+      });
+
+      it("should strip the default preserved patterns when the user replaces them", function () {
+        expect(html).to.not.include("lit-part");
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/plugin-minify-html/test/cases/option-ignore-custom-comments/src/pages/index.html
+++ b/packages/plugin-minify-html/test/cases/option-ignore-custom-comments/src/pages/index.html
@@ -1,0 +1,13 @@
+<html>
+  <head>
+    <title>Home</title>
+  </head>
+  <body>
+    <h1>Home Page</h1>
+    <!-- KEEP: banner -->
+    <!-- a normal comment -->
+    <!--lit-part abc123=-->
+    <p>content</p>
+    <!--/lit-part-->
+  </body>
+</html>


### PR DESCRIPTION
## Related Issue

Resolves #357

Design proposal with rationale posted on the issue: https://github.com/ProjectEvergreen/greenwood/issues/357#issuecomment-5178298232

## Documentation

Package README included in this PR. If accepted as first-party, I will open a follow-up PR to [www.greenwoodjs.dev](https://github.com/ProjectEvergreen/www.greenwoodjs.dev) adding a plugin docs page.

## Summary of Changes

1. [x] new package `@greenwood/plugin-minify-html` — an opt-in resource plugin using the existing `shouldOptimize` / `optimize` lifecycle, so it only affects `greenwood build` output
1. [x] deliberately conservative transform (~50 lines): strips HTML comments and collapses whitespace runs to a single space (the same collapsing browsers perform at render time); never removes whitespace outright, so inline-element gaps and rendering semantics are untouched
1. [x] preserves comments matching `ignoreCustomComments` patterns, defaulting to `[/^!/, /^\/?lit-/]` so Lit SSR hydration markers (`<!--lit-part ...-->` / `<!--/lit-part-->`) and license style comments survive; option is user-overridable
1. [x] `<pre>`, `<textarea>`, `<script>`, `<style>`, and `<noscript>` subtrees are left byte-identical (no inline JS/CSS minification — the bundler already runs terser over scripts)
1. [x] zero new dependencies in the tree — implemented with `node-html-parser`, already a `@greenwood/cli` dependency (declared at the same `^7.0.1`)
1. [x] two fixture-based test cases (`default`, `option-ignore-custom-comments`) covering comment stripping, marker preservation, whitespace collapsing, inline gaps, and `<pre>` fidelity — all passing locally alongside the common smoke tests
1. [x] the default case fixture is added to `.prettierignore` (intentional `<pre>` formatting, following the existing fixture precedent)
1. [x] `yarn lint` (ls-lint, eslint, tsc types) and `yarn format:check` clean

One observation from fixture testing, not addressed here: comments authored inside a page's `<head>` are already dropped by core's layout merging before any resource plugin runs, so this plugin only governs body comments in practice.

No breaking changes.
