### PR TITLE
fix(cli): #1758 walk array pattern exports without crashing and isolate import map failures per dependency

### DIFF
--- a/packages/cli/src/lib/walker-package-ranger.js
+++ b/packages/cli/src/lib/walker-package-ranger.js
@@ -186,8 +186,14 @@ async function walkPackageForExports(dependency, packageJson, resolvedRoot) {
               if (item[condition]) {
                 matched = true;
                 if (sub.indexOf("*") >= 0) {
-                  // basic support, not properly tested
-                  await walkExportPatterns(dependency, sub, exports[sub][condition], resolvedRoot);
+                  // walk the pattern target from the matched array item; indexing the array
+                  // itself by condition name would pass undefined as the resolved root
+                  // https://github.com/ProjectEvergreen/greenwood/issues/1758
+                  await walkExportPatterns(
+                    dependency,
+                    item[condition].default ?? item[condition],
+                    resolvedRoot,
+                  );
                 } else {
                   // could there be more sub conditions here?  Going with default for now
                   updateImportMap(
@@ -276,10 +282,14 @@ async function walkPackageForExports(dependency, packageJson, resolvedRoot) {
 
 // we recursively cache / memoize walkedPackages to account for scenarios where Greenwood can (pre)render concurrently
 async function walkPackageJson(packageJson = {}, walkedPackages = new Set()) {
-  try {
-    const dependencies = Object.keys(packageJson.dependencies || {});
+  const dependencies = Object.keys(packageJson.dependencies || {});
 
-    for (const dependency of dependencies) {
+  for (const dependency of dependencies) {
+    // isolate failures per dependency, so one package with an unexpected exports shape
+    // degrades to an error for that package instead of silently dropping every remaining
+    // dependency from the import map
+    // https://github.com/ProjectEvergreen/greenwood/issues/1758
+    try {
       const resolved = resolveBareSpecifier(dependency);
 
       if (resolved) {
@@ -311,9 +321,9 @@ async function walkPackageJson(packageJson = {}, walkedPackages = new Set()) {
           }
         }
       }
+    } catch (e) {
+      console.error(`Error building up import map for dependency => \`${dependency}\``, e);
     }
-  } catch (e) {
-    console.error("Error building up import map", e);
   }
 
   return { importMap, diagnostics };

--- a/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/develop.default.import-map-array-pattern-exports.spec.js
+++ b/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/develop.default.import-map-array-pattern-exports.spec.js
@@ -1,0 +1,121 @@
+/*
+ * Use Case
+ * Run Greenwood develop command with a dependency whose package.json exports a subpath
+ * pattern with an array ("fallback") target, e.g. "./*": [{ "import": "./src/*.js" }],
+ * followed by another perfectly valid dependency.
+ *
+ * User Result
+ * Should generate an import map covering both dependencies, instead of crashing the
+ * walk on the array target and silently dropping every dependency after it.
+ *
+ * User Command
+ * greenwood develop
+ *
+ * User Config
+ * None (Greenwood Default)
+ *
+ * User Workspace
+ *  src/
+ *   pages/
+ *     index.html
+ * package.json (fake-array-pattern-exports, fake-subsequent-dependency)
+ *
+ * The two fake packages live in ./fixtures and are staged into the monorepo's own
+ * node_modules for the duration of the suite, since the import map walker resolves
+ * dependencies with import.meta.resolve from the CLI's location, not the project's.
+ */
+import { expect } from "chai";
+import fs from "node:fs";
+import { JSDOM } from "jsdom";
+import path from "node:path";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+const fakePackages = ["fake-array-pattern-exports", "fake-subsequent-dependency"];
+
+// https://github.com/ProjectEvergreen/greenwood/issues/1758
+describe("Develop Greenwood With: ", function () {
+  const LABEL = "Default Greenwood Configuration and a dependency with array pattern exports";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  const hostname = "http://localhost";
+  const port = 1984;
+  let runner;
+
+  before(function () {
+    this.context = {
+      hostname: `${hostname}:${port}`,
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      for (const fakePackage of fakePackages) {
+        fs.cpSync(
+          path.join(outputPath, "fixtures", fakePackage),
+          path.join(process.cwd(), "node_modules", fakePackage),
+          { recursive: true },
+        );
+      }
+
+      await runner.setup(outputPath);
+
+      await new Promise((resolve, reject) => {
+        runner
+          .runCommand(cliPath, "develop", {
+            onStdOut: (message) => {
+              if (message.includes(`Started local development server at http://localhost:1984`)) {
+                resolve();
+              }
+            },
+          })
+          .catch(reject);
+      });
+    });
+
+    describe("Import map generation with an array pattern exports dependency", function () {
+      let importMap;
+
+      before(async function () {
+        const response = await fetch(`${hostname}:${port}/`, {
+          headers: {
+            accept: "text/html",
+          },
+        });
+        const dom = new JSDOM(await response.text());
+        const importMapTag = dom.window.document.querySelector('head > script[type="importmap"]');
+
+        importMap = JSON.parse(importMapTag.textContent).imports;
+      });
+
+      it("should have an import map entry for the array pattern exports package itself", function () {
+        expect(importMap["fake-array-pattern-exports"]).to.not.equal(undefined);
+      });
+
+      it("should have an import map entry for the subpath resolved from the array pattern target", function () {
+        const subpathKeys = Object.keys(importMap).filter((key) =>
+          key.startsWith("fake-array-pattern-exports/"),
+        );
+
+        expect(subpathKeys.length).to.be.greaterThan(0);
+      });
+
+      it("should still have an import map entry for the dependency listed after the array pattern exports package", function () {
+        expect(importMap["fake-subsequent-dependency"]).to.not.equal(undefined);
+      });
+    });
+  });
+
+  after(async function () {
+    for (const fakePackage of fakePackages) {
+      fs.rmSync(path.join(process.cwd(), "node_modules", fakePackage), {
+        recursive: true,
+        force: true,
+      });
+    }
+
+    await runner.teardown([path.join(outputPath, ".greenwood")]);
+    await runner.stopCommand();
+  });
+});

--- a/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/fixtures/fake-array-pattern-exports/index.js
+++ b/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/fixtures/fake-array-pattern-exports/index.js
@@ -1,0 +1,1 @@
+export default "fake-array-pattern-exports";

--- a/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/fixtures/fake-array-pattern-exports/package.json
+++ b/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/fixtures/fake-array-pattern-exports/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fake-array-pattern-exports",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./index.js",
+    "./*": [
+      {
+        "import": "./src/*.js"
+      }
+    ]
+  }
+}

--- a/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/fixtures/fake-array-pattern-exports/src/feature.js
+++ b/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/fixtures/fake-array-pattern-exports/src/feature.js
@@ -1,0 +1,1 @@
+export default "feature";

--- a/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/fixtures/fake-subsequent-dependency/index.js
+++ b/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/fixtures/fake-subsequent-dependency/index.js
@@ -1,0 +1,1 @@
+export default "fake-subsequent-dependency";

--- a/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/fixtures/fake-subsequent-dependency/package.json
+++ b/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/fixtures/fake-subsequent-dependency/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fake-subsequent-dependency",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  }
+}

--- a/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/package.json
+++ b/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-develop-command-import-map-array-pattern-exports",
+  "type": "module",
+  "dependencies": {
+    "fake-array-pattern-exports": "*",
+    "fake-subsequent-dependency": "*"
+  }
+}

--- a/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/src/pages/index.html
+++ b/packages/cli/test/cases/develop.default.import-map-array-pattern-exports/src/pages/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Import Map Array Pattern Exports</title>
+    <script type="module">
+      import subsequent from "fake-subsequent-dependency";
+
+      console.log({ subsequent });
+    </script>
+  </head>
+
+  <body>
+    <h1>Import Map Array Pattern Exports</h1>
+  </body>
+</html>


### PR DESCRIPTION
## Related Issue

Resolves #1758

## Documentation

N/A — no user-facing documentation changes.

## Summary of Changes

1. [x] `walkPackageForExports` (`packages/cli/src/lib/walker-package-ranger.js`): for a subpath **pattern** export with an **array** target (`"./*": [{ "import": "./src/*.js" }]`), walk the pattern from the matched array item (`item[condition]`) instead of calling `walkExportPatterns` with a 4th argument and `exports[sub][condition]` — which indexes the array by a condition name, yields `undefined`, and throws `TypeError: Invalid URL` at `new URL(undefined)`.
2. [x] `walkPackageJson`: move the `try/catch` inside the per-dependency loop, so a package with an unexpected exports shape degrades to a `console.error` naming that package instead of silently dropping **every remaining dependency** from the import map. (The error message now includes the dependency name for traceability.)
3. [x] Regression test `develop.default.import-map-array-pattern-exports`: two fake packages (the array-pattern shape above plus a plain dependency listed after it), asserting the crasher's `.` entry, its pattern subpath entry, and — the headline — that the subsequent dependency still gets its entry. On unpatched `master` the last two fail (subpath missing; subsequent dependency dropped from the map):

```
  1 passing (548ms)
  2 failing
  1) ... should have an import map entry for the subpath resolved from the array pattern target:
     AssertionError: expected +0 to be above +0
  2) ... should still have an import map entry for the dependency listed after the array pattern exports package:
     AssertionError: expected undefined to not equal undefined
```

With the fix, all 3 pass; `develop.default` (import-map snapshot) and `develop.config.polyfills-import-maps` still pass (120 specs), and lint / format / ls-lint are clean.

### Test setup note

The import map walker resolves dependencies with `import.meta.resolve` from the CLI's own module location, not from the test project directory — so the spec stages its two fake packages into the monorepo's `node_modules/` in `before()` and removes them in `after()`. Flagging it since it's a new pattern for a test case; happy to restructure if there's a preferred way to get fixture packages onto the resolver's walk-up path.

### Scope / follow-up

This is deliberately just the crash + truncation fix. The walker has separate keying issues found in the same audit (pattern subpaths keyed by the RHS target path instead of the LHS subpath; array "." exports keyed by target paths; legacy flat-`main` globbing the whole package tree) — issues to follow so each can be reviewed on its own.
