### PR TITLE
fix(cli): #1694 serve lifecycle not honoring renderer plugins api route handlers

### DIFF
--- a/packages/cli/src/lifecycles/serve.js
+++ b/packages/cli/src/lifecycles/serve.js
@@ -366,6 +366,9 @@ async function getStaticServer(compilation, composable) {
 async function getHybridServer(compilation) {
   const { graph, manifest, config } = compilation;
   const isolationMode = config.isolation;
+  const apiRouteWorkerUrl =
+    config.plugins.find((plugin) => plugin.type === "renderer").provider()?.apiRouteWorkerUrl ??
+    new URL("../lib/api-route-worker.js", import.meta.url);
   const app = await getStaticServer(compilation, true);
 
   app.use(koaBody());
@@ -463,7 +466,7 @@ async function getHybridServer(compilation) {
           const req = await requestAsObject(request);
 
           await new Promise((resolve, reject) => {
-            const worker = new Worker(new URL("../lib/api-route-worker.js", import.meta.url));
+            const worker = new Worker(apiRouteWorkerUrl);
 
             worker.on("message", (result) => {
               const responseAsObject = result;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue

related to #1694 

> See https://github.com/ProjectEvergreen/greenwood/pull/1796

## Documentation 

N / A

## Summary of Changes

1. `greenwood serve` was not honoring a renderer plugin's custom API route handler

> _**NOTE**: tests are failing due to a known issue with analogstudios.net changing domain.  Will fix it in the next couple of days_