### PR TITLE
fix(cli): #1788 return the intended status for active content graph error paths

### DIFF
--- a/packages/cli/src/plugins/resource/plugin-active-content.js
+++ b/packages/cli/src/plugins/resource/plugin-active-content.js
@@ -44,38 +44,36 @@ class ContentAsDataResource {
     const delimiterIndex = contentKey.indexOf("-");
     const type = delimiterIndex === -1 ? contentKey : contentKey.slice(0, delimiterIndex);
     const value = delimiterIndex === -1 ? "" : contentKey.slice(delimiterIndex + 1);
-    let status;
     let body;
 
     if (contentKey === "") {
-      status = 403;
-      body = "Bad Request - No Cache Key found";
+      return new Response("Bad Request - No Cache Key found", { status: 403 });
+    }
+
+    if (contentKey === "graph") {
+      body = graph;
+    } else if (type === "collection") {
+      body = filterContentByCollection(graph, value);
+    } else if (type === "route") {
+      body = filterContentByRoute(graph, value);
     } else {
-      status = 200;
+      return new Response("Bad Request - Unsupported Cache Key", { status: 400 });
+    }
 
-      if (contentKey === "graph") {
-        body = graph;
-      } else if (type === "collection") {
-        body = filterContentByCollection(graph, value);
-      } else if (type === "route") {
-        body = filterContentByRoute(graph, value);
-      }
+    if (process.env.__GWD_COMMAND__ === "build") {
+      const fileKey = `./data-${contentKey.replace(/\//g, "_")}.json`;
 
-      if (process.env.__GWD_COMMAND__ === "build") {
-        const fileKey = `./data-${contentKey.replace(/\//g, "_")}.json`;
-
-        if (!(await checkResourceExists(new URL(fileKey, this.compilation.context.outputDir)))) {
-          await fs.writeFile(
-            new URL(fileKey, this.compilation.context.outputDir),
-            JSON.stringify(pruneGraph(body)),
-            "utf-8",
-          );
-        }
+      if (!(await checkResourceExists(new URL(fileKey, this.compilation.context.outputDir)))) {
+        await fs.writeFile(
+          new URL(fileKey, this.compilation.context.outputDir),
+          JSON.stringify(pruneGraph(body)),
+          "utf-8",
+        );
       }
     }
 
     return new Response(JSON.stringify(pruneGraph(body)), {
-      status,
+      status: 200,
       headers: new Headers({
         "Content-Type": "application/json",
       }),

--- a/packages/cli/test/cases/develop.config.active-content/develop.config.active-content.spec.js
+++ b/packages/cli/test/cases/develop.config.active-content/develop.config.active-content.spec.js
@@ -151,6 +151,37 @@ describe("Develop Greenwood With: ", function () {
       });
     });
 
+    // https://github.com/ProjectEvergreen/greenwood/issues/1788
+    describe("Content Request Errors", function () {
+      describe("Missing Content Key", function () {
+        let response;
+
+        before(async function () {
+          response = await fetch(`${hostname}:${port}/___graph.json`);
+        });
+
+        it("should return a 403 status", function () {
+          expect(response.status).to.equal(403);
+        });
+      });
+
+      describe("Unrecognized Content Key", function () {
+        let response;
+
+        before(async function () {
+          response = await fetch(`${hostname}:${port}/___graph.json`, {
+            headers: {
+              "x-content-key": "bogus-key",
+            },
+          });
+        });
+
+        it("should return a 400 status", function () {
+          expect(response.status).to.equal(400);
+        });
+      });
+    });
+
     // https://github.com/ProjectEvergreen/greenwood/issues/1743
     describe("Active Frontmatter values containing replacement patterns", () => {
       let dom;


### PR DESCRIPTION
### Related Issue

Resolves #1788

### Documentation

No documentation changes needed — this restores the status codes the plugin already intended to send, and adds no new public API or configuration.

### Summary of Changes

1. [x] Return the 403 `Bad Request - No Cache Key found` response directly when `x-content-key` is missing, before anything calls `pruneGraph`. Previously this path assigned a *string* body and then hit `pruneGraph`'s `pages.map`, throwing and turning the intended 403 into a 500 — the 403 was dead code.
2. [x] Return **400 `Bad Request - Unsupported Cache Key`** for a content key that is not `graph`, `collection-*` or `route-*`. Previously `body` stayed `undefined` and `undefined.map` threw, also producing a 500.
3. [x] The `graph` / `collection` / `route` success paths are unchanged, including the `__GWD_COMMAND__ === "build"` data-file write. The only edit to them is de-indentation from removing the wrapping `else`, plus `status` becoming the literal `200` now that the shared return is reached only on success.
4. [x] The 400 message deliberately does not echo the client-supplied key back into the response body.
5. [x] Folded the regression coverage into the existing `develop.config.active-content` case rather than adding a new fixture directory, following your note on #1720. Two new specs assert the status codes rather than stack text: no header → 403, `bogus-key` → 400.
6. [x] Verified the tests fail on unpatched `master` with exactly this symptom — `expected 500 to equal 403` and `expected 500 to equal 400`, 9 passing / 2 failing — and pass after the fix at 11 passing.
7. [x] `yarn lint` (0 errors) and `yarn format:check` clean. The neighbouring `serve.config.active-content` (35 passing) and the `build.config.base-path-active-content` / `develop.config.active-content-collection-hyphen` cases (33 passing) are unchanged.

One open question: 400 on an unrecognized key is the strict reading, since the client asked for something the server cannot supply. The lenient alternative is **200 with `[]`**, treating an unknown key as an empty result set, which would keep the data client's consumers on the happy path and never surface an error to page code. Happy to switch to that if you prefer it — the 403 half of the fix is unaffected either way.
