### PR TITLE
enhancement(cli): #1769 warn on unsupported top level greenwood config options

### DIFF
--- a/packages/cli/src/lifecycles/config.js
+++ b/packages/cli/src/lifecycles/config.js
@@ -78,6 +78,8 @@ const defaultConfig = {
   useTsc: false,
   workspace: new URL("./src/", cwd),
 };
+// staticRouter has no default value of its own, so it is not part of defaultConfig
+const supportedConfigOptions = [...Object.keys(defaultConfig), "staticRouter"];
 
 const readAndMergeConfig = async () => {
   // check for greenwood.config.ts or greenwood.config.js
@@ -119,6 +121,14 @@ const readAndMergeConfig = async () => {
       polyfills,
       useTsc,
     } = userCfgFile;
+
+    for (const key of Object.keys(userCfgFile)) {
+      if (!supportedConfigOptions.includes(key)) {
+        console.warn(
+          `Configuration warning: "${key}" is not a supported configuration option and will be ignored.`,
+        );
+      }
+    }
 
     // workspace validation
     if (workspace) {

--- a/packages/cli/test/cases/build.config.unknown-keys/build.config.unknown-keys.spec.js
+++ b/packages/cli/test/cases/build.config.unknown-keys/build.config.unknown-keys.spec.js
@@ -1,0 +1,80 @@
+/*
+ * Use Case
+ * Run Greenwood build command with unsupported top level options in a custom config.
+ *
+ * User Result
+ * Should complete the build and warn about each unsupported option.
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * {
+ *   basepath: "/my-app",
+ *   notARealOption: 42,
+ *   staticRouter: false
+ * }
+ *
+ * User Workspace
+ * src/
+ *   pages/
+ *     index.html
+ */
+import { expect } from "chai";
+import path from "node:path";
+import { getOutputTeardownFiles } from "../../../../../test/utils.js";
+import { Runner } from "gallinago";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { fileURLToPath } from "node:url";
+
+describe("Build Greenwood With: ", function () {
+  const LABEL = "Custom Configuration with unsupported options";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+  let stderr = "";
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner();
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+
+      const build = runner.runCommand(cliPath, "build");
+
+      // the runner only surfaces stderr for a non zero exit code, and this build is expected to pass
+      runner.childProcess.stderr.on("data", function (data) {
+        stderr += data.toString();
+      });
+
+      await build;
+    });
+
+    runSmokeTest(["public", "index"], LABEL);
+
+    it("should warn about a misspelling of a supported option", function () {
+      expect(stderr).to.contain(
+        'Configuration warning: "basepath" is not a supported configuration option and will be ignored.',
+      );
+    });
+
+    it("should warn about an option Greenwood does not know about at all", function () {
+      expect(stderr).to.contain(
+        'Configuration warning: "notARealOption" is not a supported configuration option and will be ignored.',
+      );
+    });
+
+    it("should not warn about a supported option that has no default value", function () {
+      expect(stderr).to.not.contain('Configuration warning: "staticRouter"');
+    });
+  });
+
+  after(async function () {
+    await runner.teardown(getOutputTeardownFiles(outputPath));
+  });
+});

--- a/packages/cli/test/cases/build.config.unknown-keys/greenwood.config.js
+++ b/packages/cli/test/cases/build.config.unknown-keys/greenwood.config.js
@@ -1,0 +1,5 @@
+export default {
+  basepath: "/my-app",
+  notARealOption: 42,
+  staticRouter: false,
+};

--- a/packages/cli/test/cases/build.config.unknown-keys/src/pages/index.html
+++ b/packages/cli/test/cases/build.config.unknown-keys/src/pages/index.html
@@ -1,0 +1,4 @@
+<body>
+  <h1>Home Page</h1>
+  <p>A page built from a configuration containing unsupported options.</p>
+</body>


### PR DESCRIPTION
## Related Issue

Resolves #1769

## Documentation

No documentation changes. The set of supported options is already documented at [Configuration](https://greenwoodjs.dev/docs/reference/configuration/) and is unchanged by this PR.

## Summary of Changes

An unsupported top level key in `greenwood.config.js` is currently dropped without any diagnostic. The user config is destructured into a fixed list of names in `readAndMergeConfig`, and the merged config is built only from those bindings, so anything else is silently discarded. A near miss typo of a real option (`basepath` for `basePath`) is indistinguishable from an option simply not working.

This adds a check right after that destructure which warns once per unrecognized top level key:

```
Configuration warning: "basepath" is not a supported configuration option and will be ignored.
```

**It warns, it does not throw.** Rejecting an unknown key would be a breaking change: any project that currently carries a stray or forward compatible key builds fine today and would start failing. That call belongs to you, not to this fix, so this only makes the discard visible. It follows the existing non-fatal precedent in this same file, the "more than one custom renderer plugin detected" warning.

Scope is deliberately **top level only**. Unknown keys nested inside `devServer` and `polyfills` are dropped the same way, but those sub-objects are looser (`devServer.proxy` is already an unvalidated pass through bag), so warning there has a higher chance of false positives. Happy to extend to the nested scopes in a follow up if you want it.

The list of supported options is derived from `defaultConfig` rather than being a second hand maintained list, so it stays in sync automatically. `staticRouter` is appended because it is the one supported option with no default value.

### Testing

New test case `packages/cli/test/cases/build.config.unknown-keys`. It builds with a config containing a misspelled real option (`basepath`), a wholly unknown option (`notARealOption`), and a supported option (`staticRouter`), then asserts warnings for the first two and no warning for the third, while the build still succeeds. On master the two warning assertions fail; with this change all pass.

I did not fold this into an existing config case because none of them exercise a successful build with unsupported keys, and the point of the test is that the build still exits cleanly. Folding it into one of the `build.config.error-*` cases would not have covered the "warn, do not throw" behavior.

### Overlap with #1746

#1746 (approved, unmerged) also touches `packages/cli/src/lifecycles/config.js`, swapping `forEach` for `for...of` in the plugins loop at lines 156-181. This change sits at lines 78-80 and 122-130, so the hunks do not collide and the two should merge in either order.
