### PR TITLE
fix(plugins): #1585 ignore page navigations during puppeteer prerendering

### DIFF
--- a/packages/plugin-renderer-puppeteer/src/lib/browser.js
+++ b/packages/plugin-renderer-puppeteer/src/lib/browser.js
@@ -23,13 +23,24 @@ class BrowserRunner {
 
   async serialize(requestUrl) {
     const page = await this.browser.newPage();
-    let response = null;
 
     // Page may reload when setting isMobile
     // https://github.com/GoogleChrome/puppeteer/blob/v1.10.0/docs/api.md#pagesetviewportviewport
-    page.evaluateOnNewDocument("customElements.forcePolyfill = true");
-    page.evaluateOnNewDocument("ShadyDOM = {force: true}");
-    page.evaluateOnNewDocument("ShadyCSS = {shimcssproperties: true}");
+    await page.evaluateOnNewDocument("customElements.forcePolyfill = true");
+    await page.evaluateOnNewDocument("ShadyDOM = {force: true}");
+    await page.evaluateOnNewDocument("ShadyCSS = {shimcssproperties: true}");
+
+    // Keep the initial document active and block navigation's during prerendering while still allowing JavaScript to execute
+    // https://github.com/ProjectEvergreen/greenwood/issues/1585#issuecomment-5227293583
+    await page.evaluateOnNewDocument(`
+      if (globalThis.top === globalThis && globalThis.navigation) {
+        globalThis.navigation.addEventListener("navigate", (event) => {
+          if (!event.destination.sameDocument) {
+            event.preventDefault();
+          }
+        });
+      }
+    `);
 
     await page.setCacheEnabled(false); // https://github.com/ProjectEvergreen/greenwood/pull/699
     await page.setRequestInterception(true);
@@ -51,32 +62,25 @@ class BrowserRunner {
 
     try {
       // Navigate to page. Wait until there are no outstanding network requests.
-      // https://pptr.dev/#?product=Puppeteer&version=v1.8.0&show=api-pagegotourl-options
-      response = await page.goto(requestUrl, {
+      const response = await page.goto(requestUrl, {
         waitUntil: "networkidle0",
         timeout: 0,
       });
-    } catch (e) {
-      console.error("browser error", e);
+
+      if (!response) {
+        throw new Error(`Unable to prerender ${requestUrl}: navigation returned no HTTP response.`);
+      }
+
+      return await page.content();
+    } finally {
+      if (!page.isClosed()) {
+        await page.close();
+      }
     }
-
-    if (!response) {
-      console.error("response does not exist");
-      // This should only occur when the page is about:blank. See
-      // https://github.com/GoogleChrome/puppeteer/blob/v1.5.0/docs/api.md#pagegotourl-options.
-      return { status: 400, content: "" };
-    }
-
-    // Serialize page.
-    const content = await page.content();
-
-    await page.close();
-
-    return content;
   }
 
-  close() {
-    this.browser.close();
+  async close() {
+    await this.browser.close();
   }
 }
 

--- a/packages/plugin-renderer-puppeteer/src/plugins/server.js
+++ b/packages/plugin-renderer-puppeteer/src/plugins/server.js
@@ -11,9 +11,17 @@ class PuppeteerServer {
     if (process.env.__GWD_COMMAND__ === "build") {
       const { port } = this.compilation.config.devServer;
       const offsetPort = port + 1; // don't try and start the dev server on the same port as the CLI
+      const app = await getDevServer(this.compilation);
 
-      (await getDevServer(this.compilation)).listen(offsetPort, async () => {
-        console.info(`Started puppeteer prerender server at http://localhost:${offsetPort}`);
+      await new Promise((resolve, reject) => {
+        const onError = (error) => reject(error);
+        const server = app.listen(offsetPort, () => {
+          server.off("error", onError);
+          console.info(`Started puppeteer prerender server at http://localhost:${offsetPort}`);
+          resolve();
+        });
+
+        server.once("error", onError);
       });
     } else {
       await Promise.resolve();

--- a/packages/plugin-renderer-puppeteer/src/puppeteer-handler.js
+++ b/packages/plugin-renderer-puppeteer/src/puppeteer-handler.js
@@ -5,24 +5,19 @@ export default async function (compilation, callback) {
   const browserRunner = new BrowserRunner();
 
   const runBrowser = async (serverUrl, pages) => {
-    try {
-      return asyncMap(pages, async (page) => {
-        const { route } = page;
-        console.info("prerendering page...", route);
+    return asyncMap(pages, async (page) => {
+      const { route } = page;
+      console.info("prerendering page...", route);
 
-        return await browserRunner.serialize(`${serverUrl}${route}`).then(async (html) => {
-          console.info(`prerendering complete for page ${route}.`);
+      const html = await browserRunner.serialize(`${serverUrl}${route}`);
 
-          // clean this up here to avoid sending webcomponents-bundle to rollup
-          html = html.replace(/<script src="(.*webcomponents-bundle.js)"><\/script>/, "");
+      console.info(`prerendering complete for page ${route}.`);
 
-          await callback(page, html);
-        });
-      });
-    } catch (e) {
-      console.error(e);
-      return false;
-    }
+      // clean this up here to avoid sending webcomponents-bundle to rollup
+      const body = html.replace(/<script src="(.*webcomponents-bundle.js)"><\/script>/, "");
+
+      await callback(page, body);
+    });
   };
 
   // gracefully handle if puppeteer is not installed correctly
@@ -54,6 +49,9 @@ export default async function (compilation, callback) {
   const offsetPort = port + 1; // don't try and start the dev server on the same port as the CLI
   const serverAddress = `http://127.0.0.1:${offsetPort}`;
 
-  await runBrowser(serverAddress, pages);
-  browserRunner.close();
+  try {
+    await runBrowser(serverAddress, pages);
+  } finally {
+    await browserRunner.close();
+  }
 }

--- a/packages/plugin-renderer-puppeteer/test/cases/build.default/build.default.spec.js
+++ b/packages/plugin-renderer-puppeteer/test/cases/build.default/build.default.spec.js
@@ -150,6 +150,34 @@ describe("Build Greenwood With: ", function () {
         expect(header[0].textContent.trim()).to.equal("This is the header component.");
       });
     });
+
+    // validates that the 404.html page's <meta> refresh directive is ignored during prerendering by Puppeteer
+    // https://github.com/ProjectEvergreen/greenwood/issues/1585#issuecomment-5227293583
+    describe("Default output for 404.html that has a <meta> refresh directive", function () {
+      let dom;
+
+      before(async function () {
+        const outputFile = path.join(this.context.publicDir, "./404.html");
+
+        dom = await JSDOM.fromFile(outputFile);
+      });
+
+      it("should ignore client-side redirects during prerendering", function () {
+        const appHeader = dom.window.document.querySelector("body app-header");
+        const header = appHeader.querySelector("header");
+
+        expect(header).to.not.equal(null);
+        expect(header.textContent.trim()).to.equal("This is the header component.");
+        expect(dom.window.document.querySelector("h1").textContent).to.equal("Page Not Found");
+      });
+
+      it("should still retain the meta refresh tag", function () {
+        const refresh = dom.window.document.querySelector('meta[http-equiv="refresh"]');
+
+        expect(refresh).to.not.equal(null);
+        expect(refresh.content).to.equal("0; url=https://www.greenwoodjs.dev");
+      });
+    });
   });
 
   after(async function () {

--- a/packages/plugin-renderer-puppeteer/test/cases/build.default/src/pages/404.html
+++ b/packages/plugin-renderer-puppeteer/test/cases/build.default/src/pages/404.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Page Not Found</title>
+    <meta http-equiv="refresh" content="0; url=https://www.greenwoodjs.dev" />
+    <script>
+      globalThis.location.href = "https://www.greenwoodjs.dev";
+    </script>
+    <script type="module" src="/components/header.js"></script>
+  </head>
+
+  <body>
+    <app-header></app-header>
+    <h1>Page Not Found</h1>
+  </body>
+</html>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

https://github.com/ProjectEvergreen/greenwood/issues/1585#issuecomment-5227293583

## Documentation 

N / A

## Summary of Changes

1. Ignore page navigations during puppeteer prerendering
1. Improve error handling
1. Add test case

## TODO
1. [x] re-run in GitHub Actions a few times (x3)