### PR TITLE
enhancement(plugins): #1780 warn on mismatched jsx inferred observability configuration

### DIFF
--- a/packages/plugin-import-jsx/src/index.js
+++ b/packages/plugin-import-jsx/src/index.js
@@ -14,6 +14,18 @@ const importMap = {
   "wc-compiler/effect": "/node_modules/wc-compiler/src/effect.js",
 };
 
+// a resource plugin is instantiated per lifecycle, so track reported modules at the module level
+const reportedObservabilityMismatches = new Set();
+
+function hasInferredObservabilityExport(tree) {
+  return tree.body.some(
+    (node) =>
+      node.type === "ExportNamedDeclaration" &&
+      node.declaration?.type === "VariableDeclaration" &&
+      node.declaration.declarations?.[0]?.id?.name === "inferredObservability",
+  );
+}
+
 class ImportJsxResource {
   constructor(compilation, options) {
     this.compilation = compilation;
@@ -35,6 +47,18 @@ class ImportJsxResource {
     // https://github.com/ProjectEvergreen/wcc/issues/116
     const tree = parseJsx(url);
     const result = generate(tree);
+
+    if (
+      !this.inferredObservability &&
+      !reportedObservabilityMismatches.has(url.pathname) &&
+      hasInferredObservabilityExport(tree)
+    ) {
+      reportedObservabilityMismatches.add(url.pathname);
+      console.warn(
+        "Configuration warning: a JSX module exports inferredObservability but the plugin option is not enabled, so the Signal polyfill will not be injected and the page will throw at runtime.  Please pass greenwoodPluginImportJsx({ inferredObservability: true }).",
+      );
+      console.debug(url.pathname);
+    }
 
     return new Response(result, {
       headers: new Headers({

--- a/packages/plugin-import-jsx/src/index.js
+++ b/packages/plugin-import-jsx/src/index.js
@@ -14,7 +14,6 @@ const importMap = {
   "wc-compiler/effect": "/node_modules/wc-compiler/src/effect.js",
 };
 
-// a resource plugin is instantiated per lifecycle, so track reported modules at the module level
 const reportedObservabilityMismatches = new Set();
 
 function hasInferredObservabilityExport(tree) {

--- a/packages/plugin-import-jsx/test/cases/loaders-build.prerender-inferred-observability-mismatch/greenwood.config.js
+++ b/packages/plugin-import-jsx/test/cases/loaders-build.prerender-inferred-observability-mismatch/greenwood.config.js
@@ -1,0 +1,6 @@
+import { greenwoodPluginImportJsx } from "../../../src/index.js";
+
+export default {
+  plugins: [greenwoodPluginImportJsx()],
+  prerender: true,
+};

--- a/packages/plugin-import-jsx/test/cases/loaders-build.prerender-inferred-observability-mismatch/loaders-build.prerender-inferred-observability-mismatch.spec.js
+++ b/packages/plugin-import-jsx/test/cases/loaders-build.prerender-inferred-observability-mismatch/loaders-build.prerender-inferred-observability-mismatch.spec.js
@@ -66,7 +66,7 @@ describe("Build Greenwood With: ", function () {
 
     describe("Build command output for the mismatched inferredObservability configuration", function () {
       it("should report the JSX module that opted into inferred observability", function (done) {
-        expect(output).to.contain(path.join("src", "components", "counter.jsx"));
+        expect(output).to.contain("src/components/counter.jsx");
 
         done();
       });

--- a/packages/plugin-import-jsx/test/cases/loaders-build.prerender-inferred-observability-mismatch/loaders-build.prerender-inferred-observability-mismatch.spec.js
+++ b/packages/plugin-import-jsx/test/cases/loaders-build.prerender-inferred-observability-mismatch/loaders-build.prerender-inferred-observability-mismatch.spec.js
@@ -1,0 +1,116 @@
+/*
+ * Use Case
+ * Run Greenwood build command with a JSX component that opts into Signals reactivity through the
+ * file level `export const inferredObservability` while the plugin is configured without the
+ * matching `inferredObservability` option.
+ *
+ * User Result
+ * Should report the mismatch at build time, since the emitted bundle references the Signal global
+ * that the plugin only injects when its own option is enabled.
+ * https://github.com/ProjectEvergreen/greenwood/issues/1780
+ *
+ * User Command
+ * greenwood build
+ *
+ * User Config
+ * import { greenwoodPluginImportJsx } from '@greenwood/plugin-import-jsx';
+ *
+ * {
+ *   prerender: true,
+ *   plugins: [
+ *     greenwoodPluginImportJsx()
+ *   ]
+ * }
+ *
+ * User Workspace
+ * src/
+ *   components/
+ *     counter.jsx
+ *   pages/
+ *     index.html
+ */
+import { expect } from "chai";
+import fs from "node:fs/promises";
+import { JSDOM } from "jsdom";
+import path from "node:path";
+import { runSmokeTest } from "../../../../../test/smoke-test.js";
+import { Runner } from "gallinago";
+import { fileURLToPath } from "node:url";
+
+describe("Build Greenwood With: ", function () {
+  const LABEL =
+    "JSX based Signals Reactivity opted into per file while the plugin option is not enabled";
+  const cliPath = path.join(process.cwd(), "packages/cli/src/bin.js");
+  const outputPath = fileURLToPath(new URL(".", import.meta.url));
+  let runner;
+  let output = "";
+
+  before(function () {
+    this.context = {
+      publicDir: path.join(outputPath, "public"),
+    };
+    runner = new Runner(false, true);
+  });
+
+  describe(LABEL, function () {
+    before(async function () {
+      await runner.setup(outputPath);
+      await runner.runCommand(cliPath, "build", {
+        onStdOut: (message) => {
+          output += message;
+        },
+      });
+    });
+
+    runSmokeTest(["public"], LABEL);
+
+    describe("Build command output for the mismatched inferredObservability configuration", function () {
+      it("should report the JSX module that opted into inferred observability", function (done) {
+        expect(output).to.contain(path.join("src", "components", "counter.jsx"));
+
+        done();
+      });
+    });
+
+    describe("Build command output for the emitted Signals bundle and page", function () {
+      let dom;
+      let scripts;
+
+      before(async function () {
+        dom = await JSDOM.fromFile(path.resolve(this.context.publicDir, "./index.html"));
+        scripts = await Array.fromAsync(
+          fs.glob("counter.*.js", { cwd: new URL("./public/", import.meta.url) }),
+        );
+      });
+
+      it("should emit a bundle that reads the Signal global", async function () {
+        const contents = await fs.readFile(
+          new URL(`./public/${scripts[0]}`, import.meta.url),
+          "utf-8",
+        );
+
+        expect(scripts.length).to.equal(1);
+        expect(contents).to.contain("new Signal.State(");
+        expect(contents).to.contain("new Signal.Computed(");
+      });
+
+      it("should not contain a script tag for exposing Signal globally", function (done) {
+        const scriptModuleTags = Array.from(
+          dom.window.document.querySelectorAll('head > script[type="module"]'),
+        ).filter((script) => script.textContent.indexOf("globalThis.Signal") >= 0);
+
+        expect(scriptModuleTags.length).to.equal(0);
+
+        done();
+      });
+    });
+  });
+
+  after(async function () {
+    await runner.teardown([
+      path.join(outputPath, "public"),
+      path.join(outputPath, ".greenwood"),
+      path.join(outputPath, "node_modules"),
+    ]);
+  });
+});

--- a/packages/plugin-import-jsx/test/cases/loaders-build.prerender-inferred-observability-mismatch/src/components/counter.jsx
+++ b/packages/plugin-import-jsx/test/cases/loaders-build.prerender-inferred-observability-mismatch/src/components/counter.jsx
@@ -1,0 +1,56 @@
+export const inferredObservability = true;
+
+export default class Counter extends HTMLElement {
+  count;
+  parity;
+  isLarge;
+
+  constructor() {
+    super();
+    this.count = new Signal.State(0);
+    this.parity = new Signal.Computed(() => (this.count.get() % 2 === 0 ? "even" : "odd"));
+    this.isLarge = new Signal.Computed(() =>
+      this.count.get() >= 100 ? "Wow!!!" : "Keep Going...",
+    );
+  }
+
+  // Shadow DOM
+  connectedCallback() {
+    if (!this.shadowRoot) {
+      this.attachShadow({
+        mode: "open",
+      });
+      this.render();
+    }
+  }
+
+  increment() {
+    this.count.set(this.count.get() + 1);
+  }
+
+  decrement() {
+    this.count.set(this.count.get() - 1);
+  }
+
+  double() {
+    this.count.set(this.count.get() * 2);
+  }
+
+  render() {
+    const { count, parity, isLarge } = this;
+
+    return (
+      <div>
+        <button onclick={this.increment}>Increment (+)</button>
+        <button onclick={this.decrement}>Decrement (-)</button>
+        <button onclick={this.double}>Double (++)</button>
+        <span class={parity.get()}>
+          The count is {count.get()} ({parity.get()})
+        </span>
+        <p>({isLarge.get()})</p>
+      </div>
+    );
+  }
+}
+
+customElements.define("wcc-counter", Counter);

--- a/packages/plugin-import-jsx/test/cases/loaders-build.prerender-inferred-observability-mismatch/src/pages/index.html
+++ b/packages/plugin-import-jsx/test/cases/loaders-build.prerender-inferred-observability-mismatch/src/pages/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <script type="module" src="../components/counter.jsx"></script>
+  </head>
+
+  <body>
+    <wcc-counter></wcc-counter>
+  </body>
+</html>


### PR DESCRIPTION
## Design question first — please redirect me if you'd rather go the other way

The linked issue has an open design choice and I'd rather settle it here than have you review the wrong implementation.

When a JSX module opts into signals through the per-file `export const inferredObservability` but the plugin is registered without its own `inferredObservability` option, Greenwood can either:

- **Option A — auto-inject.** Inject the `globalThis.Signal` polyfill anyway whenever a compiled module opted in, making the two switches consistent and the page actually work.
- **Option B — surface the mismatch.** Leave emitted output exactly as it is and report the mismatch at build time, so it is caught before the browser.

**This PR implements Option B.** Reasoning:

- It is the conservative half — purely diagnostic, no change to emitted output, so nothing existing can regress.
- It follows an existing, near-identical precedent. `packages/cli/src/lifecycles/config.js:194-197` handles the "more than one custom renderer plugin" misconfiguration with exactly this shape: `console.warn("Configuration warning: ...")`, then `console.debug(<offending values>)`, then carry on. `packages/cli/src/plugins/resource/plugin-node-modules.js:91-102` and `packages/cli/src/lifecycles/graph.js:107` do the same for other user-side misconfiguration. Hard-failing would be unprecedented — every `Configuration error:` rejection in `config.js` is a type or enum check on a single option in isolation, and no relational mismatch in the codebase has ever been fatal.
- The check sits in `serve()`, the one point where both facts are known, so it behaves identically for `build` and `develop`.

The main practical argument against Option A: the plugin only learns a module opted in when it *serves* that module, and during `greenwood develop` the HTML document is served **before** the browser requests the `.jsx` — so an auto-inject keyed off compilation would miss the first page load and only start working after a refresh. Making it order-independent means scanning the page graph for JSX modules at intercept time, which is meaningfully more machinery.

That said, Option A is the friendlier outcome for users and I have no strong attachment to B. **The change here is about a dozen lines and is straightforward to swap** — say the word and I'll rework it to auto-inject (and adjust the regression test to assert the polyfill script is present instead of asserting the warning).

## Related Issue

Resolves #1780

## Documentation

No documentation changes. Option B does not change any documented behaviour or add any configuration surface — it only reports an existing misconfiguration. If you prefer Option A, `packages/plugin-import-jsx/README.md` would want a note that the file-level export is sufficient on its own.

## Summary of Changes

`packages/plugin-import-jsx/src/index.js`

- `serve()` now inspects the tree it already gets back from `parseJsx` for a top-level `export const inferredObservability`. When that export is present and the plugin's own `inferredObservability` option is not enabled, it emits a `Configuration warning:` naming the offending module, following the `console.warn` + `console.debug` shape from `config.js`.
- Reported modules are tracked in a module-level `Set` because a resource plugin is instantiated per lifecycle, which otherwise repeats the same warning several times per build and on every refresh in `develop`.
- No change to what is emitted.

`packages/plugin-import-jsx/test/cases/loaders-build.prerender-inferred-observability-mismatch/`

New loaders build case: the same counter component as the existing `loaders-build.prerender-inferred-observability` case (file-level `export const inferredObservability = true`), but with `greenwoodPluginImportJsx()` registered without options. It asserts the mismatch is reported, and pins the symptom it is reporting — the bundle contains `new Signal.State(` / `new Signal.Computed(` while the page contains no script defining `globalThis.Signal`.

### Fail-then-pass proof

Run with `node --import ./test/test-register.js ./node_modules/mocha/bin/mocha "./packages/plugin-import-jsx/test/cases/loaders-build.prerender-inferred-observability-mismatch/*.spec.js"` (the `yarn test:loaders` harness, narrowed to the one case).

Before the change, against unmodified `packages/plugin-import-jsx/src/index.js`:

```
  Build Greenwood With:
    JSX based Signals Reactivity opted into per file while the plugin option is not enabled
      Running Smoke Tests: JSX based Signals Reactivity opted into per file while the plugin option is not enabled
        Public Directory Generated Output
          ✔ should create a public directory
          ✔ should output one graph.json file
          ✔ should not output any map files for HTML pages
      Build command output for the mismatched inferredObservability configuration
        1) should report the JSX module that opted into inferred observability
      Build command output for the emitted Signals bundle and page
        ✔ should emit a bundle that reads the Signal global
        ✔ should not contain a script tag for exposing Signal globally


  5 passing (3s)
  1 failing

  1) Build Greenwood With:
       JSX based Signals Reactivity opted into per file while the plugin option is not enabled
         Build command output for the mismatched inferredObservability configuration
           should report the JSX module that opted into inferred observability:
     AssertionError: expected '-------------------------------------…' to include 'src/components/counter.jsx'
```

Note that the two symptom assertions pass in both runs — they document the broken artifact this warning is about: a bundle reading `Signal` with nothing defining it.

After the change:

```
  Build Greenwood With:
    JSX based Signals Reactivity opted into per file while the plugin option is not enabled
      Running Smoke Tests: JSX based Signals Reactivity opted into per file while the plugin option is not enabled
        Public Directory Generated Output
          ✔ should create a public directory
          ✔ should output one graph.json file
          ✔ should not output any map files for HTML pages
      Build command output for the mismatched inferredObservability configuration
        ✔ should report the JSX module that opted into inferred observability
      Build command output for the emitted Signals bundle and page
        ✔ should emit a bundle that reads the Signal global
        ✔ should not contain a script tag for exposing Signal globally


  6 passing (3s)
```

The full `packages/plugin-import-jsx` suite passes (81 passing), and `prettier --check`, `eslint` and `tsc --project ./tsconfig.json` are clean on the changed files.
