### PR TITLE
fix(runtimes): #1783 handle duplicate module hook registration deadlocking when using `NODE_OPTIONS`

### DIFF
--- a/.github/workflows/ci-loaders.yml
+++ b/.github/workflows/ci-loaders.yml
@@ -33,3 +33,4 @@ jobs:
       - name: Test
         run: |
           yarn test:loaders
+          yarn test:loaders:options

--- a/.github/workflows/ci-win-loaders.yml
+++ b/.github/workflows/ci-win-loaders.yml
@@ -30,3 +30,4 @@ jobs:
       - name: Test
         run: |
           yarn test:loaders:win
+          yarn test:loaders:win:options

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "test": "cross-env BROWSERSLIST_IGNORE_OLD_DATA=true __GWD_ROLLUP_MODE__=strict NODE_NO_WARNINGS=1 c8 mocha --exclude \"./packages/**/test/cases/loaders-*/**\" \"./packages/**/**/*.spec.js\"",
     "test:loaders": "cross-env BROWSERSLIST_IGNORE_OLD_DATA=true __GWD_ROLLUP_MODE__=strict NODE_NO_WARNINGS=1 node --import $(pwd)/test/test-register-node.js ./node_modules/mocha/bin/mocha \"./packages/**/**/*.spec.js\"",
     "test:loaders:win": "cross-env BROWSERSLIST_IGNORE_OLD_DATA=true __GWD_ROLLUP_MODE__=strict NODE_NO_WARNINGS=1 node --import file:\\\\%cd%\\test\\test-register-node.js ./node_modules/mocha/bin/mocha --exclude \"./packages/init/test/cases/**\" \"./packages/**/**/*.spec.js\"",
+    "test:loaders:options": "cross-env BROWSERSLIST_IGNORE_OLD_DATA=true __GWD_ROLLUP_MODE__=strict NODE_NO_WARNINGS=1 NODE_OPTIONS=\"--import=$(pwd)/test/test-register-node.js\" ./node_modules/mocha/bin/mocha \"./packages/**/test/cases/loaders-*/*.spec.js\"",
+    "test:loaders:win:options": "cross-env BROWSERSLIST_IGNORE_OLD_DATA=true __GWD_ROLLUP_MODE__=strict NODE_NO_WARNINGS=1 NODE_OPTIONS=\"--import=file:///%cd:\\=/%/test/test-register-node.js\" ./node_modules/mocha/bin/mocha \"./packages/**/test/cases/loaders-*/*.spec.js\"",
     "test:tdd": "yarn test --watch",
     "lint": "yarn run lint:ls && yarn run lint:js && yarn run lint:types",
     "lint:js": "eslint",

--- a/packages/cli/src/runtimes/node/register.js
+++ b/packages/cli/src/runtimes/node/register.js
@@ -9,6 +9,7 @@ const GREENWOOD_LOADER_NODE_REGISTER = "greenwood-loader-node-register";
 // and Greenwood’s register module creates its own worker so that worker preloads the register module again and the synchronous bridge deadlocks.
 // we use a guard here to prevent the worker backing the bridge from registering another bridge when this module is preloaded through `NODE_OPTIONS`
 // https://nodejs.org/download/release/v24.13.1/docs/api/cli.html#--importmodule
