### PR TITLE
fix(cli): #1766 return a 404 when a develop page file is deleted while the server runs

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -56,8 +56,8 @@ class StandardHtmlResource {
       try {
         body = await fs.readFile(new URL(pageHref), "utf-8");
       } catch (e) {
-        // the graph is only generated once, so a matching route's page may have been deleted since then
-        if (e.code === "ENOENT") {
+        // in development the graph is only generated once, so a matching page may since be deleted
+        if (e.code === "ENOENT" && process.env.__GWD_COMMAND__ === "develop") {
           return new Response(null, { status: 404 });
         }
 

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -53,7 +53,16 @@ class StandardHtmlResource {
     let html = "";
 
     if (isHtmlContent) {
-      body = await fs.readFile(new URL(pageHref), "utf-8");
+      try {
+        body = await fs.readFile(new URL(pageHref), "utf-8");
+      } catch (e) {
+        // the graph is only generated once, so a matching route's page may have been deleted since then
+        if (e.code === "ENOENT") {
+          return new Response(null, { status: 404 });
+        }
+
+        throw e;
+      }
 
       // purge frontmatter data from HTML files that only have a `<body>` tag
       // frontmatter outside of an <html> tag will get ignored by node-html-parser

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -16,6 +16,8 @@
  * }
  *
  * User Workspace
+ * fixtures/
+ *   deleted.html (copied in as src/pages/deleted.html, then deleted mid test run)
  * src/
  *   assets/
  *     data.json
@@ -66,6 +68,7 @@ describe("Develop Greenwood With: ", function () {
   const outputPath = fileURLToPath(new URL(".", import.meta.url));
   const hostname = "http://localhost";
   const port = 1984;
+  const deletedPagePath = path.join(outputPath, "src/pages/deleted.html");
   let runner;
 
   before(function () {
@@ -77,7 +80,12 @@ describe("Develop Greenwood With: ", function () {
 
   describe(LABEL, function () {
     before(async function () {
-      await runner.setup(outputPath);
+      await runner.setup(outputPath, [
+        {
+          source: path.join(outputPath, "fixtures/deleted.html"),
+          destination: deletedPagePath,
+        },
+      ]);
 
       await new Promise((resolve, reject) => {
         runner
@@ -685,6 +693,38 @@ describe("Develop Greenwood With: ", function () {
 
       it("should return the correct status message body", function (done) {
         expect(response.statusText).to.contain("Not Found");
+        done();
+      });
+    });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/1766
+    describe("Develop command with a page deleted while the development server is running", function () {
+      let responseBeforeDelete = {};
+      let response = {};
+      let body;
+
+      before(async function () {
+        responseBeforeDelete = await fetch(`${hostname}:${port}/deleted/`);
+        await responseBeforeDelete.clone().text();
+
+        fs.rmSync(deletedPagePath);
+
+        response = await fetch(`${hostname}:${port}/deleted/`);
+        body = await response.clone().text();
+      });
+
+      it("should have returned a 200 status while the page still existed", function (done) {
+        expect(responseBeforeDelete.status).to.equal(200);
+        done();
+      });
+
+      it("should return a 404 status once the page has been deleted", function (done) {
+        expect(response.status).to.equal(404);
+        done();
+      });
+
+      it("should return an empty response body", function (done) {
+        expect(body).to.equal("");
         done();
       });
     });

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -957,6 +957,9 @@ describe("Develop Greenwood With: ", function () {
   });
 
   after(async function () {
+    // remove the copied in page first, since an aborted run can hang in stopCommand before teardown
+    fs.rmSync(deletedPagePath, { force: true });
+
     await runner.stopCommand();
     await runner.teardown([
       path.join(outputPath, ".greenwood"),

--- a/packages/cli/test/cases/develop.default/develop.default.spec.js
+++ b/packages/cli/test/cases/develop.default/develop.default.spec.js
@@ -727,6 +727,16 @@ describe("Develop Greenwood With: ", function () {
         expect(body).to.equal("");
         done();
       });
+
+      it("should return the correct content type", function (done) {
+        expect(response.headers.get("content-type")).to.equal("text/plain; charset=utf-8");
+        done();
+      });
+
+      it("should return the correct status message", function (done) {
+        expect(response.statusText).to.contain("Not Found");
+        done();
+      });
     });
 
     // proxies to https://jsonplaceholder.typicode.com/posts via greenwood.config.js

--- a/packages/cli/test/cases/develop.default/fixtures/deleted.html
+++ b/packages/cli/test/cases/develop.default/fixtures/deleted.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Deleted Page</title>
+  </head>
+
+  <body>
+    <h1>This page gets deleted while the development server is running.</h1>
+  </body>
+</html>


### PR DESCRIPTION
## Related Issue

Resolves #1766

## Documentation

No documentation changes. This corrects an HTTP status code in `greenwood develop`; the documented behaviour is unchanged.

## Summary of Changes

Deleting a page file while the dev server is running returned a **500 with an empty body**, plus a raw `ENOENT` stack in the terminal, where a **404** is correct.

The page graph is generated once at startup, so a deleted page's node is still present. `shouldServe` in the standard HTML resource plugin still matches the route, `serve` then reaches an unguarded `fs.readFile`, and the resulting `ENOENT` is swallowed by the catch-all in `lifecycles/serve.js`, which sets a 500. Restarting `develop` makes the same route correctly 404.

The fix guards that one read: in `develop`, an `ENOENT` returns a `404` response; any other error still throws so real failures are not masked.

The `develop` gate is load-bearing rather than cosmetic. `lifecycles/prerender.js` calls `plugin.serve()` on every resource plugin and does not check `response.ok`, so an ungated 404 here is swallowed during `greenwood build`: a page deleted between graph generation and prerender produced exit `0`, a `generated page...` log line, and an **empty** `public/<route>/index.html`. Greenwood's convention for a missing page file at build time is a hard failure (`lifecycles/graph.js:179`), and the stale-graph condition that justifies a 404 only exists in `develop`, so the guard is scoped to match.

### Scope

Deliberately narrow. This does **not** refresh the graph or add a file watcher — hot reloading of the graph (which is also what makes a *newly added* page 404 until restart) is tracked in #1278 and is a feature. This is just the incorrect status code and unhandled read error on delete, which is wrong regardless of whether the graph ever refreshes.

It also does **not** change `greenwood build` or `greenwood serve`. `build` still fails loudly on a missing page file, verified by test; `serve` never reaches this plugin at all, since `lifecycles/config.js:36-38` excludes `plugin-standard-html` from `isStandardStaticResource`.

### Testing

Folded into the existing `develop.default` case rather than a new directory. A `fixtures/deleted.html` is copied to `src/pages/deleted.html` via gallinago's `setupFiles` before the server starts (so it is in the graph), the test asserts it serves `200`, deletes it while the server is still running, and asserts the same route now returns `404`. Teardown removes the copy if a failure leaves it behind.

There is no timing element — `fs.rmSync` completes before the second `fetch` — so the result is deterministic. Each of the counts below is from 5 consecutive runs of `packages/cli/test/cases/develop.default`:

| | result |
| --- | --- |
| before this change (test only) | 117 passing, 1 failing — 5/5 runs, always `AssertionError: expected 500 to equal 404` |
| with the fix | 118 passing, 0 failing — 5/5 runs |

Baseline before any change was 115 passing; the new describe adds 3 tests.

Wider runs, all green with the fix:

- all `develop.*` cases: 313 passing
- `build.default`, `build.default.pages*`, `serve.default`: 48 passing

`prettier --check` and `eslint` are clean on the changed files, as is `ls-lint`.

### Note for the maintainer

The fix for #1770 lands in this same file, `packages/cli/src/plugins/resource/plugin-standard-html.js`, but at the `getMatchingDynamicSsrRoute(...) || {}` expression around line 42 — well clear of this hunk around line 56, so the two should merge without conflict.

