### PR TITLE
fix(cli): #1770 pass the page node to getBody for develop SSR pages without a segment

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -40,7 +40,8 @@ class StandardHtmlResource {
     const { pathname } = url;
     const isSpaRoute = this.compilation.graph.find((node) => node.isSPA);
     const matchingRoute = this.compilation.graph.find((node) => node.route === pathname) || {};
-    const matchingRouteWithSegment = getMatchingDynamicSsrRoute(this.compilation, pathname) || {};
+    // must stay undefined (not {}) so the ?? below can fall back to the page node
+    const matchingRouteWithSegment = getMatchingDynamicSsrRoute(this.compilation, pathname);
     const { pageHref } = matchingRoute;
     const filePath =
       !matchingRoute.external && pageHref
@@ -78,8 +79,8 @@ class StandardHtmlResource {
           break;
         }
       }
-    } else if (matchingRoute.isSSR || matchingRouteWithSegment.isSSR) {
-      const routeModuleLocationUrl = new URL(pageHref ?? matchingRouteWithSegment.pageHref);
+    } else if (matchingRoute.isSSR || matchingRouteWithSegment?.isSSR) {
+      const routeModuleLocationUrl = new URL(pageHref ?? matchingRouteWithSegment?.pageHref);
       const routeWorkerUrl = this.compilation.config.plugins
         .find((plugin) => plugin.type === "renderer")
         .provider().executeModuleUrl;

--- a/packages/cli/src/plugins/resource/plugin-standard-html.js
+++ b/packages/cli/src/plugins/resource/plugin-standard-html.js
@@ -40,7 +40,6 @@ class StandardHtmlResource {
     const { pathname } = url;
     const isSpaRoute = this.compilation.graph.find((node) => node.isSPA);
     const matchingRoute = this.compilation.graph.find((node) => node.route === pathname) || {};
-    // must stay undefined (not {}) so the ?? below can fall back to the page node
     const matchingRouteWithSegment = getMatchingDynamicSsrRoute(this.compilation, pathname);
     const { pageHref } = matchingRoute;
     const filePath =

--- a/packages/cli/test/cases/develop.ssr/develop.ssr.spec.js
+++ b/packages/cli/test/cases/develop.ssr/develop.ssr.spec.js
@@ -20,6 +20,7 @@
  *       first-post.js
  *       index.js
  *     artists.js
+ *     page-object.js
  *     post.js
  *   layouts/
  *     app.html
@@ -158,6 +159,35 @@ describe("Develop Greenwood With: ", function () {
 
         expect(artistsPageGraphData.imports[0]).to.equal(`/components/${componentName}.js`);
         expect(counterScript.length).to.equal(1);
+      });
+    });
+
+    // https://github.com/ProjectEvergreen/greenwood/issues/1770
+    describe("Develop command with HTML route response using getBody for a page with no dynamic segment", function () {
+      let dom;
+      let pageObjectPageGraphData;
+
+      before(async function () {
+        const graph = JSON.parse(
+          await fs.promises.readFile(path.join(outputPath, ".greenwood/graph.json"), "utf-8"),
+        );
+        const response = await fetch(`${hostname}/page-object/`);
+
+        dom = new JSDOM(await response.text());
+        pageObjectPageGraphData = graph.filter((page) => page.route === "/page-object/")[0];
+      });
+
+      it("should provide getBody with the page from the graph, not an empty object", function () {
+        const id = dom.window.document.querySelectorAll("body h1.page-id");
+        const route = dom.window.document.querySelectorAll("body h2.page-route");
+        const title = dom.window.document.querySelectorAll("body h3.page-title");
+
+        expect(id.length).to.equal(1);
+        expect(id[0].textContent).to.equal(pageObjectPageGraphData.id);
+        expect(route.length).to.equal(1);
+        expect(route[0].textContent).to.equal(pageObjectPageGraphData.route);
+        expect(title.length).to.equal(1);
+        expect(title[0].textContent).to.equal(pageObjectPageGraphData.title);
       });
     });
 

--- a/packages/cli/test/cases/develop.ssr/src/pages/page-object.js
+++ b/packages/cli/test/cases/develop.ssr/src/pages/page-object.js
@@ -1,0 +1,17 @@
+async function getBody(compilation, page) {
+  return `
+    <body>
+      <h1 class="page-id">${page.id}</h1>
+      <h2 class="page-route">${page.route}</h2>
+      <h3 class="page-title">${page.title}</h3>
+    </body>
+  `;
+}
+
+async function getFrontmatter() {
+  return {
+    title: "My Page Object Page",
+  };
+}
+
+export { getBody, getFrontmatter };


### PR DESCRIPTION
## Related Issue

Resolves #1770

## Documentation

No documentation changes. This aligns `greenwood develop` with the already documented and already correct `greenwood build` + `greenwood serve` behavior for the `page` argument of [`getBody`](https://www.greenwoodjs.dev/docs/pages/server-rendering/).

## Summary of Changes

For an SSR page whose route has **no** dynamic segment, `develop` was handing `getBody(compilation, page, request, params)` an empty object, while `build` + `serve` handed it the fully populated page node from the graph. So `page.title`, `page.route`, `page.data` etc. were `undefined` in development and correct in production, with no error in either mode.

In `packages/cli/src/plugins/resource/plugin-standard-html.js`:

```js
const matchingRouteWithSegment = getMatchingDynamicSsrRoute(this.compilation, pathname) || {};
// ...
page: JSON.stringify(matchingRouteWithSegment ?? matchingRoute),
```

`getMatchingDynamicSsrRoute` returns `undefined` when nothing matches, but the `|| {}` turned that into `{}`. `{}` is not nullish, so the `??` never fell through to `matchingRoute` — which is resolved on the very same request a couple of lines above and is used for the layout further down, so the correct node was available the whole time.

The fix drops the `|| {}` so the `??` can do its job, and switches the two unguarded property reads on that variable to optional chaining so they behave exactly as they did when it was defaulted to `{}`:

- `matchingRoute.isSSR || matchingRouteWithSegment?.isSSR`
- `new URL(pageHref ?? matchingRouteWithSegment?.pageHref)`

The other two reads (`matchingRouteWithSegment && matchingRouteWithSegment.segment` for params) were already guarded and are untouched.

`getLayout` was **not** affected — it is dispatched separately from `lib/layout-utils.js` with the real node — and layout behavior is unchanged here.

### Tests

Folded into the existing `develop.ssr` case rather than adding a new directory:

- new fixture `packages/cli/test/cases/develop.ssr/src/pages/page-object.js`, an SSR page with `getBody` + `getFrontmatter` and no dynamic segment, which renders `page.id`, `page.route` and `page.title`
- new `describe` block asserting those rendered values match the corresponding node in `.greenwood/graph.json`

`packages/cli/test/cases/develop.ssr`:

| | passing | failing |
| --- | --- | --- |
| before the fix | 33 | 1 (`expected 'undefined' to equal 'page-object'`) |
| after the fix | 34 | 0 |

Also re-ran, all green: `develop.dynamic-routing`, `develop.dynamic-routing-static-paths`, `develop.typescript.ssr`, `serve.dynamic-routing`, `serve.dynamic-routing-static-paths` (33 passing), and `build.default.ssr-prerender`, `build.default.ssr-static-export`, `serve.default.ssr`, `serve.dynamic-routing` (144 passing).

### Note

#1766's fix also lands in `packages/cli/src/plugins/resource/plugin-standard-html.js`, around the `fs.readFile` a dozen lines below this hunk. The two changes are disjoint and should merge cleanly in either order.