+// https://github.com/ProjectEvergreen/greenwood/pull/1795
 if (workerData !== GREENWOOD_LOADER_NODE_REGISTER) {
   registerHooks(
     initializeSyncWorkerBridge(new URL("./worker.js", import.meta.url), {

--- a/packages/cli/src/runtimes/node/register.js
+++ b/packages/cli/src/runtimes/node/register.js
@@ -1,17 +1,26 @@
 // entry point for NodeJS custom loader hooks, e.g. `node --import @greenwood/cli/register`
 import { registerHooks } from "node:module";
-import { SHARE_ENV } from "node:worker_threads";
+import { SHARE_ENV, workerData } from "node:worker_threads";
 import { initializeSyncWorkerBridge } from "../bridge.js";
 
-registerHooks(
-  initializeSyncWorkerBridge(new URL("./worker.js", import.meta.url), {
-    workerOptions: {
-      // share read / write access to process.env across parent / child worker threads, like `__GWD_COMMAND__`
-      // https://nodejs.org/docs/latest-v24.x/api/worker_threads.html#worker_threadsshare_env
-      env: SHARE_ENV,
-      // send `[]` to prevent the initial loader hook (--import @greenwood/cli/register``) from inheriting itself as part of `process.execArgv`
-      // and thus have register calling itself recursively
-      execArgv: [],
-    },
-  }),
-);
+const GREENWOOD_LOADER_NODE_REGISTER = "greenwood-loader-node-register";
+
+// Node propagates `--import` preloads from `NODE_OPTIONS` into workers,
+// and Greenwood’s register module creates its own worker so that worker preloads the register module again and the synchronous bridge deadlocks.
+// we use a guard here to prevent the worker backing the bridge from registering another bridge when this module is preloaded through `NODE_OPTIONS`
+// https://nodejs.org/download/release/v24.13.1/docs/api/cli.html#--importmodule
+if (workerData !== GREENWOOD_LOADER_NODE_REGISTER) {
+  registerHooks(
+    initializeSyncWorkerBridge(new URL("./worker.js", import.meta.url), {
+      workerOptions: {
+        // share read / write access to process.env across parent / child worker threads, like `__GWD_COMMAND__`
+        // https://nodejs.org/docs/latest-v24.x/api/worker_threads.html#worker_threadsshare_env
+        env: SHARE_ENV,
+        // send `[]` to prevent the initial loader hook (--import @greenwood/cli/register``) from inheriting itself as part of `process.execArgv`
+        // and thus have register calling itself recursively
+        execArgv: [],
+        workerData: GREENWOOD_LOADER_NODE_REGISTER,
+      },
+    }),
+  );
+}


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #1783 

Noticed in https://github.com/ProjectEvergreen/www.greenwoodjs.dev/pull/294 after upgrading to **v0.35.0-alpha.1**, that running custom loader hooks (using `NODE_OPTIONS`) was timing out
```sh
➜  www.greenwoodjs.dev git:(enhancement/upgrade-greenwood-v0.35.0) ✗ npm run build

> www.greenwoodjs.dev@0.0.1 build
> NODE_OPTIONS='--import @greenwood/cli/register' greenwood build

file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/node_modules/@greenwood/cli/src/runtimes/bridge.js:52
      throw new Error(`Timed out waiting for Greenwood's ${action} loader hook for ${url}`);
            ^

Error: Timed out waiting for Greenwood's resolve loader hook for file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/node_modules/@greenwood/cli/src/bin.js
    at SyncLoaderBridge.dispatch (file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/node_modules/@greenwood/cli/src/runtimes/bridge.js:52:13)
    at resolve (file:///Users/owenbuckley/Workspace/project-evergreen/www.greenwoodjs.dev/node_modules/@greenwood/cli/src/runtimes/bridge.js:87:36)
    at nextStep (node:internal/modules/customization_hooks:189:26)
    at resolveWithHooks (node:internal/modules/customization_hooks:417:10)
    at ModuleLoader.resolveSync (node:internal/modules/esm/loader:755:14)
    at #resolve (node:internal/modules/esm/loader:701:17)
    at ModuleLoader.getOrCreateModuleJob (node:internal/modules/esm/loader:621:35)
    at onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:650:32)
    at TracingChannel.tracePromise (node:diagnostics_channel:350:14)
    at ModuleLoader.import (node:internal/modules/esm/loader:646:21)

Node.js v24.13.1
```

## Documentation 

N / A

## Summary of Changes

1. Prevent deadlocking when registering custom loaders using `NODE_OPTIONS`

## TODO
1. [x] Should try and add a test case / reproduction