### PR TITLE
chore(workspace): #1721 silence intentional eslint warnings

### DIFF
--- a/packages/cli/test/cases/build.config.polyfills-import-attributes-edge-cases/src/main.js
+++ b/packages/cli/test/cases/build.config.polyfills-import-attributes-edge-cases/src/main.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-duplicates */
 // import shadow from "./theme.css" with { type: "css" }; older commented-out example
 import withTheme from "./theme.css" with { type: "css" };
 import a from "./shared.css" with { type: "css" };

--- a/packages/cli/test/cases/develop.config.polyfills-import-attributes-edge-cases/src/main.js
+++ b/packages/cli/test/cases/develop.config.polyfills-import-attributes-edge-cases/src/main.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-duplicates */
 // import shadow from "./theme.css" with { type: "css" }; older commented-out example
 import withTheme from "./theme.css" with { type: "css" };
 import a from "./shared.css" with { type: "css" };


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

#1721 

Missed this in [the PR review](https://github.com/ProjectEvergreen/greenwood/pull/1722/changes#diff-9028f36ccf446a49d28ec8f7ae39d4e579d63015defd69497ccef91f84ba3852R3)
<img width="1394" height="520" alt="Screenshot 2026-08-29 at 11 09 32 AM" src="https://github.com/user-attachments/assets/9c13ab9d-66f0-4919-8b8d-c565c972857e" />

```sh
/Users/owenbuckley/Workspace/project-evergreen/greenwood/packages/cli/test/cases/build.config.polyfills-import-attributes-edge-cases/src/main.js
  3:15  warning  '/Users/owenbuckley/Workspace/project-evergreen/greenwood/packages/cli/test/cases/build.config.polyfills-import-attributes-edge-cases/src/shared.css' imported multiple times  import/no-duplicates
  4:15  warning  '/Users/owenbuckley/Workspace/project-evergreen/greenwood/packages/cli/test/cases/build.config.polyfills-import-attributes-edge-cases/src/shared.css' imported multiple times  import/no-duplicates

/Users/owenbuckley/Workspace/project-evergreen/greenwood/packages/cli/test/cases/develop.config.polyfills-import-attributes-edge-cases/src/main.js
  3:15  warning  '/Users/owenbuckley/Workspace/project-evergreen/greenwood/packages/cli/test/cases/develop.config.polyfills-import-attributes-edge-cases/src/shared.css' imported multiple times  import/no-duplicates
  4:15  warning  '/Users/owenbuckley/Workspace/project-evergreen/greenwood/packages/cli/test/cases/develop.config.polyfills-import-attributes-edge-cases/src/shared.css' imported multiple times  import/no-duplicates
```

## Documentation 

N / A

## Summary of Changes

1. silence intentional eslint warnings